### PR TITLE
Release 1.11.0

### DIFF
--- a/constants/javaTypes.js
+++ b/constants/javaTypes.js
@@ -2,3 +2,4 @@ export const EntityArmorStand = Java.type("net.minecraft.entity.item.EntityArmor
 export const EntityItem = Java.type("net.minecraft.entity.item.EntityItem");
 export const EntityFishHook = Java.type("net.minecraft.entity.projectile.EntityFishHook");
 export const S2FPacketSetSlot = Java.type("net.minecraft.network.play.server.S2FPacketSetSlot");
+export const EntityFireworkRocket = Java.type("net.minecraft.entity.item.EntityFireworkRocket");

--- a/constants/seaCreatures.js
+++ b/constants/seaCreatures.js
@@ -43,7 +43,7 @@ export const ALL_SEA_CREATURES_NAMES = [
     'Flaming Worm',
     'Lava Blaze',
     'Lava Pigman',
-    'Zombie Miner',
+    'Abyssal Miner',
     'Scarecrow',
     'Nightmare',
     'Werewolf',

--- a/constants/triggers.js
+++ b/constants/triggers.js
@@ -1,7 +1,7 @@
 import * as drops from './drops';
 import * as sounds from './sounds';
 import * as seaCreatures from './seaCreatures';
-import { GREEN, GOLD, DARK_PURPLE, LIGHT_PURPLE, BLUE, RED, BOLD, RESET, COMMON, RARE, EPIC, LEGENDARY, MYTHIC, GRAY, AQUA, YELLOW } from './formatting';
+import { GREEN, GOLD, DARK_PURPLE, LIGHT_PURPLE, BLUE, RED, BOLD, RESET, COMMON, RARE, EPIC, LEGENDARY, MYTHIC, GRAY, AQUA, YELLOW, DARK_RED } from './formatting';
 
 // WATER SEA CREATURES
 
@@ -96,6 +96,7 @@ export const KILLED_BY_THUNDER_MESSAGE = `${RESET}${GRAY}You were killed by Thun
 export const KILLED_BY_LORD_JAWBUS_MESSAGE = `${RESET}${GRAY}You were killed by Lord Jawbus${RESET}${GRAY}${RESET}${GRAY}.`; // &r&7You were killed by Lord Jawbus&r&7&r&7.
 
 export const THUNDER_BOTTLE_CHARGED_MESSAGE = `${RESET}${YELLOW}> Your bottle of thunder has fully charged!`;
+export const REINDRAKE_SPAWNED_BY_ANYONE_MESSAGE = `${RESET}${RED}${BOLD}WOAH! ${RESET}${RED}A ${RESET}${DARK_RED}Reindrake ${RESET}${RED}was summoned from the depths!${RESET}`;
 
 export const RARE_CATCH_TRIGGERS = [
     {

--- a/data/overlayCoords.js
+++ b/data/overlayCoords.js
@@ -2,6 +2,7 @@ import PogObject from "PogData";
 
 export const overlayCoordsData = new PogObject("FeeshNotifier", {
     "totemRemainingTimeOverlay": { "x": 10, "y": 30, "scale": 1 },
+    "flareRemainingTimeOverlay": { "x": 10, "y": 30, "scale": 1 },
     "rareCatchesTrackerOverlay": { "x": 10, "y": 50, "scale": 1 },
     "seaCreaturesHpOverlay": { "x": 10, "y": 30, "scale": 1 },
     "seaCreaturesCountOverlay": { "x": 10, "y": 50, "scale": 1 },

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Releases
 
+## v1.11.0
+
+- Added flare timer overlay + alert when it expires soon.
+- Added button to reset barn fishing timer when in chat/inventory.
+- Hide Worm profit tracker overlay when it contains no data.
+- Fixed Abyssal Miner not counting towards sea creatures counter.
+- Added new alert on any reindrake spawned in a lobby (disabled by default).
+- Hide remaining totem time overlay when it shows 00s.
+
 ## v1.10.0
 
 - Worm profit tracker overlay

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -8,13 +8,18 @@
 
 ## Features
 
+Some of the features are disabled by default, please explore the settings to toggle them.
+
 1. Movable GUI overlays for:
-  - Worm profit tracker.
   - Rare sea creatures per session (reset session via the settings or **/feeshResetRareCatches**):
     - ![alt](https://i.imgur.com/cosR7No.png)
   - Count of sea creatures nearby and barn fishing timer:
     - ![alt](https://i.imgur.com/vMFVlNZ.png)
+  - Worm profit tracker:
+    - Calculates total profit per session, and average profit per hour.
+    - You can choose between worm membranes / gemstone chambers display mode.
   - Totem of corruption remaining time.
+  - Warning flare / Alert flare / SOS flare remaining time.
   - HP of nearby Jawbus/Thunder/Reindrake (appears only when you are close to it):
     - ![alt](https://i.imgur.com/w8smpFl.png)
     - ![alt](https://i.imgur.com/FcnSCki.png)
@@ -23,6 +28,17 @@
     - Legion counter shows other players within 30 blocks excluding you.
     - Bobbing Time counter shows fishing hooks within 30 blocks including your own (as it also buffs the stats).
     - ![alt](https://i.imgur.com/z81mOKi.png)
+  - Jerry Workshop tracker overlay (reset session via the settings or /feeshResetJerryWorkshop):
+    - Amount of times you caught a sea creature after the last Yeti / Reindrake.
+    - Average catches between Yeti / Reindrake.
+    - Timestamp when the last Yeti / Reindrake was caught.
+    - Amount of Baby Yeti pets dropped.
+  - Crimson Isle tracker overlay (reset session via the settings or /feeshResetCrimsonIsle):
+    - Amount of times you caught a sea creature after the last Thunder / Lord Jawbus.
+    - Average catches between Thunder / Lord Jawbus.
+    - Timestamp when the last Thunder / Lord Jawbus was caught.
+    - Amount of Radioactive Vials dropped.
+    - Timestamp when the last Radioactive Vials wa dropped.
   - Most of the overlays are shown only when you have a fishing rod in the hotbar.
 2. Alerts:
   - Party ping when catching a rare sea creature (takes into account double hook):
@@ -50,6 +66,10 @@
     - Magma Core
     - Radioactive Vial
     - Carmine Dye
+    - Flame Dye
+    - Aquamarine Dye
+    - Iceberg Dye
+    - Nadeshiko Dye
   ![alt](https://i.imgur.com/hSAWYu9.png)
   - Party ping on death from Thunder/Lord Jawbus (so the party can wait for everyone to come back before killing).
   - Ping when player's totem is about to expire.
@@ -59,4 +79,7 @@
   - Ping when catching a Worm the Fish (Dirt rod).
 3. Inventory features:
   - Highlight cheap fishing books (e.g. Corruption) in inventory and storages, using red background.
+  - Empty Thunder Bottle charging progress rendered in the inventory / storages / AH.
+  - Pet level rendered in the inventory / storages / AH.
+  - Fishing armor / fishing rod attributes rendered in the inventory / storages / AH.
 4. Allows to enable/disable any of those features - **/feesh**

--- a/features/alerts/alertOnReindrake.js
+++ b/features/alerts/alertOnReindrake.js
@@ -1,0 +1,30 @@
+import settings from "../../settings";
+import * as triggers from '../../constants/triggers';
+import * as seaCreatures from '../../constants/seaCreatures';
+import { NOTIFICATION_SOUND_SOURCE, OFF_SOUND_MODE } from "../../constants/sounds";
+import { isInSkyblock } from "../../utils/playerState";
+import { getCatchTitle } from "../../utils/common";
+
+// Alert on any reindrake spawned in a lobby
+
+register("Chat", (event) => playAlertOnReindrake()).setCriteria(triggers.REINDRAKE_SPAWNED_BY_ANYONE_MESSAGE).setContains();
+
+const reindrakeTrigger = triggers.RARE_CATCH_TRIGGERS.find(t => t.seaCreature == seaCreatures.REINDRAKE);
+const title = getCatchTitle(reindrakeTrigger.seaCreature, reindrakeTrigger.rarityColorCode);
+
+function playAlertOnReindrake() {
+	try {
+		if (!settings.alertOnAnyReindrakeCatch || !isInSkyblock()) {
+			return;
+		}
+		
+		Client.showTitle(title, '', 1, 30, 1);
+	
+		if (settings.soundMode !== OFF_SOUND_MODE) {
+			new Sound(NOTIFICATION_SOUND_SOURCE).play();
+		}
+	} catch (e) {
+		console.error(e);
+		console.log(`[FeeshNotifier] Failed to play alert on reindrake.`);
+	}
+}

--- a/features/alerts/alertOnThunderBottleCharged.js
+++ b/features/alerts/alertOnThunderBottleCharged.js
@@ -12,7 +12,7 @@ function playAlertOnThunderBottleCharged() {
 			return;
 		}
 		
-		Client.showTitle(`${AQUA}Thunder bottle is full`, '', 1, 25, 1);
+		Client.showTitle(`${AQUA}Thunder bottle is full`, '', 1, 30, 1);
 	
 		if (settings.soundMode !== OFF_SOUND_MODE) {
             World.playSound('random.orb', 1, 1);

--- a/features/overlays/flareTracker.js
+++ b/features/overlays/flareTracker.js
@@ -1,0 +1,135 @@
+import settings from "../../settings";
+import { RED, RESET, WHITE, YELLOW } from "../../constants/formatting";
+import { EntityFireworkRocket } from "../../constants/javaTypes";
+import { OFF_SOUND_MODE, TIMER_SOUND_SOURCE } from "../../constants/sounds";
+import { overlayCoordsData } from "../../data/overlayCoords";
+import { isInSkyblock } from "../../utils/playerState";
+
+let isFlarePlaced = false;
+let flareName = null;
+let lastFlarePlacedAt = null;
+let flareTimerRemainingSeconds = null;
+let flareX = null;
+let flareZ = null;
+
+const secondsBeforeExpiration = 10;
+const flareDistance = 40;
+
+// We check for interaction with a flare, to minimize triggering on other people flares & other types of firework rockets e.g. Bat Fireworks.
+register("playerInteract", (action, pos, event) => handleFlareInteraction(action));
+register('step', () => trackFlareStatus()).setFps(1);
+register('renderOverlay', () => renderFlareOverlay());
+register("worldUnload", () => {
+    resetFlare();
+});
+register("chat", () => {
+    resetFlare();
+}).setCriteria(`${RESET}${YELLOW}Your flare disappeared because you were too far away!${RESET}`);
+
+function handleFlareInteraction(action) {
+    try {
+        if ((!settings.alertOnFlareExpiresSoon && !settings.flareRemainingTimeOverlay) ||
+            !isInSkyblock ||
+            !action.toString().includes('RIGHT_CLICK') ||
+            new Date() - lastFlarePlacedAt < 500 // sometimes playerInteract event happens multiple times
+        ) {
+            return;
+        }
+
+        const heldItemName = Player.getHeldItem()?.getName();
+        const isFlare = heldItemName?.includes('Flare');
+        if (!isFlare) {
+            return;
+        }
+
+        setTimeout(function() {
+            trackFlareNearby(heldItemName);
+        }, 500); // Give time for a firework rocket to appear after click
+    } catch (e) {
+		console.error(e);
+		console.log(`[FeeshNotifier] Failed to handle flare interaction.`);
+	}
+
+    function trackFlareNearby(heldItemName) {
+        const player = Player.getPlayer();
+        const flareRockets = World
+            .getAllEntitiesOfType(EntityFireworkRocket)
+            .filter(rocket => rocket.distanceTo(player) <= flareDistance);
+    
+        if (flareRockets.length) {
+            var closestFlareRocket = flareRockets.reduce(function(prev, curr) {
+                return prev.distanceTo(player) < curr.distanceTo(player) ? prev : curr;
+            });
+            isFlarePlaced = true;
+            flareTimerRemainingSeconds = 180;
+            flareName = heldItemName;
+            lastFlarePlacedAt = new Date();
+            flareX = closestFlareRocket.getX();
+            flareZ = closestFlareRocket.getZ();
+        }
+    
+        // Future notes: flare itself appears on slightly different coords than the initial rocket
+        // e.g. rocket is at 62.01113596669814 -160.09375 and flare (armor stand) is at 62.125 -160.09375
+    }    
+}
+
+function trackFlareStatus() {
+    try {
+        if ((!settings.alertOnFlareExpiresSoon && !settings.flareRemainingTimeOverlay) || !isInSkyblock) {
+            return;
+        }
+
+        if (isFlarePlaced && flareTimerRemainingSeconds <= 0) {
+            resetFlare();
+        }
+    
+        if (isFlarePlaced) {
+            flareTimerRemainingSeconds -= 1;
+    
+            if (settings.alertOnFlareExpiresSoon && flareTimerRemainingSeconds === secondsBeforeExpiration) {
+                Client.showTitle(`${flareName} ${RED}expires soon`, '', 1, 30, 1);
+    
+                if (settings.soundMode !== OFF_SOUND_MODE)
+                {
+                    new Sound(TIMER_SOUND_SOURCE).play();
+                }
+            }
+        }    
+    } catch (e) {
+		console.error(e);
+		console.log(`[FeeshNotifier] Failed to track flare status.`);
+	}
+}
+
+function resetFlare() {
+    if (!isFlarePlaced) {
+        return;
+    }
+
+    isFlarePlaced = false;
+    flareName = null;
+    lastFlarePlacedAt = null;
+    flareTimerRemainingSeconds = null;
+    flareX = null;
+    flareZ = null;
+}
+
+function renderFlareOverlay() {
+    if (!settings.flareRemainingTimeOverlay ||
+        !isFlarePlaced ||
+        flareTimerRemainingSeconds <= 0 ||
+        !isInSkyblock()
+    ) {
+        return;
+    }
+
+    const timerColor = flareTimerRemainingSeconds <= secondsBeforeExpiration ? RED : WHITE;
+    const minutes = ~~((flareTimerRemainingSeconds % 3600) / 60);
+    const seconds = ~~flareTimerRemainingSeconds % 60;
+    const text = minutes > 0 ? `${minutes.toString().padStart(2, '0')}m ${seconds.toString().padStart(2, '0')}s` : `${seconds.toString().padStart(2, '0')}s`;
+    const overlayText = `${flareName}: ${timerColor}${text}`;
+    const overlay = new Text(`${overlayText}`, overlayCoordsData.flareRemainingTimeOverlay.x, overlayCoordsData.flareRemainingTimeOverlay.y)
+        .setShadow(true)
+        .setScale(overlayCoordsData.flareRemainingTimeOverlay.scale);
+    overlay.draw();
+}

--- a/features/overlays/legionAndBobbingTimeTracker.js
+++ b/features/overlays/legionAndBobbingTimeTracker.js
@@ -4,6 +4,7 @@ import { EntityFishHook } from "../../constants/javaTypes";
 import { overlayCoordsData } from "../../data/overlayCoords";
 import { getWorldName, hasFishingRodInHotbar, isInSkyblock } from "../../utils/playerState";
 import { KUUDRA } from "../../constants/areas";
+import { getPlayerNamesInRange } from "../../utils/common";
 
 let playersCount = 0;
 let fishingHooksCount = 0;
@@ -30,17 +31,7 @@ function trackPlayersAndFishingHooksNearby() {
             !hook.getEntity()?.field_146042_b?.getDisplayNameString()?.includes('Phantom Fisher')) // field_146042_b = angler
         .length;
 
-    const players = World
-        .getAllPlayers()
-        .filter(player =>
-            (player.getUUID().version() === 4 || player.getUUID().version() === 1) && // Players and Watchdog have version 4, nicked players have version 1, this is done to exclude NPCs
-            player.ping === 1 && // -1 is watchdog and ghost players, also there is a ghost player with high ping value when joining a world
-            player.name != Player.getName() && // Exclude current player because they do not count for legion
-            player.distanceTo(Player.getPlayer()) < legionDistance
-        )
-        .map(player => player.name)
-        .filter((x, i, a) => a.indexOf(x) == i); // Distinct, sometimes the players are duplicated in the list
-
+    const players = getPlayerNamesInRange(legionDistance);
     playersCount = players.length;
 }
 

--- a/features/overlays/rareCatchesTracker.js
+++ b/features/overlays/rareCatchesTracker.js
@@ -115,7 +115,7 @@ export function renderRareCatchTrackerOverlay() {
 
     entries.forEach((entry) => {
         const rarityColorCode = RARE_CATCH_TRIGGERS.find(t => t.seaCreature === entry.seaCreature).rarityColorCode;
-        overlayText += ` ${rarityColorCode}${fromUppercaseToCapitalizedFirstLetters(entry.seaCreature)}: ${WHITE}${formatNumberWithSpaces(entry.amount)} ${GRAY}(${entry.percent}%)\n`;
+        overlayText += `${GRAY}- ${rarityColorCode}${fromUppercaseToCapitalizedFirstLetters(entry.seaCreature)}: ${WHITE}${formatNumberWithSpaces(entry.amount)} ${GRAY}(${entry.percent}%)\n`;
     });
 
     overlayText += `${YELLOW}Total: ${WHITE}${persistentData.totalRareCatches}`;

--- a/features/overlays/totemTracker.js
+++ b/features/overlays/totemTracker.js
@@ -2,7 +2,7 @@ import settings from "../../settings";
 import { overlayCoordsData } from "../../data/overlayCoords";
 import { EntityArmorStand } from "../../constants/javaTypes";
 import { TIMER_SOUND_SOURCE, OFF_SOUND_MODE } from "../../constants/sounds";
-import { WHITE, GOLD, RED } from "../../constants/formatting";
+import { WHITE, RED, DARK_PURPLE } from "../../constants/formatting";
 import { isInSkyblock } from "../../utils/playerState";
 
 let remainingTotemTime; // Format examples: 01m 02s, 50s, 09s
@@ -12,6 +12,9 @@ const secondsBeforeExpiration = 10;
 
 register('step', () => trackTotemStatus()).setFps(1);
 register('renderOverlay', () => renderTotemOverlay());
+register("worldUnload", () => {
+    resetTotem();
+});
 
 function trackTotemStatus() {
     if ((!settings.alertOnTotemExpiresSoon && !settings.totemRemainingTimeOverlay) || !isInSkyblock()) {
@@ -24,8 +27,7 @@ function trackTotemStatus() {
         return name.includes('Owner:') && name.includes(currentPlayer);
     });
     if (playerTotemPosition && !hasPlayersTotem) {
-        playerTotemPosition = null;
-        remainingTotemTime = null;
+        resetTotem();
     }
 
 	entities.forEach(entity => {
@@ -41,7 +43,7 @@ function trackTotemStatus() {
                 remainingTotemTime = name.split('Remaining: ').pop();
 
                 if (settings.alertOnTotemExpiresSoon && remainingTotemTime && remainingTotemTime === `${secondsBeforeExpiration}s`) {
-                    Client.showTitle(`&cYour totem expires soon`, '', 1, 45, 1);
+                    Client.showTitle(`${DARK_PURPLE}Totem ${RED}expires soon`, '', 1, 30, 1);
 
                     if (settings.soundMode !== OFF_SOUND_MODE)
                     {
@@ -54,14 +56,19 @@ function trackTotemStatus() {
 }
 
 function renderTotemOverlay() {
-    if (!settings.totemRemainingTimeOverlay || !remainingTotemTime || !isInSkyblock()) {
+    if (!settings.totemRemainingTimeOverlay || !remainingTotemTime || remainingTotemTime === '00s' || !isInSkyblock()) {
         return;
     }
 
     const timerColor = !remainingTotemTime.includes('m') && remainingTotemTime.slice(0, -1) <= secondsBeforeExpiration ? RED : WHITE;
-    const overlayText = `${GOLD}Remaining totem time: ${timerColor}${remainingTotemTime}`;
+    const overlayText = `${DARK_PURPLE}Totem of Corruption: ${timerColor}${remainingTotemTime}`;
     const overlay = new Text(overlayText, overlayCoordsData.totemRemainingTimeOverlay.x, overlayCoordsData.totemRemainingTimeOverlay.y)
         .setShadow(true)
         .setScale(overlayCoordsData.totemRemainingTimeOverlay.scale);
     overlay.draw();
+}
+
+function resetTotem() {
+    playerTotemPosition = null;
+    remainingTotemTime = null;
 }

--- a/features/overlays/wormMembraneProfitTracker.js
+++ b/features/overlays/wormMembraneProfitTracker.js
@@ -242,7 +242,12 @@ function refreshValuesPerHour() {
 }
 
 function renderWormMembraneProfitTrackerOverlay() {
-    if (!settings.wormProfitTrackerOverlay || !isInSkyblock() || !hasFishingRodInHotbar() || getWorldName() !== CRYSTAL_HOLLOWS) {
+    if (!settings.wormProfitTrackerOverlay ||
+        !isInSkyblock() ||
+        !hasFishingRodInHotbar() ||
+        getWorldName() !== CRYSTAL_HOLLOWS ||
+        (!totalWormsCount && !totalMembranesCount)
+    ) {
         resetTrackerDisplay.hide();
         return;
     }

--- a/index.js
+++ b/index.js
@@ -14,11 +14,13 @@ import { getCatchMessage, getColoredPlayerNameFromDisplayName, getColoredPlayerN
 import { trackCatch, renderRareCatchTrackerOverlay } from './features/overlays/rareCatchesTracker';
 import { sendMessageOnPlayerDeath } from "./features/chat/messageOnPlayerDeath";
 import { playAlertOnPlayerDeath } from "./features/alerts/alertOnPlayerDeath";
-import "./features/overlays/totem";
+import "./features/overlays/totemTracker";
+import "./features/overlays/flareTracker";
 import "./features/overlays/seaCreaturesHpTracker";
 import "./features/overlays/seaCreaturesCountAndTimeTracker";
 import "./features/alerts/alertOnNonFishingArmor";
 import "./features/alerts/alertOnWormTheFish";
+import "./features/alerts/alertOnReindrake";
 import "./features/inventory/highlightCheapBooks";
 import "./features/overlays/legionAndBobbingTimeTracker";
 import "./features/overlays/crimsonIsleTracker";

--- a/metadata.json
+++ b/metadata.json
@@ -3,7 +3,7 @@
     "entry": "index.js",
     "author": "MoonTheSadFisher",
     "description": "Hypixel Skyblock fishing utilities for parties.",
-    "version": "1.10.0",
+    "version": "1.11.0",
     "requires": [
         "Vigilance",
         "PogData",

--- a/moveOverlay.js
+++ b/moveOverlay.js
@@ -5,6 +5,9 @@ register("dragged", (mx, my, x, y) => {
     if (settings.totemRemainingTimeOverlayGui.isOpen()) {
         overlayCoordsData.totemRemainingTimeOverlay.x = x;
         overlayCoordsData.totemRemainingTimeOverlay.y = y;
+    } else if (settings.flareRemainingTimeOverlayGui.isOpen()) {
+        overlayCoordsData.flareRemainingTimeOverlay.x = x;
+        overlayCoordsData.flareRemainingTimeOverlay.y = y;
     } else if (settings.rareCatchesTrackerOverlayGui.isOpen()) {
         overlayCoordsData.rareCatchesTrackerOverlay.x = x;
         overlayCoordsData.rareCatchesTrackerOverlay.y = y;
@@ -34,6 +37,8 @@ register("guiKey", (char, keyCode, gui, event) => {
     if (keyCode == 13) { // "+" character
         if (settings.totemRemainingTimeOverlayGui.isOpen()) {
             overlayCoordsData.totemRemainingTimeOverlay.scale += 0.1;
+        } else if (settings.flareRemainingTimeOverlayGui.isOpen()) {
+            overlayCoordsData.flareRemainingTimeOverlay.scale += 0.1;
         } else if (settings.rareCatchesTrackerOverlayGui.isOpen()) {
             overlayCoordsData.rareCatchesTrackerOverlay.scale += 0.1;
         } else if (settings.seaCreaturesHpOverlayGui.isOpen()) {
@@ -52,6 +57,8 @@ register("guiKey", (char, keyCode, gui, event) => {
     } else if (keyCode == 12) { // "-" character
         if (settings.totemRemainingTimeOverlayGui.isOpen()) {
             overlayCoordsData.totemRemainingTimeOverlay.scale -= 0.1;
+        } else if (settings.flareRemainingTimeOverlayGui.isOpen()) {
+            overlayCoordsData.flareRemainingTimeOverlay.scale -= 0.1;
         } else if (settings.rareCatchesTrackerOverlayGui.isOpen()) {
             overlayCoordsData.rareCatchesTrackerOverlay.scale -= 0.1;
         } else if (settings.seaCreaturesHpOverlayGui.isOpen()) {

--- a/settings.js
+++ b/settings.js
@@ -21,6 +21,7 @@ class Settings {
     }
 
     totemRemainingTimeOverlayGui = new Gui();
+    flareRemainingTimeOverlayGui = new Gui();
     rareCatchesTrackerOverlayGui = new Gui();
     seaCreaturesHpOverlayGui = new Gui();
     seaCreaturesCountOverlayGui = new Gui();
@@ -257,6 +258,16 @@ class Settings {
     })
     alertOnTotemExpiresSoon = true;
 
+    // ******* ALERTS - Flare ******* //
+
+    @SwitchProperty({
+        name: "Alert when player's flare expires soon",
+        description: "Shows a title and plays a sound when current player's Warning Flare / Alert Flare / SOS Flare expires in 10 seconds.",
+        category: "Alerts",
+        subcategory: "Flare"
+    })
+    alertOnFlareExpiresSoon = true;
+
     // ******* ALERTS - Party member's death ******* //
 
     @SwitchProperty({
@@ -362,6 +373,14 @@ class Settings {
         subcategory: "Rare Catches"
     })
     alertOnReindrakeCatch = true;
+
+    @SwitchProperty({
+        name: "Alert on any REINDRAKE catch",
+        description: `Alerts you if any reindrake spawned in the lobby, even if it was caught not by you or your party members.`,
+        category: "Alerts",
+        subcategory: "Rare Catches"
+    })
+    alertOnAnyReindrakeCatch = false;
 
     @SwitchProperty({
         name: "Alert on NUTCRACKER catch",
@@ -541,7 +560,7 @@ class Settings {
         category: "Overlays",
         subcategory: "Totem"
     })
-    totemRemainingTimeOverlay = false;
+    totemRemainingTimeOverlay = true;
 
     @ButtonProperty({
         name: "Move remaining totem time",
@@ -553,6 +572,28 @@ class Settings {
     moveTotemRemainingTimeOverlay() {
         showOverlayMoveHelp();
         this.totemRemainingTimeOverlayGui.open();
+    };
+
+    // ******* OVERLAYS - Flare ******* //
+
+    @SwitchProperty({
+        name: "Remaining flare time",
+        description: "Shows an overlay with the remaining time of current player's Warning Flare / Alert Flare / SOS Flare.",
+        category: "Overlays",
+        subcategory: "Flare"
+    })
+    flareRemainingTimeOverlay = true;
+
+    @ButtonProperty({
+        name: "Move remaining flare time",
+        description: "Moves the overlay text.",
+        category: "Overlays",
+        subcategory: "Flare",
+        placeholder: "Move"
+    })
+    moveFlareRemainingTimeOverlay() {
+        showOverlayMoveHelp();
+        this.flareRemainingTimeOverlayGui.open();
     };
 
     // ******* OVERLAYS - Rare catches ******* //

--- a/utils/common.js
+++ b/utils/common.js
@@ -69,6 +69,12 @@ export function getColoredPlayerNameFromPartyChat(playerAndRank) { // &r&9Party 
 	return `${color}${nameWithoutRank}`;
 }
 
+export function getPlayerNameFromPartyChat(playerAndRank) { // &b[MVP&d+&b] DeadlyMetal
+	if (!playerAndRank) return '';
+	const nameWithoutRank = playerAndRank.split('] ').pop().removeFormatting();
+	return nameWithoutRank;
+}
+
 // Messages have the following format:
 // &r&9Party &8> &b[MVP&d+&b] DeadlyMetal&f: &r--> A YETI has spawned <--&r
 // &r&9Компания &8> &b[MVP] PivoTheSadFisher&f: &r--> A Deep Sea Orb has dropped <--&r
@@ -151,6 +157,21 @@ export function formatElapsedTime(elapsedSeconds) {
 
 export function isInChatOrInventoryGui() {
 	return Client.Companion.isInGui() && (Client.currentGui?.getClassName() === 'GuiInventory' || Client.currentGui?.getClassName() === 'GuiChatOF');
+}
+
+export function getPlayerNamesInRange(distance) {
+	const players = World
+		.getAllPlayers()
+		.filter(player =>
+			(player.getUUID().version() === 4 || player.getUUID().version() === 1) && // Players and Watchdog have version 4, nicked players have version 1, this is done to exclude NPCs
+			player.ping === 1 && // -1 is watchdog and ghost players, also there is a ghost player with high ping value when joining a world
+			player.name != Player.getName() && // Exclude current player because they do not count for legion
+			player.distanceTo(Player.getPlayer()) < distance
+		)
+		.map(player => player.name)
+		.filter((x, i, a) => a.indexOf(x) == i); // Distinct, sometimes the players are duplicated in the list
+		
+	return players;
 }
 
 function getArticle(str) {


### PR DESCRIPTION
Features:

- Added Warning Flare / Alert Flare / SOS flare timer overlay + alert when it expires soon.
- Added button to reset barn fishing timer when in chat/inventory.
- Added new alert on any reindrake spawned in a lobby (disabled by default).

Bugfixes:

- Hide Worm profit tracker overlay when it contains no data.
- Fixed Abyssal Miner not counting towards sea creatures counter.
- Hide remaining totem time overlay when it shows 00s.