### PR TITLE
Release 1.17.0

### DIFF
--- a/commands.js
+++ b/commands.js
@@ -6,6 +6,8 @@ import { resetWormMembraneProfitTracker } from "./features/overlays/wormMembrane
 import { resetMagmaCoreProfitTracker } from "./features/overlays/magmaCoreProfitTracker";
 import { resetFishingProfitTracker } from "./features/overlays/fishingProfitTracker";
 import { resetDropNumbers } from "./features/chat/messageOnDrop";
+import { calculateFishingPetPrices } from "./features/commands/calculateFishingPetsPrices";
+import { calculateGearCraftPrices } from "./features/commands/calculateGearCraftPrices";
 
 register("command", (...args) => {
     settings.openGUI();
@@ -57,3 +59,13 @@ register("command", (...args) => {
     setRadioactiveVials(+count, lastOn);
     return;
 }).setName("feeshSetRadioactiveVials");
+
+register("command", (...args) => {
+    calculateFishingPetPrices();
+    return;
+}).setName("feeshPetLevelUpPrices");
+
+register("command", (...args) => {
+    calculateGearCraftPrices();
+    return;
+}).setName("feeshGearCraftPrices");

--- a/constants/fishingProfitItems.js
+++ b/constants/fishingProfitItems.js
@@ -967,6 +967,12 @@ export const FISHING_PROFIT_ITEMS = [
         npcPrice: 0,
     },
     {
+        itemId: 'BLAZEN_SPHERE',
+        itemName: 'Blazen Sphere',
+        itemDisplayName: `${RARE}Blazen Sphere`,
+        npcPrice: 0,
+    },
+    {
         itemId: 'ENCHANTMENT_PISCARY_6',
         itemName: 'Enchanted Book (Piscary VI)',
         itemDisplayName: `${RARE}Piscary VI ${WHITE}Book`,

--- a/constants/triggers.js
+++ b/constants/triggers.js
@@ -88,12 +88,12 @@ export const DEEP_SEA_ORB_MESSAGE = `RARE DROP! ${RESET}${DARK_PURPLE}Deep Sea O
 export const RADIOACTIVE_VIAL_MESSAGE = `RARE DROP! ${RESET}${LIGHT_PURPLE}Radioactive Vial ${MAGIC_FIND_MESSAGE_PATTERN}`; // RARE DROP! &r&dRadioactive Vial &r&b(+&r&b236% &r&b✯ Magic Find&r&b)
 export const MAGMA_CORE_MESSAGE = `RARE DROP! ${RESET}${BLUE}Magma Core ${MAGIC_FIND_MESSAGE_PATTERN}`; // RARE DROP! &r&9Magma Core &r&b(+&r&b236% &r&b✯ Magic Find&r&b)
 
-export const MUSIC_RUNE_MESSAGE = `${RESET}${DARK_PURPLE}${BOLD}GREAT CATCH! ${RESET}${AQUA}You found a ${RESET}${AQUA}◆ Music Rune I${RESET}${AQUA}.${RESET}`; // &r&5&lGREAT CATCH! &r&bYou found a &r&b◆ Music Rune I&r&b.&r
-export const AQUAMARINE_DYE_MESSAGE = `${RESET}${LIGHT_PURPLE}${BOLD}OUTSTANDING CATCH! ${RESET}${AQUA}You found a ${RESET}${AQUA}Aquamarine Dye`; // &r&d&lOUTSTANDING CATCH! &r&bYou found a &r&bAquamarine Dye
-export const ICEBERG_DYE_MESSAGE = `${RESET}${LIGHT_PURPLE}${BOLD}OUTSTANDING CATCH! ${RESET}${AQUA}You found a ${RESET}${DARK_AQUA}Iceberg Dye`; // &r&d&lOUTSTANDING CATCH! &r&bYou found a &r&3Iceberg Dye
-
+export const AQUAMARINE_DYE_MESSAGE = `${RESET}${LIGHT_PURPLE}${BOLD}WOW! ` + '${playerNameAndRank}' + ` ${RESET}${GOLD}found ${RESET}${AQUA}Aquamarine Dye${RESET}`; // &r&d&lWOW! &r&b[MVP&r&c+&r&b] &5MoonTheSadFisher&r&r&f &r&6found &r&bAquamarine Dye&r
+export const ICEBERG_DYE_MESSAGE = `${RESET}${LIGHT_PURPLE}${BOLD}WOW! ` + '${playerNameAndRank}' + ` ${RESET}${GOLD}found ${RESET}${DARK_AQUA}Iceberg Dye${RESET}`; // &r&d&lWOW! &r&b[MVP&r&c+&r&b] &5MoonTheSadFisher&r&r&f &r&6found &r&3Iceberg Dye&r
 export const CARMINE_DYE_MESSAGE = `${RESET}${LIGHT_PURPLE}${BOLD}WOW! ` + '${playerNameAndRank}' + ` ${RESET}${GOLD}found ${RESET}${DARK_RED}Carmine Dye${RESET}`; // &r&d&lWOW! &r&b[MVP&r&c+&r&b] &5MoonTheSadFisher&r&r&f &r&6found &r&4Carmine Dye&r
 export const MIDNIGHT_DYE_MESSAGE = `${RESET}${LIGHT_PURPLE}${BOLD}WOW! ` + '${playerNameAndRank}' + ` ${RESET}${GOLD}found ${RESET}${DARK_PURPLE}Midnight Dye${RESET}`; // &r&d&lWOW! &r&b[MVP&r&c+&r&b] &5MoonTheSadFisher&r&r&f &r&6found &r&5Midnight Dye&r
+
+export const MUSIC_RUNE_MESSAGE = `${RESET}${DARK_PURPLE}${BOLD}GREAT CATCH! ${RESET}${AQUA}You found a ${RESET}${AQUA}◆ Music Rune I${RESET}${AQUA}.${RESET}`; // &r&5&lGREAT CATCH! &r&bYou found a &r&b◆ Music Rune I&r&b.&r
 
 export const SQUID_PET_LEG_MESSAGE = `${DARK_PURPLE}${BOLD}GREAT CATCH! ${RESET}${AQUA}You found a ${RESET}${GRAY}[Lvl 1] ${RESET}${GOLD}Squid${RESET}${AQUA}.${RESET}`;
 export const SQUID_PET_EPIC_MESSAGE = `${DARK_PURPLE}${BOLD}GREAT CATCH! ${RESET}${AQUA}You found a ${RESET}${GRAY}[Lvl 1] ${RESET}${DARK_PURPLE}Squid${RESET}${AQUA}.${RESET}`;
@@ -338,26 +338,6 @@ export const RARE_DROP_TRIGGERS = [
 
 export const OUTSTANDING_CATCH_TRIGGERS = [
     {
-        trigger: AQUAMARINE_DYE_MESSAGE,
-        itemId: 'DYE_AQUAMARINE',
-        itemName: drops.AQUAMARINE_DYE,
-        sound: sounds.INSANE_SOUND_SOURCE,
-        isMessageEnabledSettingKey: 'messageOnAqumarineDyeDrop',
-        isAlertEnabledSettingKey: 'alertOnAqumarineDyeDrop',
-        rarityColorCode: AQUA,
-        shouldTrackDropNumber: false,
-    },
-    {
-        trigger: ICEBERG_DYE_MESSAGE,
-        itemId: 'DYE_ICEBERG',
-        itemName: drops.ICEBERG_DYE,
-        sound: sounds.INSANE_SOUND_SOURCE,
-        isMessageEnabledSettingKey: 'messageOnIcebergDyeDrop',
-        isAlertEnabledSettingKey: 'alertOnIcebergDyeDrop',
-        rarityColorCode: DARK_AQUA,
-        shouldTrackDropNumber: false,
-    },
-    {
         trigger: MUSIC_RUNE_MESSAGE,
         itemId: 'MUSIC_RUNE;1',
         itemName: drops.MUSIC_RUNE,
@@ -489,6 +469,26 @@ export const DYE_TRIGGERS = [
         isMessageEnabledSettingKey: 'messageOnMidnightDyeDrop',
         isAlertEnabledSettingKey: 'alertOnMidnightDyeDrop',
         rarityColorCode: DARK_PURPLE,
+        shouldTrackDropNumber: false,
+    },
+    {
+        trigger: AQUAMARINE_DYE_MESSAGE,
+        itemId: 'DYE_AQUAMARINE',
+        itemName: drops.AQUAMARINE_DYE,
+        sound: sounds.INSANE_SOUND_SOURCE,
+        isMessageEnabledSettingKey: 'messageOnAqumarineDyeDrop',
+        isAlertEnabledSettingKey: 'alertOnAqumarineDyeDrop',
+        rarityColorCode: AQUA,
+        shouldTrackDropNumber: false,
+    },
+    {
+        trigger: ICEBERG_DYE_MESSAGE,
+        itemId: 'DYE_ICEBERG',
+        itemName: drops.ICEBERG_DYE,
+        sound: sounds.INSANE_SOUND_SOURCE,
+        isMessageEnabledSettingKey: 'messageOnIcebergDyeDrop',
+        isAlertEnabledSettingKey: 'alertOnIcebergDyeDrop',
+        rarityColorCode: DARK_AQUA,
         shouldTrackDropNumber: false,
     },
 ];

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,12 +1,24 @@
 # Releases
 
+## v1.17.0
+
+Released: 2024-09-17
+
+- Added Blazen Sphere to profit tracker.
+- Added possibility to use mouse scroll to resize the overlays.
+- Added command /feeshGearCraftPrices. It calculates the profits for leveling up the fishing pets from level 1 to level 100, and displays the statistics in the chat.
+You can also run it from the Commands settings section.
+- Added command /feeshPetLevelUpPrices. It calculates the profits for crafting different Magma Lord / Thunder / Nutcracker / Diver armor pieces, and displays the statistics in the chat.
+You can also run it from the Commands settings section.
+- Adjusted triggers to detect Aquamarine Dye and Iceberg Dye drop, because they now drop from the sea creatures and should have the standard dye drop message rather than Outstanding Catch!
+
 ## v1.16.0
 
 Released: 2024-08-30
 
 - Added setting to show dropped item's ordinal number for the current session in the party chat message. This requires Fishing Profit Tracker to be enabled. Search for "Include drop number" setting.
 - Added settings to share the location to ALL chat on Thunder / Lord Jawbus / Vanquisher spawn. Search for "Rare Catches - All Chat" settings section. Disabled by default.
-- Added limitations for displayed lines in the fishing profit tracker - now you can hide entries cheaper than the specified threshold, and to limit maximum amount of lines.
+- Added limitations for displayed lines in the Fishing Profit Tracker - now you can hide entries cheaper than the specified threshold, and to limit maximum amount of lines.
 Search for "Hide cheap items" and "Maximum items count" settings to configure.
 - Added Guardian pet and Squid pet drop alerts & party pings.
 - Added setting to show if an item has rarity upgrade (autorecombobulated fishing items). Disabled by default, search for "Rarity upgrade".

--- a/docs/Future requests.md
+++ b/docs/Future requests.md
@@ -1,9 +1,11 @@
+- Calculate price of Orb of Energy as Pulse RIngs
+- Removal of a line from profit tracker
 - Trading with other players adds items to the profit trackers
 - Multiple drops that happen at the same time lead to "You're sending messages too fast" error.
 - Personal cap alert (20 for CH, 5 for Crimson)
-- Best price craft suggestions (walnuts, thunder shards, etc)
 - Expertise widget
 - Attach Vials drop number to the pchat message
+- Track all mobs caught, not only rare (optional)
 - Golden fish timer
 "can you add a golden fish timer tracker into this? i only have golden fish diamond left and i like playing other games while just having my bobber in lava, and setting a 15min timer every time is p annoying lmao"
 - "i think a feature that says im out of whale bait / fish bait / carrot bait would be cool to add because sometimes im just watching video and i realise im out of bait after like 30 mins."

--- a/features/commands/calculateFishingPetsPrices.js
+++ b/features/commands/calculateFishingPetsPrices.js
@@ -1,0 +1,60 @@
+import { BOLD, COMMON, EPIC, GOLD, GREEN, LEGENDARY, MYTHIC, RARE, RESET, UNCOMMON } from "../../constants/formatting";
+import { getAuctionItemPrices } from "../../utils/auctionPrices";
+import { toShortNumber } from "../../utils/common";
+
+const PETS_TO_CHECK = [
+    `${LEGENDARY}Blue Whale`,
+    `${LEGENDARY}Flying Fish`,
+    `${LEGENDARY}Baby Yeti`,
+    `${LEGENDARY}Penguin`,
+    `${LEGENDARY}Spinosaurus`,
+    `${LEGENDARY}Megalodon`,
+    `${LEGENDARY}Ammonite`,
+    `${LEGENDARY}Squid`,
+    `${LEGENDARY}Dolphin`,
+    `${LEGENDARY}Reindeer`,
+];
+
+export function calculateFishingPetPrices() {
+    try {
+        const prices = PETS_TO_CHECK.map(petDisplayName => {
+            const petName = petDisplayName.removeFormatting();
+            const rarityColorCode = petDisplayName.substring(0, 2);
+            const rarityCode = (function (rarityColorCode) {
+                switch (rarityColorCode) {
+                    case COMMON: return 0;
+                    case UNCOMMON: return 1;
+                    case RARE: return 2;
+                    case EPIC: return 3;
+                    case LEGENDARY: return 4;
+                    case MYTHIC: return 5;
+                    default: return 0;
+                }
+            })(rarityColorCode);
+    
+            const level1ItemId = petName.split(' ').join('_').toUpperCase() + ';' + rarityCode; // FLYING_FISH;4
+            const level1AuctionPrices = getAuctionItemPrices(level1ItemId);
+            const level1Price = level1AuctionPrices?.lbin || 0;
+
+            const level100ItemId = level1ItemId + '+100'; // FLYING_FISH;4+100
+            const level100AuctionPrices = getAuctionItemPrices(level100ItemId);
+            const level100Price = level100AuctionPrices?.lbin || 0;
+
+            return {
+                petDisplayName: petDisplayName,
+                level1Price: level1Price,
+                level100Price: level100Price,
+                diff: level1Price && level100Price ? level100Price - level1Price : 0
+            };       
+        }).sort((a, b) => b.diff - a.diff);
+
+        let message = `${GREEN}${BOLD}Profits for leveling up the fishing pets:\n`;
+        for (let petInfo of prices) {
+            message += `${petInfo.petDisplayName}${RESET}: ${GREEN}+${toShortNumber(petInfo.diff) || 'N/A'}${RESET} (${GOLD}${toShortNumber(petInfo.level1Price) || 'N/A'}${RESET} -> ${GOLD}${toShortNumber(petInfo.level100Price) || 'N/A'}${RESET})\n`;
+        }
+        ChatLib.chat(message);
+    } catch (e) {
+		console.error(e);
+		console.log(`[FeeshNotifier] [ProfitTracker] Failed to calculate pet price statistics.`);
+	}
+}

--- a/features/commands/calculateGearCraftPrices.js
+++ b/features/commands/calculateGearCraftPrices.js
@@ -1,0 +1,148 @@
+import { BOLD, EPIC, GOLD, GREEN, LEGENDARY, RARE, RESET, UNCOMMON } from "../../constants/formatting";
+import { getAuctionItemPrices } from "../../utils/auctionPrices";
+import { toShortNumber } from "../../utils/common";
+
+const CRAFTABLES = [
+    {
+        baseItemId: 'MAGMA_LORD_FRAGMENT',
+        baseItemName: `${LEGENDARY}Magma Lord Fragment`,
+        items: [
+            {
+                itemId: 'MAGMA_LORD_HELMET',
+                itemName: `${LEGENDARY}Magma Lord Helmet`,
+                amountOfItems: 5
+            },
+            {
+                itemId: 'MAGMA_LORD_CHESTPLATE',
+                itemName: `${LEGENDARY}Magma Lord Chestplate`,
+                amountOfItems: 8
+            },
+            {
+                itemId: 'MAGMA_LORD_LEGGINGS',
+                itemName: `${LEGENDARY}Magma Lord Leggings`,
+                amountOfItems: 7
+            },
+            {
+                itemId: 'MAGMA_LORD_BOOTS',
+                itemName: `${LEGENDARY}Magma Lord Boots`,
+                amountOfItems: 4
+            },
+            {
+                itemId: 'MAGMA_LORD_GAUNTLET',
+                itemName: `${EPIC}Magma Lord Gauntlet`,
+                amountOfItems: 6
+            }
+        ]
+    },
+    {
+        baseItemId: 'THUNDER_SHARDS',
+        baseItemName:  `${EPIC}Thunder Shards`,
+        items: [
+            {
+                itemId: 'THUNDER_HELMET',
+                itemName: `${EPIC}Thunder Helmet`,
+                amountOfItems: 5
+            },
+            {
+                itemId: 'THUNDER_CHESTPLATE',
+                itemName: `${EPIC}Thunder Chestplate`,
+                amountOfItems: 8
+            },
+            {
+                itemId: 'THUNDER_LEGGINGS',
+                itemName: `${EPIC}Thunder Leggings`,
+                amountOfItems: 7
+            },
+            {
+                itemId: 'THUNDER_BOOTS',
+                itemName: `${EPIC}Thunder Boots`,
+                amountOfItems: 4
+            },
+            {
+                itemId: 'THUNDERBOLT_NECKLACE',
+                itemName: `${EPIC}Thunderbolt Necklace`,
+                amountOfItems: 5
+            }
+        ]
+    },
+    {
+        baseItemId: 'WALNUT',
+        baseItemName:  `${UNCOMMON}Walnut`,
+        items: [
+            {
+                itemId: 'NUTCRACKER_HELMET',
+                itemName: `${LEGENDARY}Nutcracker Helmet`,
+                amountOfItems: 15
+            },
+            {
+                itemId: 'NUTCRACKER_CHESTPLATE',
+                itemName: `${LEGENDARY}Nutcracker Chestplate`,
+                amountOfItems: 24
+            },
+            {
+                itemId: 'NUTCRACKER_LEGGINGS',
+                itemName: `${LEGENDARY}Nutcracker Leggings`,
+                amountOfItems: 21
+            },
+            {
+                itemId: 'NUTCRACKER_BOOTS',
+                itemName: `${LEGENDARY}Nutcracker Boots`,
+                amountOfItems: 12
+            },
+        ]
+    },
+    {
+        baseItemId: 'DIVER_FRAGMENT',
+        baseItemName:  `${RARE}Emperor's Skull`,
+        items: [
+            {
+                itemId: 'DIVER_HELMET',
+                itemName: `${LEGENDARY}Diver's Mask`,
+                amountOfItems: 5
+            },
+            {
+                itemId: 'DIVER_CHESTPLATE',
+                itemName: `${LEGENDARY}Diver's Shirt`,
+                amountOfItems: 8
+            },
+            {
+                itemId: 'DIVER_LEGGINGS',
+                itemName: `${LEGENDARY}Diver's Trunks`,
+                amountOfItems: 7
+            },
+            {
+                itemId: 'DIVER_BOOTS',
+                itemName: `${LEGENDARY}Diver's Boots`,
+                amountOfItems: 4
+            },
+        ]
+    }
+];
+
+export function calculateGearCraftPrices() {
+    try {
+        let message = `${GREEN}${BOLD}Profits for crafting the gear:\n`;
+        CRAFTABLES.forEach(category => {
+            const craftProfits = category.items.map(item => {
+                const itemAuctionPrices = getAuctionItemPrices(item.itemId);
+                const itemPrice = itemAuctionPrices?.lbin || 0;
+                return {
+                    itemName: item.itemName,
+                    baseItemName: category.baseItemName,
+                    itemPrice: itemPrice,
+                    profitPerBaseItem: itemPrice / item.amountOfItems
+                };
+            }).sort((a, b) => b.profitPerBaseItem - a.profitPerBaseItem);
+            
+            message += `\nGear crafted from ${category.baseItemName}:\n`;
+            for (let craftProfit of craftProfits) {
+                message += ` - ${craftProfit.itemName}${RESET}: ${GOLD}${toShortNumber(craftProfit.itemPrice) || 'N/A'}${RESET} (${GOLD}${toShortNumber(craftProfit.profitPerBaseItem)}${RESET} per item)\n`;
+            }
+        });
+
+        ChatLib.chat(message);
+    } catch (e) {
+		console.error(e);
+		console.log(`[FeeshNotifier] [ProfitTracker] Failed to calculate gear craft price statistics.`);
+	}
+}

--- a/metadata.json
+++ b/metadata.json
@@ -3,7 +3,7 @@
     "entry": "index.js",
     "author": "MoonTheSadFisher",
     "description": "Hypixel Skyblock fishing utilities for parties.",
-    "version": "1.16.0",
+    "version": "1.17.0",
     "requires": [
         "Vigilance",
         "PogData",

--- a/moveOverlay.js
+++ b/moveOverlay.js
@@ -2,6 +2,26 @@ import settings from "./settings";
 import { overlayCoordsData } from "./data/overlayCoords"
 
 register("dragged", (mx, my, x, y) => {
+    moveCurrentGui(x, y);
+});
+
+register("scrolled", (x, y, direction) => {
+    if (direction > 0) {
+        zoomInCurrentGui();
+    } else if (direction < 0) {
+        zoomOutCurrentGui();
+    }
+});
+
+register("guiKey", (char, keyCode, gui, event) => {
+    if (keyCode == 13) { // "+" character
+        zoomInCurrentGui();
+    } else if (keyCode == 12) { // "-" character
+        zoomOutCurrentGui();
+    }
+});
+
+function moveCurrentGui(x, y) {
     if (settings.totemRemainingTimeOverlayGui.isOpen()) {
         overlayCoordsData.totemRemainingTimeOverlay.x = x;
         overlayCoordsData.totemRemainingTimeOverlay.y = y;
@@ -37,57 +57,58 @@ register("dragged", (mx, my, x, y) => {
         overlayCoordsData.fishingProfitTrackerOverlay.y = y;
     }
     overlayCoordsData.save();
-});
+}
 
-register("guiKey", (char, keyCode, gui, event) => {
-    if (keyCode == 13) { // "+" character
-        if (settings.totemRemainingTimeOverlayGui.isOpen()) {
-            overlayCoordsData.totemRemainingTimeOverlay.scale += 0.1;
-        } else if (settings.flareRemainingTimeOverlayGui.isOpen()) {
-            overlayCoordsData.flareRemainingTimeOverlay.scale += 0.1;
-        } else if (settings.rareCatchesTrackerOverlayGui.isOpen()) {
-            overlayCoordsData.rareCatchesTrackerOverlay.scale += 0.1;
-        } else if (settings.seaCreaturesHpOverlayGui.isOpen()) {
-            overlayCoordsData.seaCreaturesHpOverlay.scale += 0.1;
-        } else if (settings.seaCreaturesCountOverlayGui.isOpen()) {
-            overlayCoordsData.seaCreaturesCountOverlay.scale += 0.1;
-        } else if (settings.legionAndBobbingTimeOverlayGui.isOpen()) {
-            overlayCoordsData.legionAndBobbingTimeOverlay.scale += 0.1;
-        } else if (settings.crimsonIsleTrackerOverlayGui.isOpen()) {
-            overlayCoordsData.crimsonIsleTrackerOverlay.scale += 0.1;
-        } else if (settings.jerryWorkshopTrackerOverlayGui.isOpen()) {
-            overlayCoordsData.jerryWorkshopTrackerOverlay.scale += 0.1;
-        } else if (settings.wormProfitTrackerOverlayGui.isOpen()) {
-            overlayCoordsData.wormProfitTrackerOverlay.scale += 0.1;
-        } else if (settings.magmaCoreProfitTrackerOverlayGui.isOpen()) {
-            overlayCoordsData.magmaCoreProfitTrackerOverlay.scale += 0.1;
-        } else if (settings.fishingProfitTrackerOverlayGui.isOpen()) {
-            overlayCoordsData.fishingProfitTrackerOverlay.scale += 0.1;
-        }
-    } else if (keyCode == 12) { // "-" character
-        if (settings.totemRemainingTimeOverlayGui.isOpen()) {
-            overlayCoordsData.totemRemainingTimeOverlay.scale -= 0.1;
-        } else if (settings.flareRemainingTimeOverlayGui.isOpen()) {
-            overlayCoordsData.flareRemainingTimeOverlay.scale -= 0.1;
-        } else if (settings.rareCatchesTrackerOverlayGui.isOpen()) {
-            overlayCoordsData.rareCatchesTrackerOverlay.scale -= 0.1;
-        } else if (settings.seaCreaturesHpOverlayGui.isOpen()) {
-            overlayCoordsData.seaCreaturesHpOverlay.scale -= 0.1;
-        } else if (settings.seaCreaturesCountOverlayGui.isOpen()) {
-            overlayCoordsData.seaCreaturesCountOverlay.scale -= 0.1;
-        } else if (settings.legionAndBobbingTimeOverlayGui.isOpen()) {
-            overlayCoordsData.legionAndBobbingTimeOverlay.scale -= 0.1;
-        } else if (settings.crimsonIsleTrackerOverlayGui.isOpen()) {
-            overlayCoordsData.crimsonIsleTrackerOverlay.scale -= 0.1;
-        } else if (settings.jerryWorkshopTrackerOverlayGui.isOpen()) {
-            overlayCoordsData.jerryWorkshopTrackerOverlay.scale -= 0.1;
-        } else if (settings.wormProfitTrackerOverlayGui.isOpen()) {
-            overlayCoordsData.wormProfitTrackerOverlay.scale -= 0.1;
-        } else if (settings.magmaCoreProfitTrackerOverlayGui.isOpen()) {
-            overlayCoordsData.magmaCoreProfitTrackerOverlay.scale -= 0.1;
-        } else if (settings.fishingProfitTrackerOverlayGui.isOpen()) {
-            overlayCoordsData.fishingProfitTrackerOverlay.scale -= 0.1;
-        }
+function zoomInCurrentGui() {
+    if (settings.totemRemainingTimeOverlayGui.isOpen()) {
+        overlayCoordsData.totemRemainingTimeOverlay.scale += 0.1;
+    } else if (settings.flareRemainingTimeOverlayGui.isOpen()) {
+        overlayCoordsData.flareRemainingTimeOverlay.scale += 0.1;
+    } else if (settings.rareCatchesTrackerOverlayGui.isOpen()) {
+        overlayCoordsData.rareCatchesTrackerOverlay.scale += 0.1;
+    } else if (settings.seaCreaturesHpOverlayGui.isOpen()) {
+        overlayCoordsData.seaCreaturesHpOverlay.scale += 0.1;
+    } else if (settings.seaCreaturesCountOverlayGui.isOpen()) {
+        overlayCoordsData.seaCreaturesCountOverlay.scale += 0.1;
+    } else if (settings.legionAndBobbingTimeOverlayGui.isOpen()) {
+        overlayCoordsData.legionAndBobbingTimeOverlay.scale += 0.1;
+    } else if (settings.crimsonIsleTrackerOverlayGui.isOpen()) {
+        overlayCoordsData.crimsonIsleTrackerOverlay.scale += 0.1;
+    } else if (settings.jerryWorkshopTrackerOverlayGui.isOpen()) {
+        overlayCoordsData.jerryWorkshopTrackerOverlay.scale += 0.1;
+    } else if (settings.wormProfitTrackerOverlayGui.isOpen()) {
+        overlayCoordsData.wormProfitTrackerOverlay.scale += 0.1;
+    } else if (settings.magmaCoreProfitTrackerOverlayGui.isOpen()) {
+        overlayCoordsData.magmaCoreProfitTrackerOverlay.scale += 0.1;
+    } else if (settings.fishingProfitTrackerOverlayGui.isOpen()) {
+        overlayCoordsData.fishingProfitTrackerOverlay.scale += 0.1;
     }
     overlayCoordsData.save();
-});
+}
+
+function zoomOutCurrentGui() {
+    if (settings.totemRemainingTimeOverlayGui.isOpen()) {
+        overlayCoordsData.totemRemainingTimeOverlay.scale -= 0.1;
+    } else if (settings.flareRemainingTimeOverlayGui.isOpen()) {
+        overlayCoordsData.flareRemainingTimeOverlay.scale -= 0.1;
+    } else if (settings.rareCatchesTrackerOverlayGui.isOpen()) {
+        overlayCoordsData.rareCatchesTrackerOverlay.scale -= 0.1;
+    } else if (settings.seaCreaturesHpOverlayGui.isOpen()) {
+        overlayCoordsData.seaCreaturesHpOverlay.scale -= 0.1;
+    } else if (settings.seaCreaturesCountOverlayGui.isOpen()) {
+        overlayCoordsData.seaCreaturesCountOverlay.scale -= 0.1;
+    } else if (settings.legionAndBobbingTimeOverlayGui.isOpen()) {
+        overlayCoordsData.legionAndBobbingTimeOverlay.scale -= 0.1;
+    } else if (settings.crimsonIsleTrackerOverlayGui.isOpen()) {
+        overlayCoordsData.crimsonIsleTrackerOverlay.scale -= 0.1;
+    } else if (settings.jerryWorkshopTrackerOverlayGui.isOpen()) {
+        overlayCoordsData.jerryWorkshopTrackerOverlay.scale -= 0.1;
+    } else if (settings.wormProfitTrackerOverlayGui.isOpen()) {
+        overlayCoordsData.wormProfitTrackerOverlay.scale -= 0.1;
+    } else if (settings.magmaCoreProfitTrackerOverlayGui.isOpen()) {
+        overlayCoordsData.magmaCoreProfitTrackerOverlay.scale -= 0.1;
+    } else if (settings.fishingProfitTrackerOverlayGui.isOpen()) {
+        overlayCoordsData.fishingProfitTrackerOverlay.scale -= 0.1;
+    }
+    overlayCoordsData.save();
+}

--- a/settings.js
+++ b/settings.js
@@ -3,7 +3,7 @@ import { @Vigilant, @ButtonProperty, @SwitchProperty, @SelectorProperty, @Slider
 
 @Vigilant("FeeshNotifier/config", "FeeshNotifier Settings", {
     getCategoryComparator: () => (a, b) => {
-        const categories = ["General", "Chat", "Alerts", "Overlays", "Inventory"];
+        const categories = ["General", "Chat", "Alerts", "Overlays", "Inventory", "Commands"];
 
         return categories.indexOf(a.name) - categories.indexOf(b.name);
     }
@@ -664,7 +664,7 @@ class Settings {
 
     @ButtonProperty({
         name: "Move remaining totem time",
-        description: "Moves the overlay text.",
+        description: "Allows to move and resize the overlay text.",
         category: "Overlays",
         subcategory: "Totem",
         placeholder: "Move"
@@ -686,7 +686,7 @@ class Settings {
 
     @ButtonProperty({
         name: "Move remaining flare time",
-        description: "Moves the overlay text.",
+        description: "Allows to move and resize the overlay text.",
         category: "Overlays",
         subcategory: "Flare",
         placeholder: "Move"
@@ -708,7 +708,7 @@ class Settings {
 
     @ButtonProperty({
         name: "Move rare catches tracker",
-        description: "Moves the overlay text.",
+        description: "Allows to move and resize the overlay text.",
         category: "Overlays",
         subcategory: "Rare catches",
         placeholder: "Move"
@@ -741,7 +741,7 @@ class Settings {
 
     @ButtonProperty({
         name: "Move sea creatures HP",
-        description: "Moves the overlay text.",
+        description: "Allows to move and resize the overlay text.",
         category: "Overlays",
         subcategory: "Sea creatures HP",
         placeholder: "Move"
@@ -763,7 +763,7 @@ class Settings {
 
     @ButtonProperty({
         name: "Move sea creatures count",
-        description: "Moves the overlay text.",
+        description: "Allows to move and resize the overlay text.",
         category: "Overlays",
         subcategory: "Sea creatures count",
         placeholder: "Move"
@@ -785,7 +785,7 @@ class Settings {
 
     @ButtonProperty({
         name: "Move Legion & Bobbing Time",
-        description: "Moves the overlay text.",
+        description: "Allows to move and resize the overlay text.",
         category: "Overlays",
         subcategory: "Legion & Bobbing Time",
         placeholder: "Move"
@@ -807,7 +807,7 @@ class Settings {
 
     @ButtonProperty({
         name: "Move Jerry Workshop tracker",
-        description: "Moves the overlay text.",
+        description: "Allows to move and resize the overlay text.",
         category: "Overlays",
         subcategory: "Jerry Workshop tracker",
         placeholder: "Move"
@@ -848,7 +848,7 @@ Example: /feeshSetRadioactiveVials 5 2024-03-18T14:05:00Z`,
 
     @ButtonProperty({
         name: "Move Crimson Isle tracker",
-        description: "Moves the overlay text.",
+        description: "Allows to move and resize the overlay text.",
         category: "Overlays",
         subcategory: "Crimson Isle tracker",
         placeholder: "Move"
@@ -890,7 +890,7 @@ Example: /feeshSetRadioactiveVials 5 2024-03-18T14:05:00Z`,
 
     @ButtonProperty({
         name: "Move Worm profit tracker",
-        description: "Moves the overlay text.",
+        description: "Allows to move and resize the overlay text.",
         category: "Overlays",
         subcategory: "Worm profit tracker",
         placeholder: "Move"
@@ -923,7 +923,7 @@ Example: /feeshSetRadioactiveVials 5 2024-03-18T14:05:00Z`,
 
     @ButtonProperty({
         name: "Move Magma Core profit tracker",
-        description: "Moves the overlay text.",
+        description: "Allows to move and resize the overlay text.",
         category: "Overlays",
         subcategory: "Magma Core profit tracker",
         placeholder: "Move"
@@ -960,7 +960,7 @@ ${RED}Hidden if you have no fishing rod in your hotbar!`,
 
     @ButtonProperty({
         name: "Move fishing profit tracker",
-        description: "Moves the overlay text.",
+        description: "Allows to move and resize the overlay text.",
         category: "Overlays",
         subcategory: "Fishing profit tracker",
         placeholder: "Move"
@@ -1087,10 +1087,34 @@ ${RED}Hidden if you have no fishing rod in your hotbar!`,
         subcategory: "Fishing rod attributes"
     })
     accentedFishingRodAttributes = 'double_hook,fishing_speed,trophy_hunter';
+
+    // ******* COMMANDS ******* //
+
+    @ButtonProperty({
+        name: "Pets level up prices",
+        description: `Calculates the profits for leveling up the fishing pets from level 1 to level 100, and displays the statistics in the chat. Executes ${AQUA}/feeshPetLevelUpPrices`,
+        category: "Commands",
+        subcategory: "Pet prices",
+        placeholder: "Calculate"
+    })
+    calculateFishingPetsPrices() {
+        ChatLib.command("feeshPetLevelUpPrices", true);
+    }
+
+    @ButtonProperty({
+        name: "Gear craft prices",
+        description: `Calculates the profits for crafting different Magma Lord / Thunder / Nutcracker / Diver armor pieces, and displays the statistics in the chat. Executes ${AQUA}/feeshGearCraftPrices`,
+        category: "Commands",
+        subcategory: "Gear craft prices",
+        placeholder: "Calculate"
+    })
+    calculateGearCraftPrices() {
+        ChatLib.command("feeshGearCraftPrices", true);
+    }
 }
 
 export default new Settings()
 
 function showOverlayMoveHelp() {
-    ChatLib.chat(`${GOLD}[FeeshNotifier] ${WHITE}Make sure the overlay is visible before moving! Then drag the overlay to move it. Press +/- to increase/decrease size. Press ESC when you're done.`);
+    ChatLib.chat(`${GOLD}[FeeshNotifier] ${WHITE}Make sure the overlay is visible before moving! Then drag the overlay to move it. Press +/- or mouse scroll to increase/decrease size. Press ESC when you're done.`);
 }


### PR DESCRIPTION
- Added Blazen Sphere to profit tracker.
- Added possibility to use mouse scroll to resize the overlays.
- Added command /feeshGearCraftPrices. It calculates the profits for leveling up the fishing pets from level 1 to level 100, and displays the statistics in the chat. You can also run it from the Commands settings section.
- Added command /feeshPetLevelUpPrices. It calculates the profits for crafting different Magma Lord / Thunder / Nutcracker / Diver armor pieces, and displays the statistics in the chat. You can also run it from the Commands settings section.
- Adjusted triggers to detect Aquamarine Dye and Iceberg Dye drop, because they now drop from the sea creatures and should have the standard dye drop message rather than Outstanding Catch.