### PR TITLE
Release 1.16.0

### DIFF
--- a/commands.js
+++ b/commands.js
@@ -5,6 +5,7 @@ import { resetJerryWorkshopTracker } from "./features/overlays/jerryWorkshopTrac
 import { resetWormMembraneProfitTracker } from "./features/overlays/wormMembraneProfitTracker";
 import { resetMagmaCoreProfitTracker } from "./features/overlays/magmaCoreProfitTracker";
 import { resetFishingProfitTracker } from "./features/overlays/fishingProfitTracker";
+import { resetDropNumbers } from "./features/chat/messageOnDrop";
 
 register("command", (...args) => {
     settings.openGUI();
@@ -44,6 +45,9 @@ register("command", (...args) => {
 register("command", (...args) => {
     const isConfirmed = args[0] && args[0] === "noconfirm";
     resetFishingProfitTracker(!!isConfirmed);
+    if (isConfirmed) {
+        resetDropNumbers();
+    }
     return;
 }).setName("feeshResetProfitTracker");
 

--- a/constants/drops.js
+++ b/constants/drops.js
@@ -1,6 +1,8 @@
 export const BABY_YETI_PET = "Baby Yeti";
 export const FLYING_FISH_PET = "Flying Fish";
 export const MEGALODON_PET = "Megalodon";
+export const SQUID_PET = "Squid";
+export const GUARDIAN_PET = "Guardian";
 export const LUCKY_CLOVER_CORE = "Lucky Clover Core";
 export const DEEP_SEA_ORB = "Deep Sea Orb";
 export const RADIOACTIVE_VIAL = "Radioactive Vial";

--- a/constants/triggers.js
+++ b/constants/triggers.js
@@ -1,7 +1,7 @@
 import * as drops from './drops';
 import * as sounds from './sounds';
 import * as seaCreatures from './seaCreatures';
-import { GREEN, GOLD, DARK_PURPLE, LIGHT_PURPLE, BLUE, RED, BOLD, RESET, COMMON, RARE, EPIC, LEGENDARY, MYTHIC, GRAY, AQUA, YELLOW, DARK_RED, DARK_AQUA } from './formatting';
+import { GREEN, GOLD, DARK_PURPLE, LIGHT_PURPLE, BLUE, RED, BOLD, RESET, COMMON, RARE, EPIC, LEGENDARY, MYTHIC, GRAY, AQUA, YELLOW, DARK_RED, DARK_AQUA, WHITE, UNCOMMON } from './formatting';
 
 // WATER SEA CREATURES
 
@@ -95,6 +95,18 @@ export const ICEBERG_DYE_MESSAGE = `${RESET}${LIGHT_PURPLE}${BOLD}OUTSTANDING CA
 export const CARMINE_DYE_MESSAGE = `${RESET}${LIGHT_PURPLE}${BOLD}WOW! ` + '${playerNameAndRank}' + ` ${RESET}${GOLD}found ${RESET}${DARK_RED}Carmine Dye${RESET}`; // &r&d&lWOW! &r&b[MVP&r&c+&r&b] &5MoonTheSadFisher&r&r&f &r&6found &r&4Carmine Dye&r
 export const MIDNIGHT_DYE_MESSAGE = `${RESET}${LIGHT_PURPLE}${BOLD}WOW! ` + '${playerNameAndRank}' + ` ${RESET}${GOLD}found ${RESET}${DARK_PURPLE}Midnight Dye${RESET}`; // &r&d&lWOW! &r&b[MVP&r&c+&r&b] &5MoonTheSadFisher&r&r&f &r&6found &r&5Midnight Dye&r
 
+export const SQUID_PET_LEG_MESSAGE = `${DARK_PURPLE}${BOLD}GREAT CATCH! ${RESET}${AQUA}You found a ${RESET}${GRAY}[Lvl 1] ${RESET}${GOLD}Squid${RESET}${AQUA}.${RESET}`;
+export const SQUID_PET_EPIC_MESSAGE = `${DARK_PURPLE}${BOLD}GREAT CATCH! ${RESET}${AQUA}You found a ${RESET}${GRAY}[Lvl 1] ${RESET}${DARK_PURPLE}Squid${RESET}${AQUA}.${RESET}`;
+export const SQUID_PET_RARE_MESSAGE = `${DARK_PURPLE}${BOLD}GREAT CATCH! ${RESET}${AQUA}You found a ${RESET}${GRAY}[Lvl 1] ${RESET}${BLUE}Squid${RESET}${AQUA}.${RESET}`;
+export const SQUID_PET_UNCOMMON_MESSAGE = `${DARK_PURPLE}${BOLD}GREAT CATCH! ${RESET}${AQUA}You found a ${RESET}${GRAY}[Lvl 1] ${RESET}${GREEN}Squid${RESET}${AQUA}.${RESET}`;
+export const SQUID_PET_COMMON_MESSAGE = `${DARK_PURPLE}${BOLD}GREAT CATCH! ${RESET}${AQUA}You found a ${RESET}${GRAY}[Lvl 1] ${RESET}${WHITE}Squid${RESET}${AQUA}.${RESET}`;
+
+export const GUARDIAN_PET_LEG_MESSAGE = `${DARK_PURPLE}${BOLD}GREAT CATCH! ${RESET}${AQUA}You found a ${RESET}${GRAY}[Lvl 1] ${RESET}${GOLD}Guardian${RESET}${AQUA}.${RESET}`;
+export const GUARDIAN_PET_EPIC_MESSAGE = `${DARK_PURPLE}${BOLD}GREAT CATCH! ${RESET}${AQUA}You found a ${RESET}${GRAY}[Lvl 1] ${RESET}${DARK_PURPLE}Guardian${RESET}${AQUA}.${RESET}`;
+export const GUARDIAN_PET_RARE_MESSAGE = `${DARK_PURPLE}${BOLD}GREAT CATCH! ${RESET}${AQUA}You found a ${RESET}${GRAY}[Lvl 1] ${RESET}${BLUE}Guardian${RESET}${AQUA}.${RESET}`;
+export const GUARDIAN_PET_UNCOMMON_MESSAGE = `${DARK_PURPLE}${BOLD}GREAT CATCH! ${RESET}${AQUA}You found a ${RESET}${GRAY}[Lvl 1] ${RESET}${GREEN}Guardian${RESET}${AQUA}.${RESET}`;
+export const GUARDIAN_PET_COMMON_MESSAGE = `${DARK_PURPLE}${BOLD}GREAT CATCH! ${RESET}${AQUA}You found a ${RESET}${GRAY}[Lvl 1] ${RESET}${WHITE}Guardian${RESET}${AQUA}.${RESET}`;
+
 // OTHER
 
 export const KILLED_BY_THUNDER_MESSAGE = `${RESET}${GRAY}You were killed by Thunder${RESET}${GRAY}${RESET}${GRAY}.`; // &r&7You were killed by Thunder&r&7&r&7.
@@ -183,6 +195,7 @@ export const RARE_CATCH_TRIGGERS = [
         seaCreature: seaCreatures.THUNDER,
         isMessageEnabledSettingKey: 'messageOnThunderCatch',
         isAlertEnabledSettingKey: 'alertOnThunderCatch',
+        isAnnounceToAllChatEnabledSettingKey: 'announceToAllChatOnThunderCatch',
         rarityColorCode: MYTHIC
     },
     {
@@ -190,6 +203,7 @@ export const RARE_CATCH_TRIGGERS = [
         seaCreature: seaCreatures.LORD_JAWBUS,
         isMessageEnabledSettingKey: 'messageOnLordJawbusCatch',
         isAlertEnabledSettingKey: 'alertOnLordJawbusCatch',
+        isAnnounceToAllChatEnabledSettingKey: 'announceToAllChatOnLordJawbusCatch',
         rarityColorCode: MYTHIC
     },
     {
@@ -204,6 +218,7 @@ export const RARE_CATCH_TRIGGERS = [
         seaCreature: seaCreatures.VANQUISHER,
         isMessageEnabledSettingKey: 'messageOnVanquisherCatch',
         isAlertEnabledSettingKey: 'alertOnVanquisherCatch',
+        isAnnounceToAllChatEnabledSettingKey: 'announceToAllChatOnVanquisherCatch',
         rarityColorCode: EPIC
     },
 ];
@@ -211,137 +226,270 @@ export const RARE_CATCH_TRIGGERS = [
 export const RARE_DROP_TRIGGERS = [
     {
         trigger: BABY_YETI_PET_LEG_MESSAGE,
+        itemId: 'BABY_YETI;4',
         itemName: drops.BABY_YETI_PET + ' (Legendary)',
         sound: sounds.SHEESH_SOUND_SOURCE,
         isMessageEnabledSettingKey: 'messageOnBabyYetiPetDrop',
         isAlertEnabledSettingKey: 'alertOnBabyYetiPetDrop',
-        rarityColorCode: LEGENDARY
+        rarityColorCode: LEGENDARY,
+        shouldTrackDropNumber: true,
     },
     {
         trigger: BABY_YETI_PET_EPIC_MESSAGE,
+        itemId: 'BABY_YETI;3',
         itemName: drops.BABY_YETI_PET + ' (Epic)',
         sound: sounds.AUGH_SOUND_SOURCE,
         isMessageEnabledSettingKey: 'messageOnBabyYetiPetDrop',
         isAlertEnabledSettingKey: 'alertOnBabyYetiPetDrop',
-        rarityColorCode: EPIC
+        rarityColorCode: EPIC,
+        shouldTrackDropNumber: true,
     },
     {
         trigger: FLYING_FISH_PET_LEG_MESSAGE,
+        itemId: 'FLYING_FISH;4',
         itemName: drops.FLYING_FISH_PET + ' (Legendary)',
         sound: sounds.WOW_SOUND_SOURCE,
         isMessageEnabledSettingKey: 'messageOnFlyingFishPetDrop',
         isAlertEnabledSettingKey: 'alertOnFlyingFishPetDrop',
-        rarityColorCode: LEGENDARY
+        rarityColorCode: LEGENDARY,
+        shouldTrackDropNumber: true,
     },
     {
         trigger: FLYING_FISH_PET_EPIC_MESSAGE,
+        itemId: 'FLYING_FISH;3',
         itemName: drops.FLYING_FISH_PET + ' (Epic)',
         sound: sounds.AUGH_SOUND_SOURCE,
         isMessageEnabledSettingKey: 'messageOnFlyingFishPetDrop',
         isAlertEnabledSettingKey: 'alertOnFlyingFishPetDrop',
-        rarityColorCode: EPIC
+        rarityColorCode: EPIC,
+        shouldTrackDropNumber: true,
     },
     {
         trigger: FLYING_FISH_PET_RARE_MESSAGE,
+        itemId: 'FLYING_FISH;2',
         itemName: drops.FLYING_FISH_PET + ' (Rare)',
         sound: sounds.GOOFY_LAUGH_SOUND_SOURCE,
         isMessageEnabledSettingKey: 'messageOnFlyingFishPetDrop',
         isAlertEnabledSettingKey: 'alertOnFlyingFishPetDrop',
-        rarityColorCode: RARE
+        rarityColorCode: RARE,
+        shouldTrackDropNumber: true,
     },
     {
         trigger: LUCKY_CLOVER_CORE_MESSAGE,
+        itemId: 'PET_ITEM_LUCKY_CLOVER_DROP',
         itemName: drops.LUCKY_CLOVER_CORE,
         sound: sounds.OH_MY_GOD_SOUND_SOURCE,
         isMessageEnabledSettingKey: 'messageOnLuckyCloverCoreDrop',
         isAlertEnabledSettingKey: 'alertOnLuckyCloverCoreDrop',
-        rarityColorCode: EPIC
+        rarityColorCode: EPIC,
+        shouldTrackDropNumber: true,
     },
     {
         trigger: MEGALODON_PET_LEG_MESSAGE,
+        itemId: 'MEGALODON;4',
         itemName: drops.MEGALODON_PET + ' (Legendary)',
         sound: sounds.WOW_SOUND_SOURCE,
         isMessageEnabledSettingKey: 'messageOnMegalodonPetDrop',
         isAlertEnabledSettingKey: 'alertOnMegalodonPetDrop',
-        rarityColorCode: LEGENDARY
+        rarityColorCode: LEGENDARY,
+        shouldTrackDropNumber: true,
     },
     {
         trigger: MEGALODON_PET_EPIC_MESSAGE,
+        itemId: 'MEGALODON;3',
         itemName: drops.MEGALODON_PET + ' (Epic)',
         sound: sounds.AUGH_SOUND_SOURCE,
         isMessageEnabledSettingKey: 'messageOnMegalodonPetDrop',
         isAlertEnabledSettingKey: 'alertOnMegalodonPetDrop',
-        rarityColorCode: EPIC
+        rarityColorCode: EPIC,
+        shouldTrackDropNumber: true,
     },
     {
         trigger: DEEP_SEA_ORB_MESSAGE,
+        itemId: 'DEEP_SEA_ORB',
         itemName: drops.DEEP_SEA_ORB,
         sound: sounds.OH_MY_GOD_SOUND_SOURCE,
         isMessageEnabledSettingKey: 'messageOnDeepSeaOrbDrop',
         isAlertEnabledSettingKey: 'alertOnDeepSeaOrbDrop',
-        rarityColorCode: EPIC
+        rarityColorCode: EPIC,
+        shouldTrackDropNumber: true,
     },
     {
         trigger: RADIOACTIVE_VIAL_MESSAGE,
+        itemId: 'RADIOACTIVE_VIAL',
         itemName: drops.RADIOACTIVE_VIAL,
         sound: sounds.MC_RARE_ACHIEVEMENT_SOURCE,
         isMessageEnabledSettingKey: 'messageOnRadioactiveVialDrop',
         isAlertEnabledSettingKey: 'alertOnRadioactiveVialDrop',
-        rarityColorCode: MYTHIC
+        rarityColorCode: MYTHIC,
+        shouldTrackDropNumber: false,
     },
     {
         trigger: MAGMA_CORE_MESSAGE,
+        itemId: 'MAGMA_CORE',
         itemName: drops.MAGMA_CORE,
         sound: sounds.OH_MY_GOD_SOUND_SOURCE,
         isMessageEnabledSettingKey: 'messageOnMagmaCoreDrop',
         isAlertEnabledSettingKey: 'alertOnMagmaCoreDrop',
-        rarityColorCode: RARE
+        rarityColorCode: RARE,
+        shouldTrackDropNumber: true,
     },
 ];
 
 export const OUTSTANDING_CATCH_TRIGGERS = [
     {
         trigger: AQUAMARINE_DYE_MESSAGE,
+        itemId: 'DYE_AQUAMARINE',
         itemName: drops.AQUAMARINE_DYE,
         sound: sounds.INSANE_SOUND_SOURCE,
         isMessageEnabledSettingKey: 'messageOnAqumarineDyeDrop',
         isAlertEnabledSettingKey: 'alertOnAqumarineDyeDrop',
-        rarityColorCode: AQUA
+        rarityColorCode: AQUA,
+        shouldTrackDropNumber: false,
     },
     {
         trigger: ICEBERG_DYE_MESSAGE,
+        itemId: 'DYE_ICEBERG',
         itemName: drops.ICEBERG_DYE,
         sound: sounds.INSANE_SOUND_SOURCE,
         isMessageEnabledSettingKey: 'messageOnIcebergDyeDrop',
         isAlertEnabledSettingKey: 'alertOnIcebergDyeDrop',
-        rarityColorCode: DARK_AQUA
+        rarityColorCode: DARK_AQUA,
+        shouldTrackDropNumber: false,
     },
     {
         trigger: MUSIC_RUNE_MESSAGE,
+        itemId: 'MUSIC_RUNE;1',
         itemName: drops.MUSIC_RUNE,
         sound: sounds.MUSIC_RUNE_SOUND_SOURCE,
         isMessageEnabledSettingKey: 'messageOnMusicRuneDrop',
         isAlertEnabledSettingKey: 'alertOnMusicRuneDrop',
-        rarityColorCode: EPIC
+        rarityColorCode: EPIC,
+        shouldTrackDropNumber: true,
+    },
+    {
+        trigger: SQUID_PET_LEG_MESSAGE,
+        itemId: 'SQUID;4',
+        itemName: drops.SQUID_PET + ' (Legendary)',
+        sound: sounds.WOW_SOUND_SOURCE,
+        isMessageEnabledSettingKey: 'messageOnSquidPetDrop',
+        isAlertEnabledSettingKey: 'alertOnSquidPetDrop',
+        rarityColorCode: LEGENDARY,
+        shouldTrackDropNumber: true,
+    },
+    {
+        trigger: SQUID_PET_EPIC_MESSAGE,
+        itemId: 'SQUID;3',
+        itemName: drops.SQUID_PET + ' (Epic)',
+        sound: sounds.AUGH_SOUND_SOURCE,
+        isMessageEnabledSettingKey: 'messageOnSquidPetDrop',
+        isAlertEnabledSettingKey: 'alertOnSquidPetDrop',
+        rarityColorCode: EPIC,
+        shouldTrackDropNumber: true,
+    },
+    {
+        trigger: SQUID_PET_RARE_MESSAGE,
+        itemId: 'SQUID;2',
+        itemName: drops.SQUID_PET + ' (Rare)',
+        sound: sounds.GOOFY_LAUGH_SOUND_SOURCE,
+        isMessageEnabledSettingKey: 'messageOnSquidPetDrop',
+        isAlertEnabledSettingKey: 'alertOnSquidPetDrop',
+        rarityColorCode: RARE,
+        shouldTrackDropNumber: true,
+    },
+    {
+        trigger: SQUID_PET_UNCOMMON_MESSAGE,
+        itemId: 'SQUID;1',
+        itemName: drops.SQUID_PET + ' (Uncommon)',
+        sound: sounds.GOOFY_LAUGH_SOUND_SOURCE,
+        isMessageEnabledSettingKey: 'messageOnSquidPetDrop',
+        isAlertEnabledSettingKey: 'alertOnSquidPetDrop',
+        rarityColorCode: UNCOMMON,
+        shouldTrackDropNumber: true,
+    },
+    {
+        trigger: SQUID_PET_COMMON_MESSAGE,
+        itemId: 'SQUID;0',
+        itemName: drops.SQUID_PET + ' (Common)',
+        sound: sounds.GOOFY_LAUGH_SOUND_SOURCE,
+        isMessageEnabledSettingKey: 'messageOnSquidPetDrop',
+        isAlertEnabledSettingKey: 'alertOnSquidPetDrop',
+        rarityColorCode: COMMON,
+        shouldTrackDropNumber: true,
+    },
+
+    {
+        trigger: GUARDIAN_PET_LEG_MESSAGE,
+        itemId: 'GUARDIAN;4',
+        itemName: drops.GUARDIAN_PET + ' (Legendary)',
+        sound: sounds.WOW_SOUND_SOURCE,
+        isMessageEnabledSettingKey: 'messageOnGuardianPetDrop',
+        isAlertEnabledSettingKey: 'alertOnGuardianPetDrop',
+        rarityColorCode: LEGENDARY,
+        shouldTrackDropNumber: true,
+    },
+    {
+        trigger: GUARDIAN_PET_EPIC_MESSAGE,
+        itemId: 'GUARDIAN;3',
+        itemName: drops.GUARDIAN_PET + ' (Epic)',
+        sound: sounds.AUGH_SOUND_SOURCE,
+        isMessageEnabledSettingKey: 'messageOnGuardianPetDrop',
+        isAlertEnabledSettingKey: 'alertOnGuardianPetDrop',
+        rarityColorCode: EPIC,
+        shouldTrackDropNumber: true,
+    },
+    {
+        trigger: GUARDIAN_PET_RARE_MESSAGE,
+        itemId: 'GUARDIAN;2',
+        itemName: drops.GUARDIAN_PET + ' (Rare)',
+        sound: sounds.GOOFY_LAUGH_SOUND_SOURCE,
+        isMessageEnabledSettingKey: 'messageOnGuardianPetDrop',
+        isAlertEnabledSettingKey: 'alertOnGuardianPetDrop',
+        rarityColorCode: RARE,
+        shouldTrackDropNumber: true,
+    },
+    {
+        trigger: GUARDIAN_PET_UNCOMMON_MESSAGE,
+        itemId: 'GUARDIAN;1',
+        itemName: drops.GUARDIAN_PET + ' (Uncommon)',
+        sound: sounds.GOOFY_LAUGH_SOUND_SOURCE,
+        isMessageEnabledSettingKey: 'messageOnGuardianPetDrop',
+        isAlertEnabledSettingKey: 'alertOnGuardianPetDrop',
+        rarityColorCode: UNCOMMON,
+        shouldTrackDropNumber: true,
+    },
+    {
+        trigger: GUARDIAN_PET_COMMON_MESSAGE,
+        itemId: 'GUARDIAN;0',
+        itemName: drops.GUARDIAN_PET + ' (Common)',
+        sound: sounds.GOOFY_LAUGH_SOUND_SOURCE,
+        isMessageEnabledSettingKey: 'messageOnGuardianPetDrop',
+        isAlertEnabledSettingKey: 'alertOnGuardianPetDrop',
+        rarityColorCode: COMMON,
+        shouldTrackDropNumber: true,
     },
 ];
 
 export const DYE_TRIGGERS = [
     {
         trigger: CARMINE_DYE_MESSAGE,
+        itemId: 'DYE_CARMINE',
         itemName: drops.CARMINE_DYE,
         sound: sounds.INSANE_SOUND_SOURCE,
         isMessageEnabledSettingKey: 'messageOnCarmineDyeDrop',
         isAlertEnabledSettingKey: 'alertOnCarmineDyeDrop',
-        rarityColorCode: DARK_RED
+        rarityColorCode: DARK_RED,
+        shouldTrackDropNumber: false,
     },
     {
         trigger: MIDNIGHT_DYE_MESSAGE,
+        itemId: 'DYE_MIDNIGHT',
         itemName: drops.MIDNIGHT_DYE,
         sound: sounds.INSANE_SOUND_SOURCE,
         isMessageEnabledSettingKey: 'messageOnMidnightDyeDrop',
         isAlertEnabledSettingKey: 'alertOnMidnightDyeDrop',
-        rarityColorCode: DARK_PURPLE
+        rarityColorCode: DARK_PURPLE,
+        shouldTrackDropNumber: false,
     },
 ];
 

--- a/data/data.js
+++ b/data/data.js
@@ -48,5 +48,8 @@ export const persistentData = new PogObject("FeeshNotifier", {
         "profitTrackerItems": {},
         "totalProfit": 0,
         "elapsedSeconds": 0
+    },
+    "rareDropNotifications": {
+        "items": {}
     }
 }, 'config/data.json');

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Releases
 
+## v1.16.0
+
+Released: 2024-08-30
+
+- Added setting to show dropped item's ordinal number for the current session in the party chat message. This requires Fishing Profit Tracker to be enabled. Search for "Include drop number" setting.
+- Added settings to share the location to ALL chat on Thunder / Lord Jawbus / Vanquisher spawn. Search for "Rare Catches - All Chat" settings section. Disabled by default.
+- Added limitations for displayed lines in the fishing profit tracker - now you can hide entries cheaper than the specified threshold, and to limit maximum amount of lines.
+Search for "Hide cheap items" and "Maximum items count" settings to configure.
+- Added Guardian pet and Squid pet drop alerts & party pings.
+- Added setting to show if an item has rarity upgrade (autorecombobulated fishing items). Disabled by default, search for "Rarity upgrade".
+- Applied pet rarity colors when rendering pet level.
+- Fixed items crafted from Supercraft menu being added to the Fishing Profit Tracker.
+- Added Yeti to Sea Creatures HP tracker.
+
 ## v1.15.0
 
 Released: 2024-08-16

--- a/docs/Future requests.md
+++ b/docs/Future requests.md
@@ -1,8 +1,9 @@
-- Share Jawbus location to achat
-- Personal cap alert
-- Best price craft suggestions
+- Trading with other players adds items to the profit trackers
+- Multiple drops that happen at the same time lead to "You're sending messages too fast" error.
+- Personal cap alert (20 for CH, 5 for Crimson)
+- Best price craft suggestions (walnuts, thunder shards, etc)
 - Expertise widget
-- Attach drop number (orbs, vials, magma cores, etc) to the pchat message
+- Attach Vials drop number to the pchat message
 - Golden fish timer
 "can you add a golden fish timer tracker into this? i only have golden fish diamond left and i like playing other games while just having my bobber in lava, and setting a 15min timer every time is p annoying lmao"
 - "i think a feature that says im out of whale bait / fish bait / carrot bait would be cool to add because sometimes im just watching video and i realise im out of bait after like 30 mins."

--- a/features/chat/announceMobSpawnToAllChat.js
+++ b/features/chat/announceMobSpawnToAllChat.js
@@ -1,0 +1,43 @@
+import settings from '../../settings';
+import * as triggers from '../../constants/triggers';
+import * as seaCreatures from '../../constants/seaCreatures';
+import { isDoubleHook } from '../../utils/common';
+import { isInSkyblock } from '../../utils/playerState';
+
+const chatCommand = 'ac';
+
+const mobTriggers = triggers.RARE_CATCH_TRIGGERS.filter(t => t.seaCreature === seaCreatures.THUNDER || t.seaCreature === seaCreatures.LORD_JAWBUS || t.seaCreature === seaCreatures.VANQUISHER);
+
+mobTriggers.forEach(entry => {
+    register(
+        "Chat",
+        (event) => {
+            announceMobSpawnToAllChat(entry.seaCreature, entry.isAnnounceToAllChatEnabledSettingKey);
+        }
+    ).setCriteria(entry.trigger).setContains();
+});
+
+function announceMobSpawnToAllChat(seaCreature, isAnnounceToAllChatEnabledSettingKey) {
+	try {
+		if (!seaCreature || !isAnnounceToAllChatEnabledSettingKey || !settings[isAnnounceToAllChatEnabledSettingKey] || !isInSkyblock()) {
+			return;
+		}
+
+        const isDoubleHooked = isDoubleHook();
+		const message = getMessage(seaCreature, isDoubleHooked);
+		ChatLib.command(chatCommand + ' ' + message);	
+	} catch (e) {
+		console.error(e);
+		console.log(`[FeeshNotifier] Failed to share the location.`);
+	}
+}
+
+function getMessage(seaCreature, isDoubleHooked) {
+    const location = `x: ${Math.round(Player.getX())}, y: ${Math.round(Player.getY())}, z: ${Math.round(Player.getZ())}`;
+    const zone = Scoreboard.getLines().find((line) => line.getName().includes('⏣'));
+    const messageId = ` @${(Math.random() + 1).toString(36).substring(4)}`; // Inspired by VolcAddons - to prevent "You cannot say the same message twice" error
+
+    let message = '';
+    message += `${location} | ${seaCreature} ${isDoubleHooked ? 'x2' : '' }${zone ? ' at ' + zone.getName().removeFormatting() : ''} | ${messageId}`;
+    return message;
+}

--- a/features/chat/messageOnDrop.js
+++ b/features/chat/messageOnDrop.js
@@ -1,21 +1,59 @@
 import settings from '../../settings';
+import { persistentData } from '../../data/data';
 import { getDropMessage } from '../../utils/common';
 import { isInSkyblock } from '../../utils/playerState';
 
 const chatCommand = 'pc';
+
+export function resetDropNumbers() {
+	persistentData.rareDropNotifications.items = {};
+	persistentData.save();
+}
 
 export function sendMessageOnDrop(options) {
 	try {
 		if (!options.isEnabled || !isInSkyblock()) {
 			return;
 		}
-		
-		const message = settings.includeMagicFindIntoDropMessage
-			? getDropMessage(options.itemName, options.magicFind)
-			: getDropMessage(options.itemName);
+
+		const dropNumber = getDropNumber(options);
+		const metadata = [];
+
+		if (settings.includeDropNumberIntoDropMessage && dropNumber) {
+			metadata.push(`#${dropNumber}`);
+		}
+
+		if (settings.includeMagicFindIntoDropMessage && options.magicFind) {
+			metadata.push(`+${options.magicFind}% ✯ Magic Find`);
+		}
+
+		const message = getDropMessage(options.itemName, metadata);
 		ChatLib.command(chatCommand + ' ' + message);
 	} catch (e) {
 		console.error(e);
-		console.log(`[FeeshNotifier] Failed to send the message and play alert on drop.`);
+		console.log(`[FeeshNotifier] Failed to send the message on drop.`);
+	}
+}
+
+function getDropNumber(options) {
+	try {
+		const dropNumber = null;
+
+		if (!settings.includeDropNumberIntoDropMessage || !options.shouldTrackDropNumber || !settings.fishingProfitTrackerOverlay) {
+			return dropNumber;
+		}
+
+		const currentDropNumber = persistentData.rareDropNotifications.items[options.itemId] ? persistentData.rareDropNotifications.items[options.itemId].count : 0;
+		const newDropNumber = currentDropNumber ? currentDropNumber + 1 : 1;
+		persistentData.rareDropNotifications.items[options.itemId] = {
+			count: newDropNumber,
+		};
+		persistentData.save();
+
+		return newDropNumber;
+	} catch (e) {
+		console.error(e);
+		console.log(`[FeeshNotifier] Failed to get & save drop number.`);
+		return null;
 	}
 }

--- a/features/inventory/showArmorAttributes.js
+++ b/features/inventory/showArmorAttributes.js
@@ -1,4 +1,4 @@
-import { AQUA, BOLD, DARK_GREEN, GOLD, GREEN, WHITE } from "../../constants/formatting";
+import { BOLD, GREEN, WHITE } from "../../constants/formatting";
 import settings from "../../settings";
 import { isInSkyblock } from "../../utils/playerState";
 

--- a/features/inventory/showPetLevel.js
+++ b/features/inventory/showPetLevel.js
@@ -1,4 +1,3 @@
-import { GOLD, GREEN } from "../../constants/formatting";
 import settings from "../../settings";
 import { isInSkyblock } from "../../utils/playerState";
 
@@ -15,13 +14,9 @@ function showPetLevel(item, x, y) {
         return;
     }
 
-    const name = item.getName()?.removeFormatting();
+    const displayName = item.getName();
+    const name = displayName?.removeFormatting();
     if (!name || !name.includes('[Lvl')) {
-        return;
-    }
-
-    const loreLines = item.getLore();
-    if (!loreLines) {
         return;
     }
 
@@ -31,7 +26,7 @@ function showPetLevel(item, x, y) {
     }
 
     const level = name.split('[')[1].split(']')[0].slice(4);
-    const color = loreLines.some(line => line.includes('MAX LEVEL')) ? GREEN : GOLD;
+    const color = displayName?.split('] ').pop().slice(0, 2);
     Renderer.translate(x, y, 275); // z coord = 275 to be on top of the item icon and below the tooltip
     Renderer.scale(0.7, 0.7);
     Renderer.drawString(color + level, 0, 16, true);

--- a/features/inventory/showRarityUpgrade.js
+++ b/features/inventory/showRarityUpgrade.js
@@ -1,0 +1,54 @@
+import { GOLD } from "../../constants/formatting";
+import settings from "../../settings";
+import { isInSkyblock } from "../../utils/playerState";
+
+register('renderItemIntoGui', (item, x, y, event) => {
+    showRarityUpgrade(item, x, y);
+});
+
+function showRarityUpgrade(item, x, y) {
+    if (!settings.showRarityUpgrade || !isInSkyblock()) {
+        return;
+    }
+
+    if (!item) {
+        return;
+    }
+
+    const displayName = item.getName();
+    const cleanName = displayName?.removeFormatting();
+    if (!cleanName) {
+        return;
+    }
+
+    const isFishingItem = (
+        cleanName.includes('Ice Rod') ||
+        cleanName.includes('Slug Boots') ||
+        cleanName.includes('Moogma Leggings') ||
+        cleanName.includes('Flaming Chestplate') ||
+        cleanName.includes('Taurus Helmet') ||
+        cleanName.includes('Blade of the Volcano') ||
+        cleanName.includes('Staff of the Volcano') ||
+        cleanName.includes('Fairy\'s') ||
+        cleanName.includes('Squid Boots') ||
+        cleanName.includes('Rabbit Hat') ||
+        cleanName.includes('Water Hydra Head') ||
+        cleanName.includes('Fish Affinity Talisman') ||
+        cleanName.includes('Shredder') ||
+        cleanName.includes('Lucky Hoof') ||
+        cleanName.includes('Phantom Rod') ||
+        cleanName.includes('Yeti Rod')
+    );
+    if (!isFishingItem) {
+        return;
+    }
+
+    const isUpgraded = JSON.stringify(item.getNBT()?.getCompoundTag('tag')?.getCompoundTag('ExtraAttributes')?.getInteger('rarity_upgrades'));
+    if (+isUpgraded !== 1) {
+        return;
+    }
+
+    Renderer.translate(x, y, 275); // z coord = 275 to be on top of the item icon and below the tooltip
+    Renderer.scale(0.7, 0.7);
+    Renderer.drawString(GOLD + 'R', 16, 16, true);
+}

--- a/features/overlays/seaCreaturesHpTracker.js
+++ b/features/overlays/seaCreaturesHpTracker.js
@@ -25,7 +25,7 @@ function trackSeaCreaturesHp() {
         const name = entity?.getName();
         const plainName = entity?.getName()?.removeFormatting();
 
-        if (plainName.includes('[Lv') && (plainName.includes('Lord Jawbus') || plainName.includes('Thunder') || plainName.includes('Reindrake'))) {
+        if (plainName.includes('[Lv') && (plainName.includes('Lord Jawbus') || plainName.includes('Thunder') || plainName.includes('Reindrake') || plainName.includes('Yeti'))) {
             mobs.push(name);
         }
     })	

--- a/features/overlays/wormMembraneProfitTracker.js
+++ b/features/overlays/wormMembraneProfitTracker.js
@@ -3,7 +3,7 @@ import { AQUA, BOLD, DARK_PURPLE, GOLD, GRAY, GREEN, RED, WHITE, YELLOW } from "
 import { getBazaarItemPrices } from "../../utils/bazaarPrices";
 import { formatElapsedTime, formatNumberWithSpaces, getItemsAddedToSacks, isDoubleHook, isInChatOrInventoryGui, isInSacksGui, toShortNumber } from "../../utils/common";
 import * as triggers from '../../constants/triggers';
-import { getWorldName, hasFishingRodInHotbar, isInSkyblock } from "../../utils/playerState";
+import { getLastSacksGuiClosedAt, getWorldName, hasFishingRodInHotbar, isInSkyblock } from "../../utils/playerState";
 import { CRYSTAL_HOLLOWS } from "../../constants/areas";
 import { overlayCoordsData } from "../../data/overlayCoords";
 import { getAuctionItemPrices } from "../../utils/auctionPrices";
@@ -24,7 +24,6 @@ var chamberCoinsPerHour = 0;
 var lastWormCaughtAt = null;
 var lastMembraneDroppedAt = null;
 var isSessionActive = false;
-var lastSacksGuiClosedAt = null;
 
 var previousInventory = [];
 var previousInventoryTotal = 0;
@@ -50,21 +49,6 @@ register('step', () => detectInventoryChanges()).setFps(5);
 register("worldUnload", () => {
     isSessionActive = false;
 });
-
-register("guiClosed", (gui) => {
-    if (!gui) {
-        return;
-    }
-
-    const chestName = gui.field_147002_h?.func_85151_d()?.func_145748_c_()?.text;
-    if (!chestName) {
-        return;
-    }
-
-    if (chestName.includes('Sack')) {
-        lastSacksGuiClosedAt = new Date();
-    }
-}); 
 
 
 // DisplayLine is initialized once in order to avoid multiple method calls on click.
@@ -113,7 +97,6 @@ export function resetWormMembraneProfitTracker(isConfirmed) {
         lastWormCaughtAt = null;
         lastMembraneDroppedAt = null;
         isSessionActive = false;
-        lastSacksGuiClosedAt = null;
 
         previousInventory = [];
         previousInventoryTotal = 0;
@@ -131,7 +114,7 @@ function onAddedToSacks(event) {
             return;
         }
     
-        if (isInSacksGui() || new Date() - lastSacksGuiClosedAt < 10 * 1000) { // Sacks closed < 10 seconds ago
+        if (isInSacksGui() || new Date() - getLastSacksGuiClosedAt() < 15 * 1000) { // Sacks closed < 15 seconds ago
             return;
         }
 

--- a/index.js
+++ b/index.js
@@ -11,6 +11,7 @@ import { playAlertOnCatch } from './features/alerts/alertOnCatch';
 import { playAlertOnDrop } from './features/alerts/alertOnDrop';
 import { getCatchMessage, getColoredPlayerNameFromDisplayName, getColoredPlayerNameFromPartyChat, getDoubleHookCatchMessage, getDropMessagePattern, getPartyChatMessage, getPlayerDeathMessage, isDoubleHook } from './utils/common';
 import { trackCatch, renderRareCatchTrackerOverlay } from './features/overlays/rareCatchesTracker';
+import "./features/chat/announceMobSpawnToAllChat";
 import "./features/chat/messageOnPlayerDeath";
 import "./features/alerts/alertOnPlayerDeath";
 import "./features/overlays/totemTracker";
@@ -28,6 +29,7 @@ import "./features/inventory/showThunderBottleProgress";
 import "./features/inventory/showPetLevel";
 import "./features/inventory/showArmorAttributes";
 import "./features/inventory/showFishingRodAttributes";
+import "./features/inventory/showRarityUpgrade";
 import "./features/alerts/alertOnThunderBottleCharged";
 import "./features/alerts/alertOnSpiritMaskUsed";
 import "./features/overlays/jerryWorkshopTracker";
@@ -113,10 +115,11 @@ triggers.RARE_DROP_TRIGGERS.forEach(entry => {
             });
 
             sendMessageOnDrop({
+                itemId: entry.itemId,
                 itemName: entry.itemName,
                 rarityColorCode: entry.rarityColorCode,
                 magicFind: magicFind,
-                sound: entry.sound,
+                shouldTrackDropNumber: entry.shouldTrackDropNumber,
                 isEnabled: settings[entry.isMessageEnabledSettingKey]
             });
         }
@@ -152,10 +155,11 @@ triggers.OUTSTANDING_CATCH_TRIGGERS.forEach(entry => {
             });
 
             sendMessageOnDrop({
+                itemId: entry.itemId,
                 itemName: entry.itemName,
                 rarityColorCode: entry.rarityColorCode,
                 magicFind: null,
-                sound: entry.sound,
+                shouldTrackDropNumber: entry.shouldTrackDropNumber,
                 isEnabled: settings[entry.isMessageEnabledSettingKey]
             });
         }
@@ -194,10 +198,11 @@ triggers.DYE_TRIGGERS.forEach(entry => {
             });
 
             sendMessageOnDrop({
+                itemId: entry.itemId,
                 itemName: entry.itemName,
                 rarityColorCode: entry.rarityColorCode,
                 magicFind: null,
-                sound: entry.sound,
+                shouldTrackDropNumber: entry.shouldTrackDropNumber,
                 isEnabled: settings[entry.isMessageEnabledSettingKey]
             });
         }

--- a/metadata.json
+++ b/metadata.json
@@ -3,7 +3,7 @@
     "entry": "index.js",
     "author": "MoonTheSadFisher",
     "description": "Hypixel Skyblock fishing utilities for parties.",
-    "version": "1.15.0",
+    "version": "1.16.0",
     "requires": [
         "Vigilance",
         "PogData",

--- a/settings.js
+++ b/settings.js
@@ -15,6 +15,7 @@ class Settings {
         this.setCategoryDescription("General", `${AQUA}FeeshNotifier ${WHITE}v${JSON.parse(FileLib.read("FeeshNotifier", "metadata.json")).version}\nBy ${AQUA}MoonTheSadFisher\nTry /ct load or reach out to m00nlight_sky in Discord if the module doesn't function properly!`);
 
         this.setSubcategoryDescription("Chat", "Rare Catches", `${GRAY}Sends a message to the ${BLUE}party chat ${GRAY}when a rare sea creature has caught. It enables the alerts for your party members.\n\n${DARK_GRAY}For this to work, make sure to enable Skyblock setting which sends sea creatures to the chat: Settings -> Personal -> Fishing Settings -> Sea Creature Chat.`);
+        this.setSubcategoryDescription("Chat", "Rare Catches - All Chat", `${GRAY}Sends your coords to the ${WHITE}all chat ${GRAY}when a rare sea creature has caught. It enables the waypoints for the entire server.\n\n${DARK_GRAY}For this to work, make sure to enable Skyblock setting which sends sea creatures to the chat: Settings -> Personal -> Fishing Settings -> Sea Creature Chat.`);
         this.setSubcategoryDescription("Chat", "Rare Drops", `${GRAY}Sends a message to the ${BLUE}party chat ${GRAY}when a rare item has dropped. It enables the alerts for your party members.`);
         this.setSubcategoryDescription("Alerts", "Rare Catches", `Shows a title and plays a sound when a rare sea creature has caught by you or your party members.\n\n${DARK_GRAY}For this to work, make sure to enable Skyblock setting which sends sea creatures to the chat: Settings -> Personal -> Fishing Settings -> Sea Creature Chat.`);
         this.setSubcategoryDescription("Alerts", "Rare Drops", "Shows a title and plays a sound when a rare item has dropped by you or your party members.");
@@ -154,6 +155,29 @@ class Settings {
     })
     messageOnPlhlegblastCatch = true;
 
+    // ******* CHAT - Rare Catches - All Chat ******* //
+
+    @SwitchProperty({
+        name: "Share the location to ALL chat on THUNDER catch",
+        category: "Chat",
+        subcategory: "Rare Catches - All Chat"
+    })
+    announceToAllChatOnThunderCatch = false;
+
+    @SwitchProperty({
+        name: "Share the location to ALL chat on LORD JAWBUS catch",
+        category: "Chat",
+        subcategory: "Rare Catches - All Chat"
+    })
+    announceToAllChatOnLordJawbusCatch = false;
+
+    @SwitchProperty({
+        name: "Share the location to ALL chat on VANQUISHER spawn",
+        category: "Chat",
+        subcategory: "Rare Catches - All Chat"
+    })
+    announceToAllChatOnVanquisherCatch = false;
+
     // ******* CHAT - Rare Drops ******* //
 
     @SwitchProperty({
@@ -163,6 +187,14 @@ class Settings {
         subcategory: "Rare Drops"
     })
     includeMagicFindIntoDropMessage = true;
+
+    @SwitchProperty({
+        name: "Include drop number",
+        description: `Show dropped item's ordinal number for the current session in the party chat message. Works for the items which drop relatively often per fishing session, so makes sense to track their count.\n${RED}Requires Fishing Profit Tracker to be enabled! ${GRAY}Drop numbers are reset when Fishing Profit Tracker is reset.`,
+        category: "Chat",
+        subcategory: "Rare Drops"
+    })
+    includeDropNumberIntoDropMessage = true;
 
     @SwitchProperty({
         name: "Send a message on BABY YETI PET drop",
@@ -247,6 +279,20 @@ class Settings {
         subcategory: "Rare Drops"
     })
     messageOnMusicRuneDrop = true;
+
+    @SwitchProperty({
+        name: "Send a message on SQUID PET drop",
+        category: "Chat",
+        subcategory: "Rare Drops"
+    })
+    messageOnSquidPetDrop = true;
+
+    @SwitchProperty({
+        name: "Send a message on GUARDIAN PET drop",
+        category: "Chat",
+        subcategory: "Rare Drops"
+    })
+    messageOnGuardianPetDrop = true;
 
     // ******* CHAT - Player's death ******* //
 
@@ -592,6 +638,20 @@ class Settings {
     })
     alertOnMusicRuneDrop = true;
 
+    @SwitchProperty({
+        name: "Alert on SQUID PET drop",
+        category: "Alerts",
+        subcategory: "Rare Drops"
+    })
+    alertOnSquidPetDrop = true;
+
+    @SwitchProperty({
+        name: "Alert on GUARDIAN PET drop",
+        category: "Alerts",
+        subcategory: "Rare Drops"
+    })
+    alertOnGuardianPetDrop = true;
+
     // ******* OVERLAYS - Totem ******* //
 
     @SwitchProperty({
@@ -673,7 +733,7 @@ class Settings {
 
     @SwitchProperty({
         name: "Sea creatures HP",
-        description: `Shows an overlay with the HP of nearby Thunder / Lord Jawbus. ${RED}Hidden if you have no fishing rod in your hotbar!`,
+        description: `Shows an overlay with the HP of nearby Thunder / Lord Jawbus / Reindrake / Yeti. ${RED}Hidden if you have no fishing rod in your hotbar!`,
         category: "Overlays",
         subcategory: "Sea creatures HP"
     })
@@ -813,7 +873,7 @@ Example: /feeshSetRadioactiveVials 5 2024-03-18T14:05:00Z`,
 
     @SwitchProperty({
         name: "Worm profit tracker",
-        description: `Shows an overlay with the worm fishing statistics - total and per hour, when in Crystal Hollows.\nDo ${AQUA}/feeshResetWormProfit${GRAY} to reset.\n${RED}Hidden if you have no fishing rod in your hotbar!`,
+        description: `Shows an overlay with the worm fishing statistics - total and per hour, when in Crystal Hollows. Not persistent - resets on MC restart.\nDo ${AQUA}/feeshResetWormProfit${GRAY} to reset.\n${RED}Hidden if you have no fishing rod in your hotbar!`,
         category: "Overlays",
         subcategory: "Worm profit tracker"
     })
@@ -855,7 +915,7 @@ Example: /feeshSetRadioactiveVials 5 2024-03-18T14:05:00Z`,
 
     @SwitchProperty({
         name: "Magma Core profit tracker",
-        description: `Shows an overlay with the Magma Core fishing statistics - total and per hour, when in Crystal Hollows.\nDo ${AQUA}/feeshResetMagmaCoreProfit${GRAY} to reset.\n${RED}Hidden if you have no fishing rod in your hotbar!`,
+        description: `Shows an overlay with the Magma Core fishing statistics - total and per hour, when in Crystal Hollows. Not persistent - resets on MC restart. \nDo ${AQUA}/feeshResetMagmaCoreProfit${GRAY} to reset.\n${RED}Hidden if you have no fishing rod in your hotbar!`,
         category: "Overlays",
         subcategory: "Magma Core profit tracker"
     })
@@ -930,6 +990,24 @@ ${RED}Hidden if you have no fishing rod in your hotbar!`,
     })
     fishingProfitTrackerMode = 0;
 
+    @TextProperty({
+        name: "Hide cheap items",
+        description: `Items which are cheaper than the specified threshold in coins will be hidden in the fishing profit tracker. They will be grouped under 'Cheap items' section. Set to 0 to show all items.`,
+        category: "Overlays",
+        subcategory: "Fishing profit tracker"
+    })
+    fishingProfitTracker_hideCheaperThan = '20000';
+
+    @SliderProperty({
+        name: "Maximum items count",
+        description: `Show top N lines for the most expensive items. Other cheaper items will be grouped under 'Cheap items' section.`,
+        category: "Overlays",
+        subcategory: "Fishing profit tracker",
+        min: 1,
+        max: 50
+    })
+    fishingProfitTracker_showTop = 20;
+
     @SwitchProperty({
         name: "Show profits in crimson essence",
         description: "Calculate price in crimson essence for crimson fishing items e.g. Slug Boots, Moogma Leggings, Flaming Chestplate, Blade of the Volcano, Staff of the Volcano.",
@@ -952,7 +1030,7 @@ ${RED}Hidden if you have no fishing rod in your hotbar!`,
 
     @SwitchProperty({
         name: "Thunder bottle charge progress",
-        description: `Render empty thunder bottle charge progress (percentage) as a stack size.`,
+        description: `Render empty thunder bottle charge progress (percentage)`,
         category: "Inventory",
         subcategory: "Item tooltip"
     })
@@ -960,11 +1038,19 @@ ${RED}Hidden if you have no fishing rod in your hotbar!`,
 
     @SwitchProperty({
         name: "Pet level",
-        description: `Render pet level as a stack size.`,
+        description: `Render pet rarity and level.`,
         category: "Inventory",
         subcategory: "Item tooltip"
     })
     showPetLevel = false;
+
+    @SwitchProperty({
+        name: "Rarity upgrade",
+        description: `Render rarity upgrade for recombobulated fishing items (autorecombobulator).`,
+        category: "Inventory",
+        subcategory: "Item tooltip"
+    })
+    showRarityUpgrade = false;
 
     // ******* INVENTORY - Armor attributes ******* //
 

--- a/utils/common.js
+++ b/utils/common.js
@@ -47,9 +47,9 @@ export function getDoubleHookCatchTitle(seaCreature, rarityColorCode) {
 	return `${rarityColorCode}${BOLD}${seaCreature} ${RED}${BOLD}X2`;
 }
 
-export function getDropMessage(item, magicFind) {
-	return magicFind
-		? `--> ${getArticle(item)} ${item} has dropped (+${magicFind}% ✯ Magic Find) <--`
+export function getDropMessage(item, metadata) {
+	return metadata && metadata.length
+		? `--> ${getArticle(item)} ${item} has dropped (${metadata.join(', ')}) <--`
 		: `--> ${getArticle(item)} ${item} has dropped <--`;
 }
 
@@ -196,13 +196,13 @@ export function isInChatOrInventoryGui() {
 }
 
 export function isInSacksGui() {
-	if (Client.isInGui() && Client.currentGui?.getClassName() === 'GuiChest') {
-		const chestName = Client.currentGui?.get()?.field_147002_h?.func_85151_d()?.func_145748_c_()?.text;
-		if (chestName && chestName.includes('Sack')) {
-			return true;
-		}
-	}
-	return false;
+	const chestName = getCurrentGuiChestName();
+	return (!!chestName && chestName.endsWith('Sack'));
+}
+
+export function isInSupercraftGui() {
+	const chestName = getCurrentGuiChestName();
+	return (!!chestName && chestName.endsWith('Recipe'));
 }
 
 export function getPlayerNamesInRange(distance) {
@@ -250,7 +250,25 @@ export function getItemsAddedToSacks(eventMessage) {
 	return items;
 }
 
+export function getCleanItemName(itemName) {
+    if (itemName && /.+ §8x[\d]+$/.test(itemName)) { // Booster cookie menu or NPCs append the amount to the item name - e.g. §9Fish Affinity Talisman §8x1
+        const itemNameParts = itemName.split(' ');
+        itemNameParts.pop();
+        itemName = itemNameParts.join(' ');
+    }
+    const cleanItemName = itemName?.removeFormatting()?.replace(/§L/g, ''); // For some reason, §L is not deleted when calling removeFormatting (trophy fish) 
+    return cleanItemName || '';
+}
+
 function getArticle(str) {
     const isFirstLetterVowel = ['a', 'e', 'i', 'o', 'u'].indexOf(str[0].toLowerCase()) !== -1;
 	return isFirstLetterVowel ? 'An' : 'A';
+}
+
+function getCurrentGuiChestName() {
+	if (Client.isInGui() && Client.currentGui?.getClassName() === 'GuiChest') {
+		const chestName = Client.currentGui?.get()?.field_147002_h?.func_85151_d()?.func_145748_c_()?.text;
+		return chestName;
+	}
+	return null;
 }

--- a/utils/playerState.js
+++ b/utils/playerState.js
@@ -4,6 +4,11 @@ var hasDirtRodInHand = false;
 var worldName = null;
 var isInHunterArmor = false;
 
+var lastSacksGuiClosedAt = null;
+var lastSupercraftGuiClosedAt = null;
+var lastOdgerGuiClosedAt = null;
+var lastAuctionGuiClosedAt = null;
+
 register('step', () => trackPlayerState()).setFps(2);
 
 function trackPlayerState() {
@@ -18,6 +23,27 @@ function trackPlayerState() {
 		console.log(`[FeeshNotifier] Failed to track player's state.`);
 	}
 }
+
+register("guiClosed", (gui) => {
+    if (!gui) {
+        return;
+    }
+
+    const chestName = gui.field_147002_h?.func_85151_d()?.func_145748_c_()?.text;
+    if (!chestName) {
+        return;
+    }
+
+    if (chestName.includes('Sack')) {
+        lastSacksGuiClosedAt = new Date();
+    } else if (chestName.includes('Trophy Fishing')) {
+        lastOdgerGuiClosedAt = new Date();
+    } else if (chestName.includes('Manage Auctions') || chestName.includes('Confirm Purchase') || chestName.includes('BIN Auction View') || chestName.includes('Your Bids')) {
+        lastAuctionGuiClosedAt = new Date();
+    } else if (chestName.endsWith('Recipe')) {
+        lastSupercraftGuiClosedAt = new Date();
+    }
+});
 
 export function isInSkyblock() {
 	return isInSkyblock;
@@ -37,6 +63,22 @@ export function hasDirtRodInHand() {
 
 export function isInHunterArmor() {
 	return isInHunterArmor;
+}
+
+export function getLastSacksGuiClosedAt() {
+	return lastSacksGuiClosedAt;
+}
+
+export function getLastOdgerGuiClosedAt() {
+	return lastOdgerGuiClosedAt;
+}
+
+export function getLastAuctionGuiClosedAt() {
+	return lastAuctionGuiClosedAt;
+}
+
+export function getLastSupercraftGuiClosedAt() {
+	return lastSupercraftGuiClosedAt;
 }
 
 function setIsInSkyblock() {


### PR DESCRIPTION
- Added setting to show dropped item's ordinal number for the current session in the party chat message. This requires Fishing Profit Tracker to be enabled. Search for "Include drop number" setting.
- Added limitations for displayed lines in the Fishing Profit Tracker - now you can hide entries cheaper than the specified threshold, and to limit maximum amount of lines. Search for "Hide cheap items" and "Maximum items count" settings to configure.
- Added settings to share the location to ALL chat on Thunder / Lord Jawbus / Vanquisher spawn. Search for "Rare Catches - All Chat" settings section. Disabled by default.
- Added Guardian pet and Squid pet drop alerts & party pings.
- Added setting to show if an item has rarity upgrade (autorecombobulated fishing items). Disabled by default, search for "Rarity upgrade".
- Applied pet rarity colors when rendering pet level.
- Fixed items crafted from Supercraft menu being added to the Fishing Profit Tracker.
- Added Yeti to Sea Creatures HP tracker.