### PR TITLE
Release 1.7.0

### DIFF
--- a/constants/javaTypes.js
+++ b/constants/javaTypes.js
@@ -1,1 +1,2 @@
-export const EntityArmorStand = Java.type("net.minecraft.entity.item.EntityArmorStand")
+export const EntityArmorStand = Java.type("net.minecraft.entity.item.EntityArmorStand");
+export const EntityItem = Java.type("net.minecraft.entity.item.EntityItem");

--- a/constants/sounds.js
+++ b/constants/sounds.js
@@ -1,11 +1,21 @@
-export const NOTIFICATION_SOUND = new Sound({ source: "notification.ogg" });
-export const TIMER_SOUND = new Sound({ source: "notification-bell.ogg" });
-export const OH_MY_GOD_SOUND = new Sound({ source: "oh-my-god.ogg", priority: true }); // Good items
-export const INSANE_SOUND = new Sound({ source: "insane.ogg", priority: true }); // Insane RNG drops
-export const AUGH_SOUND = new Sound({ source: "augh.ogg", priority: true }); // Epic pets
-export const GOOFY_LAUGH_SOUND = new Sound({ source: "goofy-laugh.ogg", priority: true }); // Rare pets
-export const WOW_SOUND = new Sound({ source: "wow.ogg", priority: true });  // Legendary pets
-export const SHEESH_SOUND = new Sound({ source: "sheesh.ogg", priority: true }); // Legendary yeti
+// Sounds now are instatiated right before playing, so that it does not cause Java error on switching the output device.
+export const NOTIFICATION_SOUND_SOURCE = { source: "notification.ogg" };
+export const TIMER_SOUND_SOURCE = { source: "notification-bell.ogg" };
+export const OH_MY_GOD_SOUND_SOURCE = { source: "oh-my-god.ogg", priority: true }; // Good items
+export const INSANE_SOUND_SOURCE = { source: "insane.ogg", priority: true }; // Insane RNG drops
+export const AUGH_SOUND_SOURCE = { source: "augh.ogg", priority: true }; // Epic pets
+export const GOOFY_LAUGH_SOUND_SOURCE = { source: "goofy-laugh.ogg", priority: true }; // Rare pets
+export const WOW_SOUND_SOURCE = { source: "wow.ogg", priority: true };  // Legendary pets
+export const SHEESH_SOUND_SOURCE = { source: "sheesh.ogg", priority: true }; // Legendary yeti
+
+// export const NOTIFICATION_SOUND = new Sound({ source: "notification.ogg" });
+// export const TIMER_SOUND = new Sound({ source: "notification-bell.ogg" });
+// export const OH_MY_GOD_SOUND = new Sound({ source: "oh-my-god.ogg", priority: true }); // Good items
+// export const INSANE_SOUND = new Sound({ source: "insane.ogg", priority: true }); // Insane RNG drops
+// export const AUGH_SOUND = new Sound({ source: "augh.ogg", priority: true }); // Epic pets
+// export const GOOFY_LAUGH_SOUND = new Sound({ source: "goofy-laugh.ogg", priority: true }); // Rare pets
+// export const WOW_SOUND = new Sound({ source: "wow.ogg", priority: true });  // Legendary pets
+// export const SHEESH_SOUND = new Sound({ source: "sheesh.ogg", priority: true }); // Legendary yeti
 
 export const MEME_SOUND_MODE = 0;
 export const NORMAL_SOUND_MODE = 1;

--- a/constants/triggers.js
+++ b/constants/triggers.js
@@ -1,13 +1,12 @@
-import settings from "../settings";
 import * as drops from './drops';
 import * as sounds from './sounds';
 import * as seaCreatures from './seaCreatures';
-import { GREEN, GOLD, DARK_PURPLE, LIGHT_PURPLE, BLUE, RED, BOLD, RESET, COMMON, RARE, EPIC, LEGENDARY, MYTHIC } from './formatting';
+import { GREEN, GOLD, DARK_PURPLE, LIGHT_PURPLE, BLUE, RED, BOLD, RESET, COMMON, RARE, EPIC, LEGENDARY, MYTHIC, GRAY } from './formatting';
 
 // Original Hypixel chat messages.
 
-export const YETI_MESSAGE = `${GREEN}What is this creature!?`;
-export const REINDRAKE_MESSAGE = `${GREEN}A Reindrake forms from the depths.`;
+export const YETI_MESSAGE = `${GREEN}What is this creature!?`; // &aWhat is this creature!?
+export const REINDRAKE_MESSAGE = `${GREEN}A Reindrake forms from the depths.`; // &aA Reindrake forms from the depths.
 export const NUTCRACKER_MESSAGE = `${GREEN}You found a forgotten Nutcracker laying beneath the ice.`;
 export const WATER_HYDRA_MESSAGE = `${GREEN}The Water Hydra has come to test your strength.`;
 export const SEA_EMPEROR_MESSAGE = `${GREEN}The Sea Emperor arises from the depths.`;
@@ -21,8 +20,8 @@ export const LORD_JAWBUS_MESSAGE = `${RESET}${RED}${BOLD}You have angered a lege
 export const PLHLEGBLAST_MESSAGE = `${GREEN}WOAH! A Plhlegblast appeared.`;
 export const VANQUISHER_MESSAGE = `A ${RESET}${RED}Vanquisher ${RESET}${GREEN}is spawning nearby!`;
 
-export const BABY_YETI_PET_LEG_MESSAGE = `PET DROP! ${RESET}${GOLD}Baby Yeti`;
-export const BABY_YETI_PET_EPIC_MESSAGE = `PET DROP! ${RESET}${DARK_PURPLE}Baby Yeti`;
+export const BABY_YETI_PET_LEG_MESSAGE = `PET DROP! ${RESET}${GOLD}Baby Yeti`; // PET DROP! &r&6Baby Yeti
+export const BABY_YETI_PET_EPIC_MESSAGE = `PET DROP! ${RESET}${DARK_PURPLE}Baby Yeti`; // PET DROP! &r&5Baby Yeti
 export const FLYING_FISH_PET_LEG_MESSAGE = `PET DROP! ${RESET}${GOLD}Flying Fish`;
 export const FLYING_FISH_PET_EPIC_MESSAGE = `PET DROP! ${RESET}${DARK_PURPLE}Flying Fish`;
 export const FLYING_FISH_PET_RARE_MESSAGE = `PET DROP! ${RESET}${BLUE}Flying Fish`;
@@ -33,6 +32,9 @@ export const DEEP_SEA_ORB_MESSAGE = `RARE DROP! ${RESET}${DARK_PURPLE}Deep Sea O
 export const RADIOACTIVE_VIAL_MESSAGE = `RARE DROP! ${RESET}${LIGHT_PURPLE}Radioactive Vial`;
 export const CARMINE_DYE_MESSAGE = `RARE DROP! ${RESET}${DARK_PURPLE}Carmine Dye`;
 export const MAGMA_CORE_MESSAGE = `RARE DROP! ${RESET}${BLUE}Magma Core`;
+
+export const KILLED_BY_THUNDER_MESSAGE = `${RESET}${GRAY}You were killed by Thunder${RESET}${GRAY}${RESET}${GRAY}.`; // &r&7You were killed by Thunder&r&7&r&7.
+export const KILLED_BY_LORD_JAWBUS_MESSAGE = `${RESET}${GRAY}You were killed by Lord Jawbus${RESET}${GRAY}${RESET}${GRAY}.`; // &r&7You were killed by Lord Jawbus&r&7&r&7.
 
 export const RARE_CATCH_TRIGGERS = [
     {
@@ -139,7 +141,7 @@ export const RARE_DROP_TRIGGERS = [
     {
         trigger: BABY_YETI_PET_LEG_MESSAGE,
         itemName: drops.BABY_YETI_PET + ' (Legendary)',
-        sound: sounds.SHEESH_SOUND,
+        sound: sounds.SHEESH_SOUND_SOURCE,
         isMessageEnabledSettingKey: 'messageOnBabyYetiPetDrop',
         isAlertEnabledSettingKey: 'alertOnBabyYetiPetDrop',
         rarityColorCode: LEGENDARY
@@ -147,7 +149,7 @@ export const RARE_DROP_TRIGGERS = [
     {
         trigger: BABY_YETI_PET_EPIC_MESSAGE,
         itemName: drops.BABY_YETI_PET + ' (Epic)',
-        sound: sounds.AUGH_SOUND,
+        sound: sounds.AUGH_SOUND_SOURCE,
         isMessageEnabledSettingKey: 'messageOnBabyYetiPetDrop',
         isAlertEnabledSettingKey: 'alertOnBabyYetiPetDrop',
         rarityColorCode: EPIC
@@ -155,7 +157,7 @@ export const RARE_DROP_TRIGGERS = [
     {
         trigger: FLYING_FISH_PET_LEG_MESSAGE,
         itemName: drops.FLYING_FISH_PET + ' (Legendary)',
-        sound: sounds.WOW_SOUND,
+        sound: sounds.WOW_SOUND_SOURCE,
         isMessageEnabledSettingKey: 'messageOnFlyingFishPetDrop',
         isAlertEnabledSettingKey: 'alertOnFlyingFishPetDrop',
         rarityColorCode: LEGENDARY
@@ -163,7 +165,7 @@ export const RARE_DROP_TRIGGERS = [
     {
         trigger: FLYING_FISH_PET_EPIC_MESSAGE,
         itemName: drops.FLYING_FISH_PET + ' (Epic)',
-        sound: sounds.AUGH_SOUND,
+        sound: sounds.AUGH_SOUND_SOURCE,
         isMessageEnabledSettingKey: 'messageOnFlyingFishPetDrop',
         isAlertEnabledSettingKey: 'alertOnFlyingFishPetDrop',
         rarityColorCode: EPIC
@@ -171,7 +173,7 @@ export const RARE_DROP_TRIGGERS = [
     {
         trigger: FLYING_FISH_PET_RARE_MESSAGE,
         itemName: drops.FLYING_FISH_PET + ' (Rare)',
-        sound: sounds.GOOFY_LAUGH_SOUND,
+        sound: sounds.GOOFY_LAUGH_SOUND_SOURCE,
         isMessageEnabledSettingKey: 'messageOnFlyingFishPetDrop',
         isAlertEnabledSettingKey: 'alertOnFlyingFishPetDrop',
         rarityColorCode: RARE
@@ -179,7 +181,7 @@ export const RARE_DROP_TRIGGERS = [
     {
         trigger: LUCKY_CLOVER_CORE_MESSAGE,
         itemName: drops.LUCKY_CLOVER_CORE,
-        sound: sounds.OH_MY_GOD_SOUND,
+        sound: sounds.OH_MY_GOD_SOUND_SOURCE,
         isMessageEnabledSettingKey: 'messageOnLuckyCloverCoreDrop',
         isAlertEnabledSettingKey: 'alertOnLuckyCloverCoreDrop',
         rarityColorCode: EPIC
@@ -187,7 +189,7 @@ export const RARE_DROP_TRIGGERS = [
     {
         trigger: MEGALODON_PET_LEG_MESSAGE,
         itemName: drops.MEGALODON_PET + ' (Legendary)',
-        sound: sounds.WOW_SOUND,
+        sound: sounds.WOW_SOUND_SOURCE,
         isMessageEnabledSettingKey: 'messageOnMegalodonPetDrop',
         isAlertEnabledSettingKey: 'alertOnMegalodonPetDrop',
         rarityColorCode: LEGENDARY
@@ -195,7 +197,7 @@ export const RARE_DROP_TRIGGERS = [
     {
         trigger: MEGALODON_PET_EPIC_MESSAGE,
         itemName: drops.MEGALODON_PET + ' (Epic)',
-        sound: sounds.AUGH_SOUND,
+        sound: sounds.AUGH_SOUND_SOURCE,
         isMessageEnabledSettingKey: 'messageOnMegalodonPetDrop',
         isAlertEnabledSettingKey: 'alertOnMegalodonPetDrop',
         rarityColorCode: EPIC
@@ -203,7 +205,7 @@ export const RARE_DROP_TRIGGERS = [
     {
         trigger: DEEP_SEA_ORB_MESSAGE,
         itemName: drops.DEEP_SEA_ORB,
-        sound: sounds.OH_MY_GOD_SOUND,
+        sound: sounds.OH_MY_GOD_SOUND_SOURCE,
         isMessageEnabledSettingKey: 'messageOnDeepSeaOrbDrop',
         isAlertEnabledSettingKey: 'alertOnDeepSeaOrbDrop',
         rarityColorCode: EPIC
@@ -211,7 +213,7 @@ export const RARE_DROP_TRIGGERS = [
     {
         trigger: RADIOACTIVE_VIAL_MESSAGE,
         itemName: drops.RADIOACTIVE_VIAL,
-        sound: sounds.INSANE_SOUND,
+        sound: sounds.INSANE_SOUND_SOURCE,
         isMessageEnabledSettingKey: 'messageOnRadioactiveVialDrop',
         isAlertEnabledSettingKey: 'alertOnRadioactiveVialDrop',
         rarityColorCode: MYTHIC
@@ -219,7 +221,7 @@ export const RARE_DROP_TRIGGERS = [
     {
         trigger: CARMINE_DYE_MESSAGE,
         itemName: drops.CARMINE_DYE,
-        sound: sounds.INSANE_SOUND,
+        sound: sounds.INSANE_SOUND_SOURCE,
         isMessageEnabledSettingKey: 'messageOnCarmineDyeDrop',
         isAlertEnabledSettingKey: 'alertOnCarmineDyeDrop',
         rarityColorCode: EPIC
@@ -227,9 +229,18 @@ export const RARE_DROP_TRIGGERS = [
     {
         trigger: MAGMA_CORE_MESSAGE,
         itemName: drops.MAGMA_CORE,
-        sound: sounds.OH_MY_GOD_SOUND,
+        sound: sounds.OH_MY_GOD_SOUND_SOURCE,
         isMessageEnabledSettingKey: 'messageOnMagmaCoreDrop',
         isAlertEnabledSettingKey: 'alertOnMagmaCoreDrop',
         rarityColorCode: RARE
     },
-]
+];
+
+export const KILLED_BY_TRIGGERS = [
+    {
+        trigger: KILLED_BY_THUNDER_MESSAGE
+    },
+    {
+        trigger: KILLED_BY_LORD_JAWBUS_MESSAGE
+    },
+];

--- a/features/alert-armor/alertOnNonFishingArmor.js
+++ b/features/alert-armor/alertOnNonFishingArmor.js
@@ -57,10 +57,10 @@ function isFishingArmor(item) {
         return false;
     }
 
-    if (itemLore[0].includes("Hunter")) {
+    if (itemLore[0].includes("Hunter") || itemLore[0].includes("Squid Hat")) {
         return true;
     }
 
-    const isFishingArmor = itemLore.slice(1).some(loreLine => loreLine.includes("Sea Creature Chance"));
+    const isFishingArmor = itemLore.slice(1).some(loreLine => loreLine.includes("Sea Creature Chance:"));
     return isFishingArmor;
 }

--- a/features/alert-worm-the-fish/alertOnWormTheFish.js
+++ b/features/alert-worm-the-fish/alertOnWormTheFish.js
@@ -1,0 +1,29 @@
+import settings from "../../settings";
+import { RED } from "../../constants/formatting";
+import { EntityItem } from "../../constants/javaTypes";
+import { hasDirtRodInHand, isInSkyblock } from "../../utils/playerState";
+import { OFF_SOUND_MODE } from "../../constants/sounds";
+
+let wormTheFishCount = 0;
+
+export function alertOnWormTheFishCatch() {
+    if (!isInSkyblock() ||
+        !hasDirtRodInHand()
+    ) {
+        return;
+    }
+
+    const items = World.getAllEntitiesOfType(EntityItem);
+
+    var currentWormTheFishCount = items.filter(entity => new Item(entity).getName()?.removeFormatting()?.includes('Worm the Fish')).length;
+
+    if (currentWormTheFishCount > wormTheFishCount) { // Alert only when a new item has spawned
+        Client.showTitle(`${RED}Pickup Worm the Fish!`, '', 1, 30, 1);
+        
+        if (settings.soundMode !== OFF_SOUND_MODE) {
+            World.playSound('random.splash', 1, 1);
+        }
+    }
+    
+    wormTheFishCount = currentWormTheFishCount;
+}

--- a/features/alert/alertOnCatch.js
+++ b/features/alert/alertOnCatch.js
@@ -1,17 +1,28 @@
 import settings from "../../settings";
-import { getDoubleHookTitle, getTitle } from '../../utils/common';
-import { NOTIFICATION_SOUND, OFF_SOUND_MODE } from '../../constants/sounds';
+import { getDoubleHookCatchTitle, getCatchTitle } from '../../utils/common';
+import { NOTIFICATION_SOUND_SOURCE, OFF_SOUND_MODE } from '../../constants/sounds';
+import { isInSkyblock } from "../../utils/playerState";
 
 // Shows a title and plays a sound on automated rare catch message sent by this module.
 export function playAlertOnCatch(options) {
-	if (!options.isEnabled) {
-		return;
-	}
-	
-	const title = options.isDoubleHook ? getDoubleHookTitle(options.seaCreature, options.rarityColorCode) : getTitle(options.seaCreature, options.rarityColorCode);
-	Client.showTitle(title, options.player || '', 1, 60, 1);
+	try {
+		if (!options.isEnabled || !isInSkyblock()) {
+			return;
+		}
 
-	if (settings.soundMode !== OFF_SOUND_MODE) {
-		NOTIFICATION_SOUND.play();
+		// If the party message is sent by current player, no need to show alert because they were already alerted on initial catch.
+		if (options.player && options.suppressIfSamePlayer && options.player.includes(Player.getName())) {
+			return;
+		}
+		
+		const title = options.isDoubleHook ? getDoubleHookCatchTitle(options.seaCreature, options.rarityColorCode) : getCatchTitle(options.seaCreature, options.rarityColorCode);
+		Client.showTitle(title, options.player || '', 1, 60, 1);
+	
+		if (settings.soundMode !== OFF_SOUND_MODE) {
+			new Sound(NOTIFICATION_SOUND_SOURCE).play();
+		}
+	} catch (e) {
+		console.error(e);
+		console.log(`[FeeshNotifier] Failed to play alert on catch.`);
 	}
 }

--- a/features/alert/alertOnDrop.js
+++ b/features/alert/alertOnDrop.js
@@ -1,24 +1,35 @@
 import settings from "../../settings";
 import { getDropTitle } from '../../utils/common';
-import { MEME_SOUND_MODE, NORMAL_SOUND_MODE, NOTIFICATION_SOUND } from "../../constants/sounds";
+import { MEME_SOUND_MODE, NORMAL_SOUND_MODE, NOTIFICATION_SOUND_SOURCE } from "../../constants/sounds";
+import { isInSkyblock } from "../../utils/playerState";
 
 // Shows a title and plays a sound on automated rare drop message sent by this module.
 export function playAlertOnDrop(options) {
-	if (!options.isEnabled) {
-		return;
-	}
+	try {
+		if (!options.isEnabled || !isInSkyblock()) {
+			return;
+		}
 		
-	const title = getDropTitle(options.itemName, options.rarityColorCode);
-	Client.showTitle(title, options.player || '', 1, 60, 1);
-
-	switch (settings.soundMode) {
-		case MEME_SOUND_MODE:
-			options.sound.play();
-			break;
-		case NORMAL_SOUND_MODE:
-			NOTIFICATION_SOUND.play();
-			break;
-		default:
-			break;
+		// If the party message is sent by current player, no need to show alert because they were already alerted on initial drop.
+		if (options.player && options.suppressIfSamePlayer && options.player.includes(Player.getName())) {
+			return;
+		}
+	
+		const title = getDropTitle(options.itemName, options.rarityColorCode);
+		Client.showTitle(title, options.player || '', 1, 60, 1);
+	
+		switch (settings.soundMode) {
+			case MEME_SOUND_MODE:
+				new Sound(options.sound).play();
+				break;
+			case NORMAL_SOUND_MODE:
+				new Sound(NOTIFICATION_SOUND_SOURCE).play();
+				break;
+			default:
+				break;
+		}	
+	} catch (e) {
+		console.error(e);
+		console.log(`[FeeshNotifier] Failed to play alert on drop.`);
 	}
 }

--- a/features/alert/alertOnPlayerDeath.js
+++ b/features/alert/alertOnPlayerDeath.js
@@ -1,0 +1,28 @@
+import settings from "../../settings";
+import { OFF_SOUND_MODE } from "../../constants/sounds";
+import { RED } from "../../constants/formatting";
+import { isInSkyblock } from "../../utils/playerState";
+
+// Shows a title and plays a sound on automated player death message sent by this module.
+export function playAlertOnPlayerDeath(options) {
+	try {
+		if (!options.isEnabled || !isInSkyblock()) {
+			return;
+		}
+		
+		// If the party message is sent by current player, no need to show alert.
+		if (options.player && options.player.includes(Player.getName())) {
+			return;
+		}
+	
+		const title = `${options.player || 'Party member'} ${RED}killed ☠`;
+		Client.showTitle(title, 'Wait for them to come back', 1, 45, 1);
+	
+		if (settings.soundMode !== OFF_SOUND_MODE) {
+            World.playSound('mob.villager.death', 1, 1);
+        }
+	} catch (e) {
+		console.error(e);
+		console.log(`[FeeshNotifier] Failed to play alert on party member's death.`);
+	}
+}

--- a/features/catch-tracker/catchTracker.js
+++ b/features/catch-tracker/catchTracker.js
@@ -1,60 +1,71 @@
 import settings from "../../settings";
+import * as seaCreatures from '../../constants/seaCreatures';
 import { persistentData } from "../../data/data";
 import { overlayCoordsData } from "../../data/overlayCoords";
-import { fromUppercaseToCapitalizedFirstLetters, hasDoubleHookInMessage } from '../../utils/common';
+import { fromUppercaseToCapitalizedFirstLetters, hasDoubleHookInMessage, hasDoubleHookInMessage_Reindrake, pluralize } from '../../utils/common';
 import { WHITE, GOLD, BOLD, YELLOW, GRAY } from "../../constants/formatting";
 import { RARE_CATCH_TRIGGERS } from "../../constants/triggers";
 import { getWorldName, hasFishingRodInHotbar, isInSkyblock } from "../../utils/playerState";
 
 export function resetRareCatchesTracker() {
-    if (persistentData.totalRareCatches > 0 && persistentData.rareCatches) {
-        var catches = Object.entries(persistentData.rareCatches)
-            .map(([key, value]) => {
-                return { seaCreature: key, amount: value.amount };
-            })
-            .sort((a, b) => b.amount - a.amount)
-            .map((entry) => {
-                const rarityColorCode = RARE_CATCH_TRIGGERS.find(t => t.seaCreature === entry.seaCreature).rarityColorCode;
-                return `${rarityColorCode}${entry.amount} ${fromUppercaseToCapitalizedFirstLetters(entry.seaCreature)}${entry.amount > 1 ? 's' : ''}`;
-            });
-
-        if (catches.length) {
-            ChatLib.chat(`${GOLD}[FeeshNotifier] ${WHITE}You caught ${catches.join(', ')} ${WHITE}per session (${persistentData.totalRareCatches} rare catches in total).`);
+    try {
+        if (persistentData.totalRareCatches > 0 && persistentData.rareCatches) {
+            var catches = Object.entries(persistentData.rareCatches)
+                .map(([key, value]) => {
+                    return { seaCreature: key, amount: value.amount };
+                })
+                .sort((a, b) => b.amount - a.amount)
+                .map((entry) => {
+                    const rarityColorCode = RARE_CATCH_TRIGGERS.find(t => t.seaCreature === entry.seaCreature).rarityColorCode;
+                    const seaCreatureDisplayName = fromUppercaseToCapitalizedFirstLetters(entry.seaCreature);
+                    return `${rarityColorCode}${entry.amount} ${entry.amount > 1 ? pluralize(seaCreatureDisplayName) : seaCreatureDisplayName}`;
+                });
+    
+            if (catches.length) {
+                ChatLib.chat(`${GOLD}[FeeshNotifier] ${WHITE}You caught ${catches.join(', ')} ${WHITE}per session (${persistentData.totalRareCatches} rare catches in total).`);
+            }
         }
-    }
-
-	persistentData.rareCatches = {};
-    persistentData.totalRareCatches = 0;
-    persistentData.save();
-    ChatLib.chat(`${GOLD}[FeeshNotifier] ${WHITE}Rare catches tracker was reset.`);
+    
+        persistentData.rareCatches = {};
+        persistentData.totalRareCatches = 0;
+        persistentData.save();
+        ChatLib.chat(`${GOLD}[FeeshNotifier] ${WHITE}Rare catches tracker was reset.`);    
+    } catch (e) {
+		console.error(e);
+		console.log(`[FeeshNotifier] Failed to reset rare catches tracker.`);
+	}
 }
 
 export function trackCatch(options) {
-    if (!settings.rareCatchesTrackerOverlay) {
-        return;
-    }
-
-	const isDoubleHook = hasDoubleHookInMessage();
-    const valueToAdd = isDoubleHook ? 2 : 1;
-    const currentAmount = persistentData.rareCatches[options.seaCreature] ? persistentData.rareCatches[options.seaCreature].amount : 0;
-
-	persistentData.rareCatches[options.seaCreature] = {
-        amount: currentAmount ? currentAmount + valueToAdd : valueToAdd,
-        percent: null
-    };
-
-    const total = Object.values(persistentData.rareCatches).reduce((accumulator, currentValue) => {
-        return accumulator + currentValue.amount
-    }, 0);
-    persistentData.totalRareCatches = total;
-
-    Object.keys(persistentData.rareCatches).forEach((key) => {
-        const entry = persistentData.rareCatches[key];
-        const percent = persistentData.totalRareCatches ? ((entry.amount / persistentData.totalRareCatches) * 100).toFixed(2) : 0;
-        entry.percent = percent;
-    });
-
-    persistentData.save();
+    try {
+        if (!settings.rareCatchesTrackerOverlay || !isInSkyblock()) {
+            return;
+        }
+    
+        const valueToAdd = options.isDoubleHook ? 2 : 1;
+        const currentAmount = persistentData.rareCatches[options.seaCreature] ? persistentData.rareCatches[options.seaCreature].amount : 0;
+    
+        persistentData.rareCatches[options.seaCreature] = {
+            amount: currentAmount ? currentAmount + valueToAdd : valueToAdd,
+            percent: null
+        };
+    
+        const total = Object.values(persistentData.rareCatches).reduce((accumulator, currentValue) => {
+            return accumulator + currentValue.amount
+        }, 0);
+        persistentData.totalRareCatches = total;
+    
+        Object.keys(persistentData.rareCatches).forEach((key) => {
+            const entry = persistentData.rareCatches[key];
+            const percent = persistentData.totalRareCatches ? ((entry.amount / persistentData.totalRareCatches) * 100).toFixed(2) : 0;
+            entry.percent = percent;
+        });
+    
+        persistentData.save();    
+    } catch (e) {
+		console.error(e);
+		console.log(`[FeeshNotifier] Failed to track rare catch.`);
+	}
 }
 
 export function renderRareCatchTrackerOverlay() {

--- a/features/chat/messageOnCatch.js
+++ b/features/chat/messageOnCatch.js
@@ -1,28 +1,18 @@
-import settings from "../../settings";
-import { hasDoubleHookInMessage, getDoubleHookMessage, getMessage, getDoubleHookTitle, getTitle } from '../../utils/common';
-import { NOTIFICATION_SOUND, OFF_SOUND_MODE } from '../../constants/sounds';
+import { getDoubleHookCatchMessage, getCatchMessage } from '../../utils/common';
+import { isInSkyblock } from '../../utils/playerState';
 
 const chatCommand = 'pc';
 
 export function sendMessageOnCatch(options) {
-	if (!options.isMessageEnabled && !options.isAlertEnabled) {
-		return;
-	}
-
-	const isDoubleHook = hasDoubleHookInMessage();
-
-	if (options.isMessageEnabled) {
-		const message = isDoubleHook ? getDoubleHookMessage(options.seaCreature) : getMessage(options.seaCreature);
-		ChatLib.command(chatCommand + ' ' + message);
-	}
-	
-	// Play alert if you aren't in the party so automated message is not sent
-	if (options.isAlertEnabled) {
-		const title = isDoubleHook ? getDoubleHookTitle(options.seaCreature, options.rarityColorCode) : getTitle(options.seaCreature, options.rarityColorCode);
-		Client.showTitle(title, '', 1, 60, 1);
-		
-		if (settings.soundMode !== OFF_SOUND_MODE) {
-			NOTIFICATION_SOUND.play();
+	try {
+		if (!options.isEnabled || !isInSkyblock()) {
+			return;
 		}
-	}		
+	
+		const message = options.isDoubleHook ? getDoubleHookCatchMessage(options.seaCreature) : getCatchMessage(options.seaCreature);
+		ChatLib.command(chatCommand + ' ' + message);	
+	} catch (e) {
+		console.error(e);
+		console.log(`[FeeshNotifier] Failed to send the message and play alert on catch.`);
+	}
 }

--- a/features/chat/messageOnPlayerDeath.js
+++ b/features/chat/messageOnPlayerDeath.js
@@ -1,18 +1,18 @@
-import { getDropMessage } from '../../utils/common';
+import { getPlayerDeathMessage } from '../../utils/common';
 import { isInSkyblock } from '../../utils/playerState';
 
 const chatCommand = 'pc';
 
-export function sendMessageOnDrop(options) {
+export function sendMessageOnPlayerDeath(options) {
 	try {
 		if (!options.isEnabled || !isInSkyblock()) {
 			return;
 		}
-		
-		const message = getDropMessage(options.itemName);
+
+		const message = getPlayerDeathMessage();
 		ChatLib.command(chatCommand + ' ' + message);	
 	} catch (e) {
 		console.error(e);
-		console.log(`[FeeshNotifier] Failed to send the message and play alert on drop.`);
+		console.log(`[FeeshNotifier] Failed to send the message on player's death.`);
 	}
 }

--- a/features/count-tracker/countTracker.js
+++ b/features/count-tracker/countTracker.js
@@ -1,6 +1,6 @@
 import settings from "../../settings";
 import { GOLD, RED, DARK_GRAY, WHITE } from "../../constants/formatting";
-import { TIMER_SOUND, OFF_SOUND_MODE } from "../../constants/sounds";
+import { TIMER_SOUND_SOURCE, OFF_SOUND_MODE } from "../../constants/sounds";
 import { ALL_SEA_CREATURES_NAMES } from "../../constants/seaCreatures";
 import { EntityArmorStand } from "../../constants/javaTypes";
 import { overlayCoordsData } from "../../data/overlayCoords";
@@ -53,7 +53,7 @@ export function alertOnSeaCreaturesCountThreshold() {
 
         if (settings.soundMode !== OFF_SOUND_MODE)
         {
-            TIMER_SOUND.play();
+            new Sound(TIMER_SOUND_SOURCE).play();
         }
     } else if (mobsCount < seaCreaturesCountThreshold && killMobsNotificationShown) {
         killMobsNotificationShown = false;

--- a/features/totem/totem.js
+++ b/features/totem/totem.js
@@ -1,7 +1,7 @@
 import settings from "../../settings";
 import { overlayCoordsData } from "../../data/overlayCoords";
 import { EntityArmorStand } from "../../constants/javaTypes";
-import { TIMER_SOUND, OFF_SOUND_MODE } from "../../constants/sounds";
+import { TIMER_SOUND_SOURCE, OFF_SOUND_MODE } from "../../constants/sounds";
 import { WHITE, GOLD, RED } from "../../constants/formatting";
 import { isInSkyblock } from "../../utils/playerState";
 
@@ -42,7 +42,7 @@ export function trackTotemStatus() {
 
                     if (settings.soundMode !== OFF_SOUND_MODE)
                     {
-                        TIMER_SOUND.play();
+                        new Sound(TIMER_SOUND_SOURCE).play();
                     }
                 }
             }

--- a/index.js
+++ b/index.js
@@ -2,17 +2,21 @@ import settings from "./settings";
 import "./commands";
 import "./moveOverlay";
 import * as triggers from './constants/triggers';
+import * as seaCreatures from './constants/seaCreatures';
 import { sendMessageOnCatch } from './features/chat/messageOnCatch';
 import { sendMessageOnDrop } from './features/chat/messageOnDrop';
 import { playAlertOnCatch } from './features/alert/alertOnCatch';
 import { playAlertOnDrop } from './features/alert/alertOnDrop';
-import { getMessage, getDoubleHookMessage, getDropMessage, getPartyChatMessage } from './utils/common';
+import { getCatchMessage, getColoredPlayerNameFromDisplayName, getColoredPlayerNameFromPartyChat, getDoubleHookCatchMessage, getDropMessage, getPartyChatMessage, getPlayerDeathMessage, hasDoubleHookInMessage, hasDoubleHookInMessage_Reindrake } from './utils/common';
 import { trackTotemStatus, renderTotemOverlay } from './features/totem/totem';
 import { trackCatch, renderRareCatchTrackerOverlay } from './features/catch-tracker/catchTracker';
 import { renderHpOverlay, trackSeaCreaturesHp } from "./features/hp-tracker/hpTracker";
 import { renderCountOverlay, alertOnSeaCreaturesCountThreshold, trackSeaCreaturesCount } from "./features/count-tracker/countTracker";
 import { alertOnNonFishingArmor } from "./features/alert-armor/alertOnNonFishingArmor";
 import { trackPlayerState } from "./utils/playerState";
+import { alertOnWormTheFishCatch } from "./features/alert-worm-the-fish/alertOnWormTheFish";
+import { sendMessageOnPlayerDeath } from "./features/chat/messageOnPlayerDeath";
+import { playAlertOnPlayerDeath } from "./features/alert/alertOnPlayerDeath";
 
 register('worldLoad', () => {
     Client.showTitle('', '', 1, 1, 1); // Shitty fix for a title not showing for the 1st time
@@ -21,7 +25,7 @@ register('worldLoad', () => {
 // Track reusable player's state (inventory, world, etc.)
 register('step', () => trackPlayerState()).setFps(2);
 
-// Totem
+// Totem of corruption
 
 register('step', () => trackTotemStatus()).setFps(1);
 register('renderOverlay', () => renderTotemOverlay());
@@ -31,37 +35,74 @@ register('renderOverlay', () => renderTotemOverlay());
 register('step', () => trackSeaCreaturesHp()).setFps(2);
 register('renderOverlay', () => renderHpOverlay());
 
-// Sea creatures count
+// Sea creatures count + barn fish timer
 
 register('step', () => trackSeaCreaturesCount()).setFps(2);
 register('step', () => alertOnSeaCreaturesCountThreshold()).setFps(1);
 register('renderOverlay', () => renderCountOverlay());
 
-// Armor
+// Wrong armor
 
 register("playerInteract", (action, pos, event) => {
     alertOnNonFishingArmor(action, pos, event);
 });
+
+// Party member's death (Jawbus, Thunder)
+
+triggers.KILLED_BY_TRIGGERS.forEach(entry => {
+    register(
+        "Chat",
+        (event) => {
+            sendMessageOnPlayerDeath({
+                isEnabled: settings.messageOnDeath
+            });
+        }
+    ).setCriteria(entry.trigger).setContains();
+
+    register(
+        "Chat",
+        (rankAndPlayer, event) => playAlertOnPlayerDeath({
+            isEnabled: settings.alertOnPartyMemberDeath,
+            player: getColoredPlayerNameFromPartyChat(rankAndPlayer)
+        })
+    ).setCriteria(getPartyChatMessage(getPlayerDeathMessage()));
+});
+
+// Worm The Fish (Dirt Rod fishing)
+
+register('renderWorld', () => alertOnWormTheFishCatch());
 
 // Rare catch triggers
 
 register('renderOverlay', () => renderRareCatchTrackerOverlay());
 
 triggers.RARE_CATCH_TRIGGERS.forEach(entry => {
+    // Triggers on original "all chat" catch message sent by Hypixel.
     register(
         "Chat",
-        (event) => {         
+        (event) => {
+            const isDoubleHooked = entry.seaCreature != seaCreatures.REINDRAKE ? hasDoubleHookInMessage() : hasDoubleHookInMessage_Reindrake();
+            playAlertOnCatch({ // Play alert immediately before sending to the party (in case when you're fishing solo)
+                seaCreature: entry.seaCreature,
+                rarityColorCode: entry.rarityColorCode,
+                isEnabled: settings[entry.isAlertEnabledSettingKey],
+                isDoubleHook: isDoubleHooked,
+                player: getColoredPlayerNameFromDisplayName(),
+                suppressIfSamePlayer: false
+            });
+
             sendMessageOnCatch({
                 seaCreature: entry.seaCreature,
                 rarityColorCode: entry.rarityColorCode,
-                isMessageEnabled: settings[entry.isMessageEnabledSettingKey],
-                isAlertEnabled: settings[entry.isAlertEnabledSettingKey]
+                isDoubleHook: isDoubleHooked,
+                isEnabled: settings[entry.isMessageEnabledSettingKey]
             });
 
-            trackCatch({ seaCreature: entry.seaCreature, rarityColorCode: entry.rarityColorCode });
+            trackCatch({ seaCreature: entry.seaCreature, rarityColorCode: entry.rarityColorCode, isDoubleHook: isDoubleHooked });
         }
     ).setCriteria(entry.trigger).setContains();
 
+    // Triggers on automated party chat message sent by the module (no double hook).
     register(
         "Chat",
         (rankAndPlayer, event) => playAlertOnCatch({
@@ -69,10 +110,12 @@ triggers.RARE_CATCH_TRIGGERS.forEach(entry => {
             rarityColorCode: entry.rarityColorCode,
             isEnabled: settings[entry.isAlertEnabledSettingKey],
             isDoubleHook: false,
-            player: rankAndPlayer
+            player: getColoredPlayerNameFromPartyChat(rankAndPlayer),
+            suppressIfSamePlayer: true
         })
-    ).setCriteria(getPartyChatMessage(getMessage(entry.seaCreature)));
+    ).setCriteria(getPartyChatMessage(getCatchMessage(entry.seaCreature)));
 
+    // Triggers on automated party chat message sent by the module (double hook).
     register(
         "Chat",
         (rankAndPlayer, event) => playAlertOnCatch({
@@ -80,25 +123,38 @@ triggers.RARE_CATCH_TRIGGERS.forEach(entry => {
             rarityColorCode: entry.rarityColorCode,
             isEnabled: settings[entry.isAlertEnabledSettingKey],
             isDoubleHook: true,
-            player: rankAndPlayer
+            player: getColoredPlayerNameFromPartyChat(rankAndPlayer),
+            suppressIfSamePlayer: true
         })
-    ).setCriteria(getPartyChatMessage(getDoubleHookMessage(entry.seaCreature)));
+    ).setCriteria(getPartyChatMessage(getDoubleHookCatchMessage(entry.seaCreature)));
 });
 
 // Rare drop triggers
 
 triggers.RARE_DROP_TRIGGERS.forEach(entry => {
+    // Triggers on original "all chat" drop message sent by Hypixel.
     register(
         "Chat",
-        (event) => sendMessageOnDrop({
-            itemName: entry.itemName,
-            rarityColorCode: entry.rarityColorCode,
-            sound: entry.sound,
-            isMessageEnabled: settings[entry.isMessageEnabledSettingKey],
-            isAlertEnabled: settings[entry.isAlertEnabledSettingKey]
-        })
+        (event) => {
+            playAlertOnDrop({
+                itemName: entry.itemName,
+                rarityColorCode: entry.rarityColorCode,
+                sound: entry.sound,
+                isEnabled: settings[entry.isAlertEnabledSettingKey],
+                player: getColoredPlayerNameFromDisplayName(),
+                suppressIfSamePlayer: false
+            });
+
+            sendMessageOnDrop({
+                itemName: entry.itemName,
+                rarityColorCode: entry.rarityColorCode,
+                sound: entry.sound,
+                isEnabled: settings[entry.isMessageEnabledSettingKey]
+            });
+        }
     ).setCriteria(entry.trigger).setContains();
 
+    // Triggers on automated party chat message sent by the module.
     register(
         "Chat",
         (rankAndPlayer, event) => playAlertOnDrop({
@@ -106,7 +162,8 @@ triggers.RARE_DROP_TRIGGERS.forEach(entry => {
             rarityColorCode: entry.rarityColorCode,
             sound: entry.sound,
             isEnabled: settings[entry.isAlertEnabledSettingKey],
-            player: rankAndPlayer
+            player: getColoredPlayerNameFromPartyChat(rankAndPlayer),
+            suppressIfSamePlayer: true
         })
     ).setCriteria(getPartyChatMessage(getDropMessage(entry.itemName)));
 });

--- a/metadata.json
+++ b/metadata.json
@@ -3,7 +3,7 @@
     "entry": "index.js",
     "author": "MoonTheSadFisher",
     "description": "Hypixel Skyblock fishing utilities for parties.",
-    "version": "1.6.1",
+    "version": "1.7.0",
     "requires": [
         "Vigilance",
         "PogData"

--- a/settings.js
+++ b/settings.js
@@ -205,6 +205,16 @@ class Settings {
     })
     messageOnMagmaCoreDrop = true;
 
+    // ******* CHAT - Player's death ******* //
+
+    @SwitchProperty({
+        name: "Send a message when you are killed by Thunder / Lord Jawbus",
+        description: `${GRAY}Sends a message to the ${BLUE}party chat ${GRAY}when when you are killed by Thunder / Lord Jawbus. It enables the alerts for your party members so they can wait for you.`,
+        category: "Chat",
+        subcategory: "Player's death"
+    })
+    messageOnDeath = true;
+
     // ******* ALERTS - Totem ******* //
 
     @SwitchProperty({
@@ -214,6 +224,16 @@ class Settings {
         subcategory: "Totem"
     })
     alertOnTotemExpiresSoon = true;
+
+    // ******* ALERTS - Party member's death ******* //
+
+    @SwitchProperty({
+        name: "Alert when a party member was killed by Thunder / Lord Jawbus",
+        description: `Shows a title and plays a sound when your party member reports they are killed by Thunder / Lord Jawbus, so the party can wait for them to come back.`,
+        category: "Alerts",
+        subcategory: "Party member's death"
+    })
+    alertOnPartyMemberDeath = true;
 
     // ******* ALERTS - Fishing armor ******* //
 

--- a/utils/common.js
+++ b/utils/common.js
@@ -9,19 +9,41 @@ export function hasDoubleHookInMessage() {
 	return isDoubleHook;
 }
 
-export function getMessage(seaCreature) {
+// Double hook reindrakes may produce the following messages history:
+// [CHAT] &r&eIt's a &r&aDouble Hook&r&e!&r
+// [CHAT] &r
+// [CHAT] &r&c&lWOAH! &r&cA &r&4Reindrake &r&cwas summoned from the depths!&r
+// [CHAT] &r
+// [CHAT] &r
+// [CHAT] &r&c&lWOAH! &r&cA &r&4Reindrake &r&cwas summoned from the depths!&r
+// [CHAT] &r
+// [CHAT] &r&aA Reindrake forms from the depths.&r
+export function hasDoubleHookInMessage_Reindrake() {
+	const doubleHookMessages = [ '&r&eIt\'s a &r&aDouble Hook&r&e! Woot woot!&r', '&r&eIt\'s a &r&aDouble Hook&r&e!&r' ];
+	const history = ChatLib.getChatLines()?.filter(l => l !== '&r' && l !== '&r&c&lWOAH! &r&cA &r&4Reindrake &r&cwas summoned from the depths!&r');
+	const isDoubleHook = (!!history && history.length > 1)
+		? doubleHookMessages.includes(history[1])
+		: false;
+	return isDoubleHook;
+}
+
+export function getCatchMessage(seaCreature) {
 	return `--> ${getArticle(seaCreature)} ${seaCreature} has spawned <--`;
 }
 
-export function getDoubleHookMessage(seaCreature) {
+export function getDoubleHookCatchMessage(seaCreature) {
 	return `--> DOUBLE HOOK! Two ${seaCreature}s have spawned <--`;
 }
 
-export function getTitle(seaCreature, rarityColorCode) {
+export function getPlayerDeathMessage() {
+	return `--> I was killed, please wait for me until I come back <--`;
+}
+
+export function getCatchTitle(seaCreature, rarityColorCode) {
 	return `${rarityColorCode}${BOLD}${seaCreature}`;
 }
 
-export function getDoubleHookTitle(seaCreature, rarityColorCode) {
+export function getDoubleHookCatchTitle(seaCreature, rarityColorCode) {
 	return `${rarityColorCode}${BOLD}${seaCreature} ${RED}${BOLD}X2`;
 }
 
@@ -31,6 +53,20 @@ export function getDropMessage(item) {
 
 export function getDropTitle(item, rarityColorCode) {
 	return `${rarityColorCode}${BOLD}${item}`;
+}
+
+export function getColoredPlayerNameFromDisplayName() {
+	const displayName = Player.getDisplayName(); // [Level] Nickname, e.g. §r§r§8[§d326§8] §bMoonTheSadFisher §7α§r§7
+	const nameWithoutLevel = displayName.getText().split('] ').pop();
+	const name = nameWithoutLevel.split(' ')[0];
+	return name;
+}
+
+export function getColoredPlayerNameFromPartyChat(playerAndRank) { // &r&9Party &8> &b[MVP&d+&b] DeadlyMetal&f: &r--> A YETI has spawned <--&r
+	if (!playerAndRank) return '';
+	const color = playerAndRank.substring(0, 2);
+	const nameWithoutRank = playerAndRank.split('] ').pop();
+	return `${color}${nameWithoutRank}`;
 }
 
 // Messages have the following format:
@@ -50,6 +86,19 @@ export function fromUppercaseToCapitalizedFirstLetters(str) {
 	return words.map((word) => { 
 	    return word[0].toUpperCase() + word.substring(1).toLowerCase(); 
 	}).join(' ');
+}
+
+// Pluralizes the words, e.g. Thunder => Thunders, Lord Jawbus => Lord Jawbuses.
+export function pluralize(str) {
+	if (!str) {
+		return '';
+	}
+
+	if (str.endsWith('s') || str.endsWith('z') || str.endsWith('x') || str.endsWith('sh') || str.endsWith('ch')) {
+		return `${str}es`;
+	}
+
+	return `${str}s`;
 }
 
 function getArticle(str) {

--- a/utils/playerState.js
+++ b/utils/playerState.js
@@ -1,6 +1,7 @@
 var isInSkyblock = false;
 var hasFishingRodInHotbar = false;
 var hasFishingRodInHand = false;
+var hasDirtRodInHand = false;
 var worldName = null;
 
 export function trackPlayerState() {
@@ -8,6 +9,7 @@ export function trackPlayerState() {
 	setWorldName();
 	setHasFishingRodInHotbar();
     setHasFishingRodInHand();
+	setHasDirtRodInHand();
 }
 
 export function isInSkyblock() {
@@ -24,6 +26,10 @@ export function hasFishingRodInHotbar() {
 
 export function hasFishingRodInHand() {
 	return hasFishingRodInHand;
+}
+
+export function hasDirtRodInHand() {
+	return hasDirtRodInHand;
 }
 
 function setIsInSkyblock() {
@@ -73,5 +79,21 @@ function setHasFishingRodInHand() {
 	} else {
 		const isRod = heldItem.getLore().some(loreLine => loreLine.includes('FISHING ROD') || loreLine.includes('FISHING WEAPON'));
 		hasFishingRodInHand = isRod;
+	}
+}
+
+function setHasDirtRodInHand() {
+	if (!isInSkyblock) {
+		hasDirtRodInHand = false;
+		return;
+	}
+
+	const heldItem = Player.getHeldItem();
+	if (!heldItem) {
+		hasDirtRodInHand = false;
+	} else {
+		const loreLines = heldItem.getLore();
+		const isDirtRod = loreLines[0].includes('Dirt Rod');
+		hasDirtRodInHand = isDirtRod;
 	}
 }


### PR DESCRIPTION
Features:

- Toggleable alert when you/your party member died from Thunder/Jawbus (so party can wait before killing)
- Alert on worm the fish caught (Dirt Rod)

Fixes:

- Fixed cause of alert triggers unloading
- Reindrake title/pchat message now shows double hook
- No fishing armor equipped alert - Squid Hat considered as fishing armor
- No fishing armor equipped alert - check for SCC in armor stats only
- Fixed Jawbus pluralization when resetting rare catches
- Refactored alerts on catches/drops
- Removed player ranks from the subtitles