### PR TITLE
Release 1.8.0

### DIFF
--- a/commands.js
+++ b/commands.js
@@ -7,7 +7,8 @@ register("command", (...args) => {
 }).setName("feesh").setAliases(["feeshnotifier"]);
 
 register("command", (...args) => {
-    resetRareCatchesTracker();
+    const isConfirmed = args[0] && args[0] === "noconfirm";
+    resetRareCatchesTracker(!!isConfirmed);
     return;
 }).setName("feeshResetRareCatches");
 

--- a/constants/javaTypes.js
+++ b/constants/javaTypes.js
@@ -1,2 +1,3 @@
 export const EntityArmorStand = Java.type("net.minecraft.entity.item.EntityArmorStand");
 export const EntityItem = Java.type("net.minecraft.entity.item.EntityItem");
+export const EntityFishHook = Java.type("net.minecraft.entity.projectile.EntityFishHook");

--- a/constants/triggers.js
+++ b/constants/triggers.js
@@ -18,7 +18,7 @@ export const ABYSSAL_MINER_MESSAGE = `${GREEN}An Abyssal Miner breaks out of the
 export const THUNDER_MESSAGE = `${RESET}${RED}${BOLD}You hear a massive rumble as Thunder emerges.`;
 export const LORD_JAWBUS_MESSAGE = `${RESET}${RED}${BOLD}You have angered a legendary creature... Lord Jawbus has arrived.`;
 export const PLHLEGBLAST_MESSAGE = `${GREEN}WOAH! A Plhlegblast appeared.`;
-export const VANQUISHER_MESSAGE = `A ${RESET}${RED}Vanquisher ${RESET}${GREEN}is spawning nearby!`;
+export const VANQUISHER_MESSAGE = `A ${RESET}${RED}Vanquisher ${RESET}${GREEN}is spawning nearby!`; // A &r&cVanquisher &r&ais spawning nearby!
 
 export const BABY_YETI_PET_LEG_MESSAGE = `PET DROP! ${RESET}${GOLD}Baby Yeti`; // PET DROP! &r&6Baby Yeti
 export const BABY_YETI_PET_EPIC_MESSAGE = `PET DROP! ${RESET}${DARK_PURPLE}Baby Yeti`; // PET DROP! &r&5Baby Yeti

--- a/data/overlayCoords.js
+++ b/data/overlayCoords.js
@@ -4,5 +4,6 @@ export const overlayCoordsData = new PogObject("FeeshNotifier", {
     "totemRemainingTimeOverlay": { "x": 10, "y": 30, "scale": 1 },
     "rareCatchesTrackerOverlay": { "x": 10, "y": 50, "scale": 1 },
     "seaCreaturesHpOverlay": { "x": 10, "y": 30, "scale": 1 },
-    "seaCreaturesCountOverlay": { "x": 10, "y": 50, "scale": 1 }
+    "seaCreaturesCountOverlay": { "x": 10, "y": 50, "scale": 1 },
+    "legionAndBobbingTimeOverlay": { "x": 10, "y": 80, "scale": 1 }
 }, 'config/overlayCoords.json');

--- a/features/alert/alertOnCatch.js
+++ b/features/alert/alertOnCatch.js
@@ -16,7 +16,7 @@ export function playAlertOnCatch(options) {
 		}
 		
 		const title = options.isDoubleHook ? getDoubleHookCatchTitle(options.seaCreature, options.rarityColorCode) : getCatchTitle(options.seaCreature, options.rarityColorCode);
-		Client.showTitle(title, options.player || '', 1, 60, 1);
+		Client.showTitle(title, options.player || '', 1, 45, 1);
 	
 		if (settings.soundMode !== OFF_SOUND_MODE) {
 			new Sound(NOTIFICATION_SOUND_SOURCE).play();

--- a/features/alert/alertOnDrop.js
+++ b/features/alert/alertOnDrop.js
@@ -16,7 +16,7 @@ export function playAlertOnDrop(options) {
 		}
 	
 		const title = getDropTitle(options.itemName, options.rarityColorCode);
-		Client.showTitle(title, options.player || '', 1, 60, 1);
+		Client.showTitle(title, options.player || '', 1, 45, 1);
 	
 		switch (settings.soundMode) {
 			case MEME_SOUND_MODE:

--- a/features/alert/alertOnNonFishingArmor.js
+++ b/features/alert/alertOnNonFishingArmor.js
@@ -43,7 +43,7 @@ export function alertOnNonFishingArmor(action, pos, event) {
     }
 
     if (fishingArmorCount < 2) {
-        Client.showTitle(`${RED}Equip fishing armor!`, "", 1, 30, 1);
+        Client.showTitle(`${RED}Equip fishing armor!`, '', 1, 30, 1);
     }
 }
 

--- a/features/alert/alertOnWormTheFish.js
+++ b/features/alert/alertOnWormTheFish.js
@@ -18,7 +18,7 @@ export function alertOnWormTheFishCatch() {
     var currentWormTheFishCount = items.filter(entity => new Item(entity).getName()?.removeFormatting()?.includes('Worm the Fish')).length;
 
     if (currentWormTheFishCount > wormTheFishCount) { // Alert only when a new item has spawned
-        Client.showTitle(`${RED}Pickup Worm the Fish!`, '', 1, 30, 1);
+        Client.showTitle(`${RED}Pickup Worm the Fish!`, '', 1, 45, 1);
         
         if (settings.soundMode !== OFF_SOUND_MODE) {
             World.playSound('random.splash', 1, 1);

--- a/features/inventory/highlightCheapBooks.js
+++ b/features/inventory/highlightCheapBooks.js
@@ -1,0 +1,43 @@
+import settings from "../../settings";
+import { isInSkyblock } from "../../utils/playerState";
+
+export function highlightCheapBooks(slot, gui) {
+    if (!settings.highlightCheapBooks || !isInSkyblock()) {
+        return;
+    }
+
+    if (!(gui instanceof net.minecraft.client.gui.inventory.GuiChest) && !(gui instanceof net.minecraft.client.gui.inventory.GuiInventory)) {
+        return;
+    }
+
+    // if (gui instanceof net.minecraft.client.gui.inventory.GuiChest) {
+    //     const chestName = gui.field_147002_h.func_85151_d().func_145748_c_().text; // inventorySlots -> getLowerChestInventory() -> getDisplayName()
+    //     if (!chestName.includes('SkyBlock Menu') && !chestName.includes('Ender Chest') && !chestName.includes('Storage') && !chestName.includes('Backpack') && !chestName.includes('Chest') && !chestName.includes('Bazaar')) {
+    //         return;
+    //     }
+    // }
+
+    const item = slot.getItem();
+
+    if (!item) {
+        return;
+    }
+
+    const name = item.getName();
+    if (!name.includes('Enchanted Book')) {
+        return;
+    }
+
+    const lore = item.getLore();
+    const bookName = lore.length ? lore[1] : '';
+
+    if (bookName.includes('Corruption') ||
+        bookName.includes('Frail') ||
+        bookName.includes('Lure') ||
+        bookName.includes('Magnet') ||
+        bookName.includes('Angler') ||
+        bookName.includes('Spiked Hook')
+    ) {
+        Renderer.drawRect(Renderer.color(255, 0, 0, 100), slot.getDisplayX(), slot.getDisplayY(), 16, 16);
+    }
+}

--- a/features/legion-and-bobbing-time-tracker/legionAndBobbingTimeTracker.js
+++ b/features/legion-and-bobbing-time-tracker/legionAndBobbingTimeTracker.js
@@ -1,0 +1,56 @@
+import settings from "../../settings";
+import { GOLD, WHITE } from "../../constants/formatting";
+import { EntityFishHook } from "../../constants/javaTypes";
+import { overlayCoordsData } from "../../data/overlayCoords";
+import { getWorldName, hasFishingRodInHotbar, isInSkyblock } from "../../utils/playerState";
+
+let playersCount = 0;
+let fishingHooksCount = 0;
+
+const legionDistance = 30;
+const bobbingTimeDistance = 30;
+
+export function trackPlayersAndFishingHooksNearby() {
+    if (!settings.legionAndBobbingTimeOverlay ||
+        !isInSkyblock() ||
+        !hasFishingRodInHotbar() ||
+        getWorldName() === 'Kuudra'
+    ) {
+        return;
+    }
+
+    fishingHooksCount = World
+        .getAllEntitiesOfType(EntityFishHook)
+        .filter(hook => hook.distanceTo(Player.getPlayer()) < bobbingTimeDistance)
+        .length;
+
+    const players = World
+        .getAllPlayers()
+        .filter(player =>
+            (player.getUUID().version() === 4 || player.getUUID().version() === 1) && // Players and Watchdog have version 4, nicked players have version 1, this is done to exclude NPCs
+            //player.ping > 0 && // Exclude watchdog
+            player.name != Player.getName() && // Exclude current player because they do not count for legion
+            player.distanceTo(Player.getPlayer()) < legionDistance
+        )
+        .map(player => player.name)
+        .filter((x, i, a) => a.indexOf(x) == i); // Distinct, sometimes the players are duplicated in the list
+
+    playersCount = players.length > 0 ? players.length - 1 : 0; // -1 to exclude watchdog
+}
+
+export function renderLegionAndBobbingTimeOverlay() {
+    if (!settings.legionAndBobbingTimeOverlay ||
+        !isInSkyblock() ||
+        !hasFishingRodInHotbar() ||
+        getWorldName() === 'Kuudra'
+    ) {
+        return;
+    }
+
+    const playersText = `${GOLD}Legion: ${WHITE}${playersCount} ${playersCount === 1 ? 'player' : 'players'}`;
+    const hooksText = `${GOLD}Bobbin' time: ${WHITE}${fishingHooksCount} ${fishingHooksCount === 1 ? 'hook' : 'hooks'} α`;
+    const overlay = new Text(`${playersText}\n${hooksText}`, overlayCoordsData.legionAndBobbingTimeOverlay.x, overlayCoordsData.legionAndBobbingTimeOverlay.y)
+        .setShadow(true)
+        .setScale(overlayCoordsData.legionAndBobbingTimeOverlay.scale);
+    overlay.draw();
+}

--- a/features/totem/totem.js
+++ b/features/totem/totem.js
@@ -38,7 +38,7 @@ export function trackTotemStatus() {
                 remainingTotemTime = name.split('Remaining: ').pop();
 
                 if (settings.alertOnTotemExpiresSoon && remainingTotemTime && remainingTotemTime === `${secondsBeforeExpiration}s`) {
-                    Client.showTitle(`&cYour totem expires in ${secondsBeforeExpiration} seconds`, '', 1, 60, 1);
+                    Client.showTitle(`&cYour totem expires soon`, '', 1, 45, 1);
 
                     if (settings.soundMode !== OFF_SOUND_MODE)
                     {

--- a/index.js
+++ b/index.js
@@ -11,12 +11,14 @@ import { getCatchMessage, getColoredPlayerNameFromDisplayName, getColoredPlayerN
 import { trackTotemStatus, renderTotemOverlay } from './features/totem/totem';
 import { trackCatch, renderRareCatchTrackerOverlay } from './features/catch-tracker/catchTracker';
 import { renderHpOverlay, trackSeaCreaturesHp } from "./features/hp-tracker/hpTracker";
-import { renderCountOverlay, alertOnSeaCreaturesCountThreshold, trackSeaCreaturesCount } from "./features/count-tracker/countTracker";
-import { alertOnNonFishingArmor } from "./features/alert-armor/alertOnNonFishingArmor";
+import { renderCountOverlay, alertOnSeaCreaturesCountThreshold, alertOnSeaCreaturesTimerThreshold, trackSeaCreaturesCount } from "./features/count-tracker/countTracker";
+import { alertOnNonFishingArmor } from "./features/alert/alertOnNonFishingArmor";
 import { trackPlayerState } from "./utils/playerState";
-import { alertOnWormTheFishCatch } from "./features/alert-worm-the-fish/alertOnWormTheFish";
+import { alertOnWormTheFishCatch } from "./features/alert/alertOnWormTheFish";
 import { sendMessageOnPlayerDeath } from "./features/chat/messageOnPlayerDeath";
 import { playAlertOnPlayerDeath } from "./features/alert/alertOnPlayerDeath";
+import { highlightCheapBooks } from "./features/inventory/highlightCheapBooks";
+import { renderLegionAndBobbingTimeOverlay, trackPlayersAndFishingHooksNearby } from "./features/legion-and-bobbing-time-tracker/legionAndBobbingTimeTracker";
 
 register('worldLoad', () => {
     Client.showTitle('', '', 1, 1, 1); // Shitty fix for a title not showing for the 1st time
@@ -32,19 +34,31 @@ register('renderOverlay', () => renderTotemOverlay());
 
 // Sea creatures HP
 
-register('step', () => trackSeaCreaturesHp()).setFps(2);
+register('step', () => trackSeaCreaturesHp()).setFps(4);
 register('renderOverlay', () => renderHpOverlay());
 
 // Sea creatures count + barn fish timer
 
 register('step', () => trackSeaCreaturesCount()).setFps(2);
 register('step', () => alertOnSeaCreaturesCountThreshold()).setFps(1);
+register('step', () => alertOnSeaCreaturesTimerThreshold()).setFps(1);
 register('renderOverlay', () => renderCountOverlay());
 
-// Wrong armor
+// Non-fishing armor
 
 register("playerInteract", (action, pos, event) => {
     alertOnNonFishingArmor(action, pos, event);
+});
+
+// Players and fishing hooks (legion / bobbing time)
+
+register('step', () => trackPlayersAndFishingHooksNearby()).setFps(2);
+register('renderOverlay', () => renderLegionAndBobbingTimeOverlay());
+
+// Highlight cheap enchanted books
+
+register('renderSlot', (slot, gui, event) => {
+    highlightCheapBooks(slot, gui);
 });
 
 // Party member's death (Jawbus, Thunder)
@@ -72,7 +86,7 @@ triggers.KILLED_BY_TRIGGERS.forEach(entry => {
 
 register('renderWorld', () => alertOnWormTheFishCatch());
 
-// Rare catch triggers
+// Rare catches overlay
 
 register('renderOverlay', () => renderRareCatchTrackerOverlay());
 

--- a/metadata.json
+++ b/metadata.json
@@ -3,7 +3,7 @@
     "entry": "index.js",
     "author": "MoonTheSadFisher",
     "description": "Hypixel Skyblock fishing utilities for parties.",
-    "version": "1.7.0",
+    "version": "1.8.0",
     "requires": [
         "Vigilance",
         "PogData"

--- a/moveOverlay.js
+++ b/moveOverlay.js
@@ -14,6 +14,9 @@ register("dragged", (mx, my, x, y) => {
     } else if (settings.seaCreaturesCountOverlayGui.isOpen()) {
         overlayCoordsData.seaCreaturesCountOverlay.x = x;
         overlayCoordsData.seaCreaturesCountOverlay.y = y;
+    }  else if (settings.legionAndBobbingTimeOverlayGui.isOpen()) {
+        overlayCoordsData.legionAndBobbingTimeOverlay.x = x;
+        overlayCoordsData.legionAndBobbingTimeOverlay.y = y;
     }
     overlayCoordsData.save();
 });
@@ -26,6 +29,10 @@ register("guiKey", (char, keyCode, gui, event) => {
             overlayCoordsData.rareCatchesTrackerOverlay.scale += 0.1;
         } else if (settings.seaCreaturesHpOverlayGui.isOpen()) {
             overlayCoordsData.seaCreaturesHpOverlay.scale += 0.1;
+        } else if (settings.seaCreaturesCountOverlayGui.isOpen()) {
+            overlayCoordsData.seaCreaturesCountOverlay.scale += 0.1;
+        } else if (settings.legionAndBobbingTimeOverlayGui.isOpen()) {
+            overlayCoordsData.legionAndBobbingTimeOverlay.scale += 0.1;
         }
     } else if (keyCode == 12) { // "-" character
         if (settings.totemRemainingTimeOverlayGui.isOpen()) {
@@ -36,6 +43,8 @@ register("guiKey", (char, keyCode, gui, event) => {
             overlayCoordsData.seaCreaturesHpOverlay.scale -= 0.1;
         } else if (settings.seaCreaturesCountOverlayGui.isOpen()) {
             overlayCoordsData.seaCreaturesCountOverlay.scale -= 0.1;
+        } else if (settings.legionAndBobbingTimeOverlayGui.isOpen()) {
+            overlayCoordsData.legionAndBobbingTimeOverlay.scale -= 0.1;
         }
     }
     overlayCoordsData.save();

--- a/settings.js
+++ b/settings.js
@@ -1,9 +1,9 @@
-import { AQUA, GOLD, GRAY, RED, WHITE, BLUE } from "./constants/formatting";
+import { AQUA, GOLD, GRAY, RED, WHITE, BLUE, DARK_GRAY } from "./constants/formatting";
 import { @Vigilant, @ButtonProperty, @SwitchProperty, @SelectorProperty, @SliderProperty } from "../Vigilance/index"
 
 @Vigilant("FeeshNotifier/config", "FeeshNotifier Settings", {
     getCategoryComparator: () => (a, b) => {
-        const categories = ["General", "Chat", "Alerts", "Overlays"];
+        const categories = ["General", "Chat", "Alerts", "Overlays", "Inventory"];
 
         return categories.indexOf(a.name) - categories.indexOf(b.name);
     }
@@ -24,6 +24,7 @@ class Settings {
     rareCatchesTrackerOverlayGui = new Gui();
     seaCreaturesHpOverlayGui = new Gui();
     seaCreaturesCountOverlayGui = new Gui();
+    legionAndBobbingTimeOverlayGui = new Gui();
 
     // ******* GENERAL ******* //
 
@@ -295,6 +296,16 @@ class Settings {
     })
     seaCreaturesCountThreshold_Default = 50;
 
+    // ******* ALERTS - Sea creatures timer ******* //
+
+    @SwitchProperty({
+        name: "Alert when sea creatures are alive for 5+ minutes",
+        description: `Shows a title and plays a sound when the sea creatures nearby are alive for 5+ minutes. ${RED}Disabled if you have no fishing rod in your hotbar!`,
+        category: "Alerts",
+        subcategory: "Sea creatures timer"
+    })
+    alertOnSeaCreaturesTimerThreshold = false;
+
     // ******* ALERTS - Rare Catches ******* //
 
     @SwitchProperty({
@@ -505,7 +516,7 @@ class Settings {
         placeholder: "Reset"
     })
     resetRareCatchesTracker() {
-        ChatLib.command("feeshResetRareCatches", true);
+        ChatLib.command("feeshResetRareCatches noconfirm", true);
     }
 
     // ******* OVERLAYS - Sea creatures HP ******* //
@@ -551,6 +562,38 @@ class Settings {
         showOverlayMoveHelp();
         this.seaCreaturesCountOverlayGui.open();
     };
+
+    // ******* OVERLAYS - Legion & Bobbing Time ******* //
+
+    @SwitchProperty({
+        name: "Legion & Bobbing Time",
+        description: `Shows an overlay with the amount of players within 30 blocks (excluding you), and amount of fishing hooks within 30 blocks (including your own hook). ${RED}Hidden if you have no fishing rod in your hotbar!\n\n${DARK_GRAY}If you have other players' hooks hidden by the mods, this may not work correctly. E.g. it works with NEU hooks hider, but doesn't work with Skytils.`,
+        category: "Overlays",
+        subcategory: "Legion & Bobbing Time"
+    })
+    legionAndBobbingTimeOverlay = false;
+
+    @ButtonProperty({
+        name: "Move Legion & Bobbing Time",
+        description: "Moves the overlay text.",
+        category: "Overlays",
+        subcategory: "Legion & Bobbing Time",
+        placeholder: "Move"
+    })
+    moveLegionAndBobbingTimeOverlay() {
+        showOverlayMoveHelp();
+        this.legionAndBobbingTimeOverlayGui.open();
+    };
+
+    // ******* INVENTORY - Highlight ******* //
+
+    @SwitchProperty({
+        name: "Highlight cheap enchanted books",
+        description: `Use red background for the fishing enchanted books that are worth nothing (e.g. Corruption), when they are in your inventory and storages. ${DARK_GRAY}For people who accidentally throw away Blessing and Prosperity c:`,
+        category: "Inventory",
+        subcategory: "Highlight"
+    })
+    highlightCheapBooks = false;
 }
 
 export default new Settings()


### PR DESCRIPTION
- Legion & Bobbing Time counter overlay (disabled by default)
- Legion counter shows other players within 30 blocks excluding you
- Bobbing Time counter shows fishing hooks within 30 blocks including your own (as it also buffs the stats)
- Added button to reset Rare Catches overlay, it appears when chat / inventory is opened
- Now you need to confirm Rare Catches resetting, to avoid unintentional data loss
- Alert when barn fishing timer shows 5+ minutes (disabled by default)
- Highlight cheap fishing books in inventory and storages (disabled by default) Simplified totem alert message
- Do not count vanquisher in catch tracker when no fishing rod in hotbar