### PR TITLE
Release 1.19.0

### DIFF
--- a/constants/fishingProfitItems.js
+++ b/constants/fishingProfitItems.js
@@ -1234,6 +1234,7 @@ export const FISHING_PROFIT_ITEMS = [
     {
         itemId: 'ENCHANTMENT_PROSPERITY_1',
         itemName: 'Enchanted Book (Prosperity I)',
+        itemAlternateNames: [ 'Enchanted Book (Prosperity 1)' ],
         itemDisplayName: `${RARE}Prosperity I ${WHITE}Book`,
         npcPrice: 0,
     },

--- a/constants/javaTypes.js
+++ b/constants/javaTypes.js
@@ -5,3 +5,4 @@ export const S2FPacketSetSlot = Java.type("net.minecraft.network.play.server.S2F
 export const EntityFireworkRocket = Java.type("net.minecraft.entity.item.EntityFireworkRocket");
 export const GuiInventory = Java.type("net.minecraft.client.gui.inventory.GuiInventory");
 export const GuiChat = Java.type("net.minecraft.client.gui.GuiChat");
+export const EntityJoinWorldEvent = Java.type("net.minecraftforge.event.entity.EntityJoinWorldEvent");

--- a/constants/triggers.js
+++ b/constants/triggers.js
@@ -88,10 +88,10 @@ export const DEEP_SEA_ORB_MESSAGE = `RARE DROP! ${RESET}${DARK_PURPLE}Deep Sea O
 export const RADIOACTIVE_VIAL_MESSAGE = `RARE DROP! ${RESET}${LIGHT_PURPLE}Radioactive Vial ${MAGIC_FIND_MESSAGE_PATTERN}`; // RARE DROP! &r&dRadioactive Vial &r&b(+&r&b236% &r&b✯ Magic Find&r&b)
 export const MAGMA_CORE_MESSAGE = `RARE DROP! ${RESET}${BLUE}Magma Core ${MAGIC_FIND_MESSAGE_PATTERN}`; // RARE DROP! &r&9Magma Core &r&b(+&r&b236% &r&b✯ Magic Find&r&b)
 
-export const AQUAMARINE_DYE_MESSAGE = `${RESET}${LIGHT_PURPLE}${BOLD}WOW! ` + '${playerNameAndRank}' + ` ${RESET}${GOLD}found ${RESET}${AQUA}Aquamarine Dye${RESET}`; // &r&d&lWOW! &r&b[MVP&r&c+&r&b] &5MoonTheSadFisher&r&r&f &r&6found &r&bAquamarine Dye&r
-export const ICEBERG_DYE_MESSAGE = `${RESET}${LIGHT_PURPLE}${BOLD}WOW! ` + '${playerNameAndRank}' + ` ${RESET}${GOLD}found ${RESET}${DARK_AQUA}Iceberg Dye${RESET}`; // &r&d&lWOW! &r&b[MVP&r&c+&r&b] &5MoonTheSadFisher&r&r&f &r&6found &r&3Iceberg Dye&r
-export const CARMINE_DYE_MESSAGE = `${RESET}${LIGHT_PURPLE}${BOLD}WOW! ` + '${playerNameAndRank}' + ` ${RESET}${GOLD}found ${RESET}${DARK_RED}Carmine Dye${RESET}`; // &r&d&lWOW! &r&b[MVP&r&c+&r&b] &5MoonTheSadFisher&r&r&f &r&6found &r&4Carmine Dye&r
-export const MIDNIGHT_DYE_MESSAGE = `${RESET}${LIGHT_PURPLE}${BOLD}WOW! ` + '${playerNameAndRank}' + ` ${RESET}${GOLD}found ${RESET}${DARK_PURPLE}Midnight Dye${RESET}`; // &r&d&lWOW! &r&b[MVP&r&c+&r&b] &5MoonTheSadFisher&r&r&f &r&6found &r&5Midnight Dye&r
+export const AQUAMARINE_DYE_MESSAGE = `${RESET}${LIGHT_PURPLE}${BOLD}WOW! ` + '${playerNameAndRank}' + ` ${RESET}${GOLD}found ${RESET}${AQUA}Aquamarine Dye`; // &r&d&lWOW! &r&b[MVP&r&c+&r&b] &bMoonTheSadFisher&r&r&f &r&6found &r&bAquamarine Dye &r&8#95&r&6!&r
+export const ICEBERG_DYE_MESSAGE = `${RESET}${LIGHT_PURPLE}${BOLD}WOW! ` + '${playerNameAndRank}' + ` ${RESET}${GOLD}found ${RESET}${DARK_AQUA}Iceberg Dye`; // &r&d&lWOW! &r&b[MVP&r&c+&r&b] &bMoonTheSadFisher&r&r&f &r&6found &r&3Iceberg Dye&r
+export const CARMINE_DYE_MESSAGE = `${RESET}${LIGHT_PURPLE}${BOLD}WOW! ` + '${playerNameAndRank}' + ` ${RESET}${GOLD}found ${RESET}${DARK_RED}Carmine Dye`; // &r&d&lWOW! &r&b[MVP&r&c+&r&b] &bMoonTheSadFisher&r&r&f &r&6found &r&4Carmine Dye&r
+export const MIDNIGHT_DYE_MESSAGE = `${RESET}${LIGHT_PURPLE}${BOLD}WOW! ` + '${playerNameAndRank}' + ` ${RESET}${GOLD}found ${RESET}${DARK_PURPLE}Midnight Dye`; // &r&d&lWOW! &r&b[MVP&r&c+&r&b] &bMoonTheSadFisher&r&r&f &r&6found &r&5Midnight Dye&r
 
 export const MUSIC_RUNE_MESSAGE = `${RESET}${DARK_PURPLE}${BOLD}GREAT CATCH! ${RESET}${AQUA}You found a ${RESET}${AQUA}◆ Music Rune I${RESET}${AQUA}.${RESET}`; // &r&5&lGREAT CATCH! &r&bYou found a &r&b◆ Music Rune I&r&b.&r
 
@@ -118,6 +118,7 @@ export const CHUM_BUCKET_AUTO_PICKED_UP_MESSAGE = `${RESET}${YELLOW}Automaticall
 export const SPIRIT_MASK_USED_MESSAGE = `${RESET}${GOLD}Second Wind Activated${RESET}${GREEN}! ${RESET}${GREEN}Your Spirit Mask saved your life!${RESET}`; // &r&6Second Wind Activated&r&a! &r&aYour Spirit Mask saved your life!&r
 export const GOOD_CATCH_COINS_MESSAGE = `${RESET}${GOLD}${BOLD}GOOD CATCH! ${RESET}${AQUA}You found ${RESET}${GOLD}` + "${coins}" + ` Coins${RESET}${AQUA}.${RESET}`;
 export const GREAT_CATCH_COINS_MESSAGE = `${RESET}${DARK_PURPLE}${BOLD}GREAT CATCH! ${RESET}${AQUA}You found ${RESET}${GOLD}` + "${coins}" + ` Coins${RESET}${AQUA}.${RESET}`;
+export const GOLDEN_FISH_MESSAGE = `${RESET}${BLUE}You spot a ${RESET}${GOLD}Golden Fish ${RESET}${BLUE}surface from beneath the lava!${RESET}`; // &r&9You spot a &r&6Golden Fish &r&9surface from beneath the lava!&r
 
 export const RARE_CATCH_TRIGGERS = [
     {

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,5 +1,25 @@
 # Releases
 
+## v1.19.0
+
+Released: 2024-11-08
+
+Features:
+- Highlight matching items with the same attribute tier, when combining the gear / attribute shards in the Attribute Fusion menu [disabled by default].
+- Render attributes and levels for crimson armor and equipment [disabled by default].
+- Added alert on Golden Fish spawn [disabled by default].
+- Sea creatures HP tracker - added Plhlegblast.
+- Sea creatures HP tracker - make a quiet sound on SC detected.
+
+Bugfixes:
+- Fixed Dye drop alert.
+- Fixed Prosperity book not being counted in Fishing profit tracker if it's displayed with numbers (Prosperity 1 instead of Prosperity I).
+- Fixed some pets counted towards Sea creatures count / Sea creatures HP due to the same name as the mob.
+
+Other:
+- Refactored code for Alert on non-fishing armor, highlight cheap books.
+- Code for catch/drop alerts is moved to the separate files, so index.js file looks more clean.
+
 ## v1.18.0
 
 Released: 2024-10-19

--- a/docs/Future requests.md
+++ b/docs/Future requests.md
@@ -1,14 +1,93 @@
-- Allow moving overlays even if they are invisible.
+- Achievements (ScathaPro / SBO as reference)
+- Party chat commands
+  - !feeshsincejawbus
+  - !feeshsincethunder
+  - !feeshsinceyeti
+  - !feeshsincereindrake
+  - !feeshsincevial
+  - !feeshvials
+  - !kdr - kills/deaths rate for thunder/jawbus [requires API key and custom backend]
+  - Commands cooldown so people do not spam
+  - /feeshkdr <player> - to check myself or someone privately without sending to the party chat [requires API key and custom backend]
+- Customized sounds
+  - Sounds folder: config/custom-assets
+  - Ability to open folder from settings
+  - Ability to test sound from settings
+- Allow moving overlays even if they are invisible
+- Sea creatures/hour
 - Trading with other players adds items to the profit trackers
 - Multiple drops that happen at the same time lead to "You're sending messages too fast" error.
 - Personal cap alert (20 for CH, 5 for Crimson)
 - Expertise widget
+- Fishing XP tracker
 - Attach Vials drop number to the pchat message
-- Track all mobs caught, not only rare (optional)
+- Track all mobs caught, not only rare
 - Golden fish timer
 "can you add a golden fish timer tracker into this? i only have golden fish diamond left and i like playing other games while just having my bobber in lava, and setting a 15min timer every time is p annoying lmao"
 - "i think a feature that says im out of whale bait / fish bait / carrot bait would be cool to add because sometimes im just watching video and i realise im out of bait after like 30 mins."
 
-Internal:
-- Refactor index.js
-- Refactor "No fishing armor" Ruki's code
+
+Achievements prototype:
+
+Unlocked: X/Total (%)
+Sort by: rarity, locked/unlocked
+
+- Crimson
+  - [EASY] Catch your first Thunder
+  - [EASY] Catch your first Jawbus
+  - Get your first vial
+  - Lootshare a vial
+  - Get 25 vials (requires tracker to be enabled)
+  - 400+ MF on vial (or 450?)
+  - < 150 MF on vial. A non killed it, I swear!
+  - No vial for 300 Jawbuses (requires tracker to be enabled) (Do I have negative MF?)
+  - Full jawbus bestiary
+  - 10 10 rod
+  - Double hook Jawbus
+  - B2B thunder (requires tracker to be enabled)
+  - B2B2B thunder (requires tracker to be enabled)
+  - B2B Jawbus (requires tracker to be enabled)
+  - [EASY] Smth with deaths  (Wait, what is this white circle?.. <player> was killed by Thunder.)
+  - No jawbus for 1000 catches (check that in magma lord)
+  - No jawbus for 3000 catches (check that in magma lord)
+- Jerry
+  - No yeti for 1000 catches (requires tracker to be enabled)
+  - No reindrake for 3000 catches (requires tracker to be enabled)
+  - Lootshare a baby yeti
+  - B2b yeti (requires tracker to be enabled)
+  - B2B2B yeti (requires tracker to be enabled)
+  - Get a yeti pet with less than 50 MF
+  - Smth with tons of nutcrackers (requires tracker to be enabled)
+  - Fish the entire event (spend ~9 hours)
+- Spooky
+  - 2 orbs in 10 seconds
+- Ink
+  - Squid / night squid leaderboard
+  - Ink sack collection leaderboard?
+- CH
+  - Get N magma cores in 10 seconds
+- Water
+  - Get 2 lucky clover cores in 10 seconds
+  - Full oasis bestiary (It was so much fun... Sigh / Useless grind)
+- Marina
+  - Get 400+ sharks per festival
+- Trophy
+  - Gold hunter
+  - DIamond hunter
+- Treasure
+  - Catch legendary squid / guardian
+  - The same as above, but 2x (blessing)
+- Dye
+  - Obtain aquamarine / iceberg / etc dye
+- Giant rod
+- Dirt fishing - get worm the fish
+- Equip 10 10 magma lord set
+- 1B exp overflow
+- ? exp overflow
+- Top 10 in any fishing leaderboard
+- Top 1 in any fishing leaderboard (mobs, trophy, collection, ...)
+- All fishing bestiaries complete
+- Be in party with me :3
+
+- Do not count on Alpha
+- 1s timeout after the main event

--- a/features/alerts/alertOnCatch.js
+++ b/features/alerts/alertOnCatch.js
@@ -1,10 +1,63 @@
 import settings from "../../settings";
-import { getDoubleHookCatchTitle, getCatchTitle } from '../../utils/common';
+import * as triggers from '../../constants/triggers';
+import { sendMessageOnCatch } from '../chat/messageOnCatch';
+import { getDoubleHookCatchTitle, getCatchTitle, getCatchMessage, getColoredPlayerNameFromDisplayName, getColoredPlayerNameFromPartyChat, getDoubleHookCatchMessage, getPartyChatMessage, isDoubleHook } from '../../utils/common';
 import { NOTIFICATION_SOUND_SOURCE, OFF_SOUND_MODE } from '../../constants/sounds';
 import { isInSkyblock } from "../../utils/playerState";
 
+triggers.RARE_CATCH_TRIGGERS.forEach(entry => {
+    // Triggers on original "all chat" catch message sent by Hypixel.
+    register(
+        "Chat",
+        (event) => {
+            const isDoubleHooked = isDoubleHook();
+            playAlertOnCatch({ // Play alert immediately before sending to the party (in case when you're fishing solo)
+                seaCreature: entry.seaCreature,
+                rarityColorCode: entry.rarityColorCode,
+                isEnabled: settings[entry.isAlertEnabledSettingKey],
+                isDoubleHook: isDoubleHooked,
+                player: getColoredPlayerNameFromDisplayName(),
+                suppressIfSamePlayer: false
+            });
+
+            sendMessageOnCatch({
+                seaCreature: entry.seaCreature,
+                rarityColorCode: entry.rarityColorCode,
+                isDoubleHook: isDoubleHooked,
+                isEnabled: settings[entry.isMessageEnabledSettingKey]
+            });
+        }
+    ).setCriteria(entry.trigger).setContains();
+
+    // Triggers on automated party chat message sent by the module (no double hook).
+    register(
+        "Chat",
+        (rankAndPlayer, event) => playAlertOnCatch({
+            seaCreature: entry.seaCreature,
+            rarityColorCode: entry.rarityColorCode,
+            isEnabled: settings[entry.isAlertEnabledSettingKey],
+            isDoubleHook: false,
+            player: getColoredPlayerNameFromPartyChat(rankAndPlayer),
+            suppressIfSamePlayer: true
+        })
+    ).setCriteria(getPartyChatMessage(getCatchMessage(entry.seaCreature)));
+
+    // Triggers on automated party chat message sent by the module (double hook).
+    register(
+        "Chat",
+        (rankAndPlayer, event) => playAlertOnCatch({
+            seaCreature: entry.seaCreature,
+            rarityColorCode: entry.rarityColorCode,
+            isEnabled: settings[entry.isAlertEnabledSettingKey],
+            isDoubleHook: true,
+            player: getColoredPlayerNameFromPartyChat(rankAndPlayer),
+            suppressIfSamePlayer: true
+        })
+    ).setCriteria(getPartyChatMessage(getDoubleHookCatchMessage(entry.seaCreature)));
+});
+
 // Shows a title and plays a sound on automated rare catch message sent by this module.
-export function playAlertOnCatch(options) {
+function playAlertOnCatch(options) {
 	try {
 		if (!options.isEnabled || !isInSkyblock()) {
 			return;

--- a/features/alerts/alertOnChumBucketAutopickup.js
+++ b/features/alerts/alertOnChumBucketAutopickup.js
@@ -31,6 +31,6 @@ export function playAlertOnBucketAutoPickup() {
         }
 	} catch (e) {
 		console.error(e);
-		console.log(`[FeeshNotifier] Failed to play alert onChum bucket auto pickup.`);
+		console.log(`[FeeshNotifier] Failed to play alert on Chum bucket auto pickup.`);
 	}
 }

--- a/features/alerts/alertOnDrop.js
+++ b/features/alerts/alertOnDrop.js
@@ -1,10 +1,134 @@
 import settings from "../../settings";
-import { getDropTitle } from '../../utils/common';
+import * as triggers from '../../constants/triggers';
+import { getDropTitle, getColoredPlayerNameFromDisplayName, getColoredPlayerNameFromPartyChat, getDropMessagePattern, getPartyChatMessage } from '../../utils/common';
+import { sendMessageOnDrop } from '../chat/messageOnDrop';
 import { MEME_SOUND_MODE, NORMAL_SOUND_MODE, NOTIFICATION_SOUND_SOURCE } from "../../constants/sounds";
 import { isInSkyblock } from "../../utils/playerState";
 
+triggers.RARE_DROP_TRIGGERS.forEach(entry => {
+    // Triggers on original "all chat" drop message sent by Hypixel.
+    register(
+        "Chat",
+        (magicFind, event) => {
+            playAlertOnDrop({
+                itemName: entry.itemName,
+                rarityColorCode: entry.rarityColorCode,
+                sound: entry.sound,
+                isEnabled: settings[entry.isAlertEnabledSettingKey],
+                player: getColoredPlayerNameFromDisplayName(),
+                suppressIfSamePlayer: false
+            });
+
+            sendMessageOnDrop({
+                itemId: entry.itemId,
+                itemName: entry.itemName,
+                rarityColorCode: entry.rarityColorCode,
+                magicFind: magicFind,
+                shouldTrackDropNumber: entry.shouldTrackDropNumber,
+                isEnabled: settings[entry.isMessageEnabledSettingKey]
+            });
+        }
+    ).setCriteria(entry.trigger).setContains();
+
+    // Triggers on automated party chat message sent by the module.
+    register(
+        "Chat",
+        (rankAndPlayer, event) => playAlertOnDrop({
+            itemName: entry.itemName,
+            rarityColorCode: entry.rarityColorCode,
+            sound: entry.sound,
+            isEnabled: settings[entry.isAlertEnabledSettingKey],
+            player: getColoredPlayerNameFromPartyChat(rankAndPlayer),
+            suppressIfSamePlayer: true
+        })
+    ).setCriteria(getPartyChatMessage(getDropMessagePattern(entry.itemName)));
+});
+
+// Great/Outstanding catch messages do not have magic find in the message
+triggers.OUTSTANDING_CATCH_TRIGGERS.forEach(entry => {
+    // Triggers on original "all chat" drop message sent by Hypixel.
+    register(
+        "Chat",
+        (event) => {
+            playAlertOnDrop({
+                itemName: entry.itemName,
+                rarityColorCode: entry.rarityColorCode,
+                sound: entry.sound,
+                isEnabled: settings[entry.isAlertEnabledSettingKey],
+                player: getColoredPlayerNameFromDisplayName(),
+                suppressIfSamePlayer: false
+            });
+
+            sendMessageOnDrop({
+                itemId: entry.itemId,
+                itemName: entry.itemName,
+                rarityColorCode: entry.rarityColorCode,
+                magicFind: null,
+                shouldTrackDropNumber: entry.shouldTrackDropNumber,
+                isEnabled: settings[entry.isMessageEnabledSettingKey]
+            });
+        }
+    ).setCriteria(entry.trigger).setContains();
+
+    // Triggers on automated party chat message sent by the module.
+    register(
+        "Chat",
+        (rankAndPlayer, event) => playAlertOnDrop({
+            itemName: entry.itemName,
+            rarityColorCode: entry.rarityColorCode,
+            sound: entry.sound,
+            isEnabled: settings[entry.isAlertEnabledSettingKey],
+            player: getColoredPlayerNameFromPartyChat(rankAndPlayer),
+            suppressIfSamePlayer: true
+        })
+    ).setCriteria(getPartyChatMessage(getDropMessagePattern(entry.itemName)));
+});
+
+triggers.DYE_TRIGGERS.forEach(entry => {
+    // Triggers on original "all chat" drop message sent by Hypixel.
+    register(
+        "Chat",
+        (playerNameAndRank, event) => {
+            if (!playerNameAndRank || !playerNameAndRank.removeFormatting().includes(Player.getName())) {
+                return;
+            }
+
+            playAlertOnDrop({
+                itemName: entry.itemName,
+                rarityColorCode: entry.rarityColorCode,
+                sound: entry.sound,
+                isEnabled: settings[entry.isAlertEnabledSettingKey],
+                player: getColoredPlayerNameFromDisplayName(),
+                suppressIfSamePlayer: false
+            });
+
+            sendMessageOnDrop({
+                itemId: entry.itemId,
+                itemName: entry.itemName,
+                rarityColorCode: entry.rarityColorCode,
+                magicFind: null,
+                shouldTrackDropNumber: entry.shouldTrackDropNumber,
+                isEnabled: settings[entry.isMessageEnabledSettingKey]
+            });
+        }
+    ).setCriteria(entry.trigger).setContains();
+
+    // Triggers on automated party chat message sent by the module.
+    register(
+        "Chat",
+        (rankAndPlayer, event) => playAlertOnDrop({
+            itemName: entry.itemName,
+            rarityColorCode: entry.rarityColorCode,
+            sound: entry.sound,
+            isEnabled: settings[entry.isAlertEnabledSettingKey],
+            player: getColoredPlayerNameFromPartyChat(rankAndPlayer),
+            suppressIfSamePlayer: true
+        })
+    ).setCriteria(getPartyChatMessage(getDropMessagePattern(entry.itemName)));
+});
+
 // Shows a title and plays a sound on automated rare drop message sent by this module.
-export function playAlertOnDrop(options) {
+function playAlertOnDrop(options) {
 	try {
 		if (!options.isEnabled || !isInSkyblock()) {
 			return;

--- a/features/alerts/alertOnGoldenFish.js
+++ b/features/alerts/alertOnGoldenFish.js
@@ -1,0 +1,24 @@
+import settings from "../../settings";
+import * as triggers from '../../constants/triggers';
+import { OFF_SOUND_MODE } from "../../constants/sounds";
+import { GOLD, WHITE } from "../../constants/formatting";
+import { isInSkyblock } from "../../utils/playerState";
+
+register("Chat", (event) => playAlertOnGoldenFish()).setCriteria(triggers.GOLDEN_FISH_MESSAGE);
+
+function playAlertOnGoldenFish() {
+	try {
+		if (!settings.alertOnGoldenFishSpawned || !isInSkyblock()) {
+			return;
+		}
+		
+		Client.showTitle(`${WHITE}Catch ${GOLD}Golden Fish`, '', 1, 30, 1);
+	
+		if (settings.soundMode !== OFF_SOUND_MODE) {
+            World.playSound('random.splash', 1, 1);
+        }
+	} catch (e) {
+		console.error(e);
+		console.log(`[FeeshNotifier] Failed to play alert on Golden Fish.`);
+	}
+}

--- a/features/alerts/alertOnNonFishingArmor.js
+++ b/features/alerts/alertOnNonFishingArmor.js
@@ -1,78 +1,83 @@
 import settings from "../../settings";
 import { RED } from "../../constants/formatting";
-import { getWorldName, isInSkyblock } from "../../utils/playerState";
+import { getWorldName, hasFishingRodInHotbar, isInSkyblock } from "../../utils/playerState";
 import { OFF_SOUND_MODE } from "../../constants/sounds";
-import { KUUDRA } from "../../constants/areas";
+import { DUNGEONS, KUUDRA } from "../../constants/areas";
+import { EntityFishHook } from "../../constants/javaTypes";
 
-// This module is made with help of ruki_tryuki, praises!
+let lastHookDetectedAt = null;
 
-register("playerInteract", (action, pos, event) => {
-    alertOnNonFishingArmor(action, pos, event);
+register("worldUnload", () => {
+    lastHookDetectedAt = null; 
 });
 
-function alertOnNonFishingArmor(action, pos, event) {
+register(net.minecraftforge.event.entity.EntityJoinWorldEvent, (event) => alertOnNonFishingArmor(event));
+
+function alertOnNonFishingArmor(event) {
     try {
-        if (!settings.alertOnNonFishingArmor ||
-            !isInSkyblock() ||
-            getWorldName() === KUUDRA ||
-            !action.toString().includes('RIGHT_CLICK') // RIGHT_CLICK_BLOCK, RIGHT_CLICK_EMPTY
-        ) {
+        if (!settings.alertOnNonFishingArmor || !isInSkyblock() || !hasFishingRodInHotbar() || getWorldName() === KUUDRA || getWorldName() === DUNGEONS || !(event.entity instanceof EntityFishHook)) {
             return;
         }
     
-        const heldItem = Player.getHeldItem();
-	    if (!heldItem) {
-	    	return;
-	    }
-	    
-        const isFishingRod = heldItem.getLore().some(loreLine => loreLine.includes('FISHING ROD') || loreLine.includes('FISHING WEAPON'));
-	    if (!isFishingRod) {
+        if (Player.getPlayer().field_71104_cf != event.entity) { // Check for player's own hook
             return;
         }
+    
+        if (isPlayerWearingFishingArmor()) {
+            return;
+        }
+    
+        if (lastHookDetectedAt && new Date() - lastHookDetectedAt < 5000) {
+            return;
+        }
+    
+        lastHookDetectedAt = new Date();
+    
+        // Time for hook to land on water/lava
+        setTimeout(function() {
+            const heldItem = Player.getHeldItem();
+            if (heldItem?.getName()?.includes('Carnival Rod')) {
+                return;
+            }
+            
+            const playerHook = World.getAllEntitiesOfType(EntityFishHook).find(e => Player.getPlayer().field_71104_cf == e.getEntity()); // field_71104_cf = fishEntity
+            if (!playerHook) {
+                return;
+            }
+        
+            let isHookActive = false;
+            if (playerHook.isInWater() || playerHook.isInLava()) { // For regular rods, the player's hook must be in lava or water
+                isHookActive = true;
+            } else {
+                const loreLines = heldItem?.getLore() || [];
+                const isDirtRod = loreLines.length ? loreLines[0].includes('Dirt Rod') : false;
+                if (isDirtRod) { // For dirt rod, the player's hook can be in dirt
+                    isHookActive = true;
+                }
+            }
 
-        if (heldItem.getName()?.includes('Carnival Rod')) {
-            return;
-        }
-
-        const bobber = Player.getPlayer().field_71104_cf; // field_71104_cf = fishEntity
-        if (!bobber) 
-        {
-            return;
-        }
+            if (!isHookActive) {
+                return;
+            }
     
-        if (bobber.func_180799_ab() == false && // func_180799_ab = isInLava()
-            bobber.func_70090_H() == false // func_70090_H = isInWater()
-        ) {
-            return;
-        }
-    
-        let fishingArmorCount = 0;
-        const armor = Player.armor;
-    
-        if (isFishingArmor(armor.getHelmet())) {
-            fishingArmorCount++;
-        }
-        if (isFishingArmor(armor.getChestplate())) {
-            fishingArmorCount++;
-        }
-        if (isFishingArmor(armor.getLeggings())) {
-            fishingArmorCount++;
-        }
-        if (isFishingArmor(armor.getBoots())) {
-            fishingArmorCount++;
-        }
-    
-        if (fishingArmorCount < 2) {
             Client.showTitle(`${RED}Equip fishing armor!`, '', 1, 25, 1);
     
             if (settings.soundMode !== OFF_SOUND_MODE) {
                 World.playSound('random.orb', 1, 1);
             }
-        }    
+        }, 1000);    
     } catch (e) {
         console.error(e);
-        console.log(`[FeeshNotifier] Failed to check fishing armor.`);
+        console.log(`[FeeshNotifier] Failed to check fishing armor on fishing hook appeared.`);
     }
+}
+
+function isPlayerWearingFishingArmor() {
+    const armor = Player.armor;
+    const armorPieces = [ armor.getHelmet(), armor.getChestplate(), armor.getLeggings(), armor.getBoots() ];
+    const fishingArmorCount = armorPieces.filter(armorPiece => isFishingArmor(armorPiece)).length;
+
+    return (fishingArmorCount >= 3);
 }
 
 function isFishingArmor(item) {
@@ -89,6 +94,6 @@ function isFishingArmor(item) {
         return true;
     }
 
-    const isFishingArmor = itemLore.slice(1).some(loreLine => loreLine.includes("Sea Creature Chance:"));
+    const isFishingArmor = itemLore.slice(1).some(loreLine => (loreLine.includes("Sea Creature Chance:") || loreLine.includes("Fishing Speed:")));
     return isFishingArmor;
 }

--- a/features/alerts/alertOnWormTheFish.js
+++ b/features/alerts/alertOnWormTheFish.js
@@ -1,5 +1,5 @@
 import settings from "../../settings";
-import { RED } from "../../constants/formatting";
+import { RED, WHITE } from "../../constants/formatting";
 import { EntityItem } from "../../constants/javaTypes";
 import { hasDirtRodInHand, isInSkyblock } from "../../utils/playerState";
 import { OFF_SOUND_MODE } from "../../constants/sounds";
@@ -20,7 +20,7 @@ function alertOnWormTheFishCatch() {
     const currentWormTheFishCount = items.filter(entity => new Item(entity).getName()?.removeFormatting()?.includes('Worm the Fish')).length;
 
     if (currentWormTheFishCount > wormTheFishCount) { // Alert only when a new item has spawned
-        Client.showTitle(`${RED}Pickup Worm the Fish!`, '', 1, 45, 1);
+        Client.showTitle(`${WHITE}Pickup ${RED}Worm the Fish`, '', 1, 45, 1);
         
         if (settings.soundMode !== OFF_SOUND_MODE) {
             World.playSound('random.splash', 1, 1);

--- a/features/inventory/highlightAttributeFusionMatchingItems.js
+++ b/features/inventory/highlightAttributeFusionMatchingItems.js
@@ -1,0 +1,87 @@
+import settings from "../../settings";
+import { isInSkyblock } from "../../utils/playerState";
+
+const CRIMSON_ARMOR_NAMES = [
+    'CRIMSON',
+    'AURORA',
+    'TERROR',
+    'FERVOR',
+    'HOLLOW'
+];
+
+const TARGET_ITEM_SLOT_INDEX = 29;
+const COMBINED_ITEM_SLOT_INDEX = 13;
+
+register('renderSlot', (slot, gui, event) => {
+    highlightAttributeFusionMatchingItems(slot, gui);
+});
+
+function highlightAttributeFusionMatchingItems(slot, gui) {
+    if (!settings.highlightMatchingItemsInAttributeFusion || !isInSkyblock()) {
+        return;
+    }
+
+    if (!(gui instanceof net.minecraft.client.gui.inventory.GuiChest)) {
+        return;
+    }
+
+    const chestName = gui?.field_147002_h?.func_85151_d()?.func_145748_c_()?.text;
+    if (!chestName || !chestName.includes('Attribute Fusion')) {
+        return;
+    }
+
+    const containerItems = Player.getContainer().getItems() || [];
+    const targetItem = containerItems[TARGET_ITEM_SLOT_INDEX];
+    const targetItemId = targetItem?.getNBT()?.getCompoundTag('tag')?.getCompoundTag('ExtraAttributes')?.getString('id');
+    if (!targetItem || !targetItemId) {
+        return;
+    }
+
+    const item = slot.getItem();
+    const itemId = item?.getNBT()?.getCompoundTag('tag')?.getCompoundTag('ExtraAttributes')?.getString('id');
+    if (!item || !itemId) {
+        return;
+    }
+
+    if (slot.getIndex() === COMBINED_ITEM_SLOT_INDEX) {
+        return;
+    }
+
+    const isMatching = targetItemId === itemId ||
+        (
+            (isCrimsonArmorPiece(targetItemId) && isCrimsonArmorPiece(itemId)) && // For crimson armors, different armor types are combinable
+            targetItemId.split('_').pop() === itemId.split('_').pop() // Check if the same armor piece (e.g. both helmets)
+        );
+
+    if (!isMatching) { 
+        return;
+    }
+
+    var targetItemAttributes = getItemAttributes(targetItem);
+    var inventoryItemAttributes = getItemAttributes(item);
+
+    if (targetItemAttributes.some(a => inventoryItemAttributes.includes(a))) {
+        Renderer.drawRect(Renderer.color(0, 255, 0, 150), slot.getDisplayX(), slot.getDisplayY(), 16, 16);
+    }
+}
+
+function getItemAttributes(item) {
+    const itemAttributes = item?.getNBT()?.getCompoundTag('tag')?.getCompoundTag('ExtraAttributes')?.getCompoundTag('attributes')?.toObject();
+    if (!itemAttributes) {
+        return [];
+    }
+
+    var stringifiedAttributes = [];
+    Object.keys(itemAttributes).sort().forEach(attributeCode => {
+        const attributeLevel = itemAttributes[attributeCode];
+        stringifiedAttributes.push(`${attributeCode.toLowerCase()}:${attributeLevel}`);
+    });
+
+    return stringifiedAttributes;
+}
+
+// ID examples: FIERY_CRIMSON_CHESTPLATE, AURORA_HELMET, etc.
+function isCrimsonArmorPiece(itemId) {
+    return (itemId.endsWith('_HELMET') || itemId.endsWith('_CHESTPLATE') || itemId.endsWith('_LEGGINGS') || itemId.endsWith('_BOOTS')) &&
+            CRIMSON_ARMOR_NAMES.some(n => itemId.includes(n));
+}

--- a/features/inventory/highlightCheapBooks.js
+++ b/features/inventory/highlightCheapBooks.js
@@ -1,6 +1,15 @@
 import settings from "../../settings";
 import { isInSkyblock } from "../../utils/playerState";
 
+const BOOK_NAMES_TO_HIGHLIGHT = [
+    'CORRUPTION_1',
+    'FRAIL_6',
+    'LURE_6',
+    'MAGNET_6',
+    'ANGLER_6',
+    'SPIKED_HOOK_6'
+];
+
 register('renderSlot', (slot, gui, event) => {
     highlightCheapBooks(slot, gui);
 });
@@ -24,16 +33,15 @@ function highlightCheapBooks(slot, gui) {
         return;
     }
 
-    const lore = item.getLore();
-    const bookName = lore.length ? lore[1] : '';
+    const enchantments = item.getNBT()?.getCompoundTag("tag")?.getCompoundTag("ExtraAttributes")?.getCompoundTag("enchantments")?.toObject();
+    if (!enchantments) {
+        return;
+    }
 
-    if (bookName.includes('Corruption') ||
-        bookName.includes('Frail') ||
-        bookName.includes('Lure') ||
-        bookName.includes('Magnet') ||
-        bookName.includes('Angler') ||
-        bookName.includes('Spiked Hook')
-    ) {
+    const firstEnchantmentName = Object.keys(enchantments)[0];
+    const bookName = `${firstEnchantmentName?.toUpperCase()}_${enchantments[firstEnchantmentName]}`;
+
+    if (BOOK_NAMES_TO_HIGHLIGHT.includes(bookName)) {
         Renderer.drawRect(Renderer.color(255, 0, 0, 150), slot.getDisplayX(), slot.getDisplayY(), 16, 16);
     }
 }

--- a/features/inventory/showArmorAttributes.js
+++ b/features/inventory/showArmorAttributes.js
@@ -1,35 +1,35 @@
-import { BOLD, GREEN, WHITE } from "../../constants/formatting";
 import settings from "../../settings";
+import { BOLD, GREEN, WHITE } from "../../constants/formatting";
 import { isInSkyblock } from "../../utils/playerState";
 
 register('renderItemIntoGui', (item, x, y, event) => {
     showArmorAttributes(item, x, y);
 });
 
+const FISHING_GEAR_REGEX = /(Thunder|Thunderbolt|Magma Lord|Slug|Moogma|Flaming|Taurus) (Helmet|Chestplate|Leggings|Boots|Gauntlet|Necklace)/;
+const CRIMSON_ARMOR_REGEX = /(Crimson|Aurora|Terror|Fervor|Hollow|Berserker|Rampart) (Helmet|Chestplate|Leggings|Boots)/;
+const CRIMSON_EQUIPMENT_REGEX = /Gauntlet of Contagion|Flaming Fist|((Molten|Implosion|Blaze|Scoville|Scourge|Delirium|Ghast|Lava Shell|Magma|Glowstone) (Cloak|Belt|Necklace|Gauntlet|Bracelet))/;
+
 function showArmorAttributes(item, x, y) {
-    if (!settings.showArmorAttributes || !isInSkyblock()) {
+    if (!item || (!settings.showFishingArmorAttributes && !settings.showCrimsonArmorAttributes) || !isInSkyblock()) {
         return;
     }
-
-    if (!item) {
-        return;
-    }
-
-    const thunderRegex = /Thunder (Helmet|Chestplate|Leggings|Boots)/;
-    const magmaLordRegex = /Magma Lord (Helmet|Chestplate|Leggings|Boots|Gauntlet)/;
 
     const name = item.getName()?.removeFormatting();
-    if (!name || (
-        !name.includes('Thunderbolt Necklace') &&
-        !thunderRegex.test(name) &&
-        !magmaLordRegex.test(name) &&
-        (!name.includes('Slug Boots') && !name.includes('Moogma Leggings') && !name.includes('Flaming Chestplate') && !name.includes('Taurus Helmet'))
-    )) {
+    if (!name) {
         return;
     }
 
-    const loreLines = item.getLore();
-    if (!loreLines) {
+    let isFishingGear = false;
+    let isCrimsonGear = false;
+
+    if (settings.showFishingArmorAttributes && FISHING_GEAR_REGEX.test(name)) {
+        isFishingGear = true;
+    } else if (settings.showCrimsonArmorAttributes && (CRIMSON_ARMOR_REGEX.test(name) || CRIMSON_EQUIPMENT_REGEX.test(name))) {
+        isCrimsonGear = true;
+    }
+
+    if (!isFishingGear && !isCrimsonGear) {
         return;
     }
 
@@ -39,7 +39,7 @@ function showArmorAttributes(item, x, y) {
     }
 
     let attributeAbbreviations = [];
-    const highlightedAttributeCodesString = settings.accentedArmorAttributes || '';
+    const highlightedAttributeCodesString = isFishingGear ? (settings.accentedFishingArmorAttributes || '') : (settings.accentedCrimsonArmorAttributes || '');
     const highlightedAttributeCodes = highlightedAttributeCodesString.split(',');
 
     Object.keys(attributes).sort().forEach(attributeCode => {

--- a/features/inventory/showFishingRodAttributes.js
+++ b/features/inventory/showFishingRodAttributes.js
@@ -24,11 +24,6 @@ function showFishingRodAttributes(item, x, y) {
         return;
     }
 
-    const loreLines = item.getLore();
-    if (!loreLines) {
-        return;
-    }
-
     const attributes = item.getNBT()?.getCompoundTag('tag')?.getCompoundTag('ExtraAttributes')?.getCompoundTag('attributes')?.toObject();
     if (!attributes) {
         return;

--- a/features/overlays/legionAndBobbingTimeTracker.js
+++ b/features/overlays/legionAndBobbingTimeTracker.js
@@ -14,6 +14,10 @@ const bobbingTimeDistance = 30;
 
 register('step', () => trackPlayersAndFishingHooksNearby()).setFps(2);
 register('renderOverlay', () => renderLegionAndBobbingTimeOverlay());
+register("worldUnload", () => {
+    playersCount = 0;
+    fishingHooksCount = 0;
+});
 
 function trackPlayersAndFishingHooksNearby() {
     if (!settings.legionAndBobbingTimeOverlay ||

--- a/features/overlays/rareCatchesTracker.js
+++ b/features/overlays/rareCatchesTracker.js
@@ -1,12 +1,22 @@
 import settings from "../../settings";
+import * as triggers from '../../constants/triggers';
 import * as seaCreatures from '../../constants/seaCreatures';
 import { persistentData } from "../../data/data";
 import { overlayCoordsData } from "../../data/overlayCoords";
-import { formatNumberWithSpaces, fromUppercaseToCapitalizedFirstLetters, isInChatOrInventoryGui, pluralize } from '../../utils/common';
+import { formatNumberWithSpaces, fromUppercaseToCapitalizedFirstLetters, isDoubleHook, isInChatOrInventoryGui, pluralize } from '../../utils/common';
 import { WHITE, GOLD, BOLD, YELLOW, GRAY, RED, UNDERLINE } from "../../constants/formatting";
 import { RARE_CATCH_TRIGGERS } from "../../constants/triggers";
 import { getWorldName, hasFishingRodInHotbar, isInSkyblock } from "../../utils/playerState";
 import { KUUDRA } from "../../constants/areas";
+
+triggers.RARE_CATCH_TRIGGERS.forEach(entry => {
+    register("Chat", (event) => {
+        const isDoubleHooked = isDoubleHook();
+        trackCatch({ seaCreature: entry.seaCreature, rarityColorCode: entry.rarityColorCode, isDoubleHook: isDoubleHooked });
+    }).setCriteria(entry.trigger).setContains();
+});
+
+register('renderOverlay', () => renderRareCatchTrackerOverlay());
 
 // DisplayLine is initialized once in order to avoid multiple method calls on click.
 let resetTrackerDisplay = new Display().hide();
@@ -58,7 +68,7 @@ export function resetRareCatchesTracker(isConfirmed) {
 	}
 }
 
-export function trackCatch(options) {
+function trackCatch(options) {
     try {
         if (!settings.rareCatchesTrackerOverlay || !isInSkyblock()) {
             return;
@@ -94,7 +104,7 @@ export function trackCatch(options) {
 	}
 }
 
-export function renderRareCatchTrackerOverlay() {
+function renderRareCatchTrackerOverlay() {
     if (!settings.rareCatchesTrackerOverlay ||
         !Object.entries(persistentData.rareCatches).length ||
         !isInSkyblock() ||

--- a/features/overlays/seaCreaturesCountAndTimeTracker.js
+++ b/features/overlays/seaCreaturesCountAndTimeTracker.js
@@ -53,8 +53,9 @@ function trackSeaCreaturesCount() {
         const plainName = entity?.getName()?.removeFormatting();
 
         // Mobs / corrupted mobs have prefix like [Lv100], only Grinch does not have it
-        // This check is needed to exclude Necromancy souls
-        if ((plainName.includes('[Lv') && ALL_SEA_CREATURES_NAMES.some(sc => plainName.includes(sc))) || plainName.includes('Grinch  ❤')) {
+        // This check is needed to exclude Necromancy souls and pets
+        if ((plainName.includes('[Lv') && plainName.includes('❤') && 
+            ALL_SEA_CREATURES_NAMES.some(sc => plainName.includes(sc))) || plainName.includes('Grinch  ❤')) {
             if (plainName.includes('Rider of the Deep')) {
                 newMobsCount += 2;
             } else {

--- a/features/overlays/seaCreaturesHpTracker.js
+++ b/features/overlays/seaCreaturesHpTracker.js
@@ -4,38 +4,80 @@ import { EntityArmorStand } from "../../constants/javaTypes";
 import { overlayCoordsData } from "../../data/overlayCoords";
 import { getWorldName, hasFishingRodInHotbar, isInSkyblock } from "../../utils/playerState";
 import { CRIMSON_ISLE, JERRY_WORKSHOP } from "../../constants/areas";
+import { OFF_SOUND_MODE } from "../../constants/sounds";
+
+const TRACKED_MOBS = [
+    {
+        world: CRIMSON_ISLE,
+        mobShortName: 'Lord Jawbus',
+    },
+    {
+        world: CRIMSON_ISLE,
+        mobShortName: 'Thunder',
+    },
+    {
+        world: CRIMSON_ISLE,
+        mobShortName: 'Plhlegblast',
+    },
+    {
+        world: JERRY_WORKSHOP,
+        mobShortName: 'Reindrake',
+    },
+    {
+        world: JERRY_WORKSHOP,
+        mobShortName: 'Yeti',
+    },
+];
+const TRACKED_WORLD_NAMES = TRACKED_MOBS.map(m => m.world);
 
 let mobs = [];
 
 register('step', () => trackSeaCreaturesHp()).setFps(4);
 register('renderOverlay', () => renderHpOverlay());
+register("worldUnload", () => {
+    mobs = [];
+});
 
 function trackSeaCreaturesHp() {
-    if (!settings.seaCreaturesHpOverlay ||
-        !isInSkyblock() ||
-        (getWorldName() !== CRIMSON_ISLE && getWorldName() !== JERRY_WORKSHOP) ||
-        !hasFishingRodInHotbar()) {
-        return;
-    }
+    try {
+        const worldName = getWorldName();
 
-    mobs = [];
-    const entities = World.getAllEntitiesOfType(EntityArmorStand);
-
-	entities.forEach(entity => {
-        const name = entity?.getName();
-        const plainName = entity?.getName()?.removeFormatting();
-
-        if (plainName.includes('[Lv') && (plainName.includes('Lord Jawbus') || plainName.includes('Thunder') || plainName.includes('Reindrake') || plainName.includes('Yeti'))) {
-            mobs.push(name);
+        if (!settings.seaCreaturesHpOverlay ||
+            !isInSkyblock() ||
+            !TRACKED_WORLD_NAMES.some(w => w === worldName) ||
+            !hasFishingRodInHotbar()) {
+            return;
         }
-    })	
+    
+        let currentMobs = [];
+        const entities = World.getAllEntitiesOfType(EntityArmorStand);
+    
+        entities.forEach(entity => {
+            const name = entity?.getName();
+            const plainName = entity?.getName()?.removeFormatting();
+    
+            if (plainName.includes('[Lv') && plainName.includes('❤') && // Distinguish mobs from pets (e.g. Squid)
+                TRACKED_MOBS.filter(m => m.world === worldName).some(m => plainName.includes(m.mobShortName))) {
+                currentMobs.push(name);
+            }
+        });
+    
+        if (currentMobs.length > mobs.length && settings.soundMode !== OFF_SOUND_MODE) {
+            World.playSound('random.orb', 0.75, 1);
+        }
+    
+        mobs = currentMobs;
+    } catch (e) {
+		console.error(e);
+		console.log(`[FeeshNotifier] Failed to track nearby sea creatures HP.`);
+	}
 }
 
 function renderHpOverlay() {
     if (!settings.seaCreaturesHpOverlay ||
         !mobs.length ||
         !isInSkyblock() ||
-        (getWorldName() !== CRIMSON_ISLE && getWorldName() !== JERRY_WORKSHOP) ||
+        !TRACKED_WORLD_NAMES.some(w => w === getWorldName()) ||
         !hasFishingRodInHotbar()) {
         return;
     }

--- a/index.js
+++ b/index.js
@@ -1,224 +1,43 @@
-import settings from "./settings";
-import * as triggers from './constants/triggers';
 import "./commands";
 import "./moveOverlay";
 import "./utils/playerState";
 import "./utils/bazaarPrices";
 import "./utils/auctionPrices";
-import { sendMessageOnCatch } from './features/chat/messageOnCatch';
-import { sendMessageOnDrop } from './features/chat/messageOnDrop';
-import { playAlertOnCatch } from './features/alerts/alertOnCatch';
-import { playAlertOnDrop } from './features/alerts/alertOnDrop';
-import { getCatchMessage, getColoredPlayerNameFromDisplayName, getColoredPlayerNameFromPartyChat, getDoubleHookCatchMessage, getDropMessagePattern, getPartyChatMessage, getPlayerDeathMessage, isDoubleHook } from './utils/common';
-import { trackCatch, renderRareCatchTrackerOverlay } from './features/overlays/rareCatchesTracker';
-import "./features/chat/announceMobSpawnToAllChat";
-import "./features/chat/messageOnPlayerDeath";
-import "./features/chat/messageOnRevenant";
+import "./features/alerts/alertOnCatch";
+import "./features/alerts/alertOnDrop";
 import "./features/alerts/alertOnPlayerDeath";
-import "./features/overlays/totemTracker";
-import "./features/overlays/flareTracker";
-import "./features/overlays/seaCreaturesHpTracker";
-import "./features/overlays/seaCreaturesCountAndTimeTracker";
 import "./features/alerts/alertOnNonFishingArmor";
 import "./features/alerts/alertOnWormTheFish";
 import "./features/alerts/alertOnReindrake";
 import "./features/alerts/alertOnChumBucketAutopickup";
-import "./features/inventory/highlightCheapBooks";
-import "./features/overlays/legionAndBobbingTimeTracker";
-import "./features/overlays/crimsonIsleTracker";
-import "./features/inventory/showThunderBottleProgress";
-import "./features/inventory/showPetLevel";
-import "./features/inventory/showArmorAttributes";
-import "./features/inventory/showFishingRodAttributes";
-import "./features/inventory/showRarityUpgrade";
 import "./features/alerts/alertOnThunderBottleCharged";
 import "./features/alerts/alertOnSpiritMaskUsed";
+import "./features/alerts/alertOnGoldenFish";
+
+import "./features/overlays/rareCatchesTracker";
+import "./features/overlays/totemTracker";
+import "./features/overlays/flareTracker";
+import "./features/overlays/seaCreaturesHpTracker";
+import "./features/overlays/seaCreaturesCountAndTimeTracker";
+import "./features/overlays/legionAndBobbingTimeTracker";
+import "./features/overlays/crimsonIsleTracker";
 import "./features/overlays/jerryWorkshopTracker";
 import "./features/overlays/wormMembraneProfitTracker";
 import "./features/overlays/magmaCoreProfitTracker";
 import "./features/overlays/fishingProfitTracker";
 
+import "./features/inventory/highlightCheapBooks";
+import "./features/inventory/showThunderBottleProgress";
+import "./features/inventory/showPetLevel";
+import "./features/inventory/showArmorAttributes";
+import "./features/inventory/showFishingRodAttributes";
+import "./features/inventory/showRarityUpgrade";
+import "./features/inventory/highlightAttributeFusionMatchingItems";
+
+import "./features/chat/announceMobSpawnToAllChat";
+import "./features/chat/messageOnPlayerDeath";
+import "./features/chat/messageOnRevenant";
+
 register('worldLoad', () => {
     Client.showTitle('', '', 1, 1, 1); // Shitty fix for a title not showing for the 1st time
-});
-
-// Rare catches overlay
-
-register('renderOverlay', () => renderRareCatchTrackerOverlay());
-
-triggers.RARE_CATCH_TRIGGERS.forEach(entry => {
-    // Triggers on original "all chat" catch message sent by Hypixel.
-    register(
-        "Chat",
-        (event) => {
-            const isDoubleHooked = isDoubleHook();
-            playAlertOnCatch({ // Play alert immediately before sending to the party (in case when you're fishing solo)
-                seaCreature: entry.seaCreature,
-                rarityColorCode: entry.rarityColorCode,
-                isEnabled: settings[entry.isAlertEnabledSettingKey],
-                isDoubleHook: isDoubleHooked,
-                player: getColoredPlayerNameFromDisplayName(),
-                suppressIfSamePlayer: false
-            });
-
-            sendMessageOnCatch({
-                seaCreature: entry.seaCreature,
-                rarityColorCode: entry.rarityColorCode,
-                isDoubleHook: isDoubleHooked,
-                isEnabled: settings[entry.isMessageEnabledSettingKey]
-            });
-
-            trackCatch({ seaCreature: entry.seaCreature, rarityColorCode: entry.rarityColorCode, isDoubleHook: isDoubleHooked });
-        }
-    ).setCriteria(entry.trigger).setContains();
-
-    // Triggers on automated party chat message sent by the module (no double hook).
-    register(
-        "Chat",
-        (rankAndPlayer, event) => playAlertOnCatch({
-            seaCreature: entry.seaCreature,
-            rarityColorCode: entry.rarityColorCode,
-            isEnabled: settings[entry.isAlertEnabledSettingKey],
-            isDoubleHook: false,
-            player: getColoredPlayerNameFromPartyChat(rankAndPlayer),
-            suppressIfSamePlayer: true
-        })
-    ).setCriteria(getPartyChatMessage(getCatchMessage(entry.seaCreature)));
-
-    // Triggers on automated party chat message sent by the module (double hook).
-    register(
-        "Chat",
-        (rankAndPlayer, event) => playAlertOnCatch({
-            seaCreature: entry.seaCreature,
-            rarityColorCode: entry.rarityColorCode,
-            isEnabled: settings[entry.isAlertEnabledSettingKey],
-            isDoubleHook: true,
-            player: getColoredPlayerNameFromPartyChat(rankAndPlayer),
-            suppressIfSamePlayer: true
-        })
-    ).setCriteria(getPartyChatMessage(getDoubleHookCatchMessage(entry.seaCreature)));
-});
-
-// Rare drop triggers
-
-triggers.RARE_DROP_TRIGGERS.forEach(entry => {
-    // Triggers on original "all chat" drop message sent by Hypixel.
-    register(
-        "Chat",
-        (magicFind, event) => {
-            playAlertOnDrop({
-                itemName: entry.itemName,
-                rarityColorCode: entry.rarityColorCode,
-                sound: entry.sound,
-                isEnabled: settings[entry.isAlertEnabledSettingKey],
-                player: getColoredPlayerNameFromDisplayName(),
-                suppressIfSamePlayer: false
-            });
-
-            sendMessageOnDrop({
-                itemId: entry.itemId,
-                itemName: entry.itemName,
-                rarityColorCode: entry.rarityColorCode,
-                magicFind: magicFind,
-                shouldTrackDropNumber: entry.shouldTrackDropNumber,
-                isEnabled: settings[entry.isMessageEnabledSettingKey]
-            });
-        }
-    ).setCriteria(entry.trigger).setContains();
-
-    // Triggers on automated party chat message sent by the module.
-    register(
-        "Chat",
-        (rankAndPlayer, event) => playAlertOnDrop({
-            itemName: entry.itemName,
-            rarityColorCode: entry.rarityColorCode,
-            sound: entry.sound,
-            isEnabled: settings[entry.isAlertEnabledSettingKey],
-            player: getColoredPlayerNameFromPartyChat(rankAndPlayer),
-            suppressIfSamePlayer: true
-        })
-    ).setCriteria(getPartyChatMessage(getDropMessagePattern(entry.itemName)));
-});
-
-// Great/Outstanding catch messages do not have magic find in the message
-triggers.OUTSTANDING_CATCH_TRIGGERS.forEach(entry => {
-    // Triggers on original "all chat" drop message sent by Hypixel.
-    register(
-        "Chat",
-        (event) => {
-            playAlertOnDrop({
-                itemName: entry.itemName,
-                rarityColorCode: entry.rarityColorCode,
-                sound: entry.sound,
-                isEnabled: settings[entry.isAlertEnabledSettingKey],
-                player: getColoredPlayerNameFromDisplayName(),
-                suppressIfSamePlayer: false
-            });
-
-            sendMessageOnDrop({
-                itemId: entry.itemId,
-                itemName: entry.itemName,
-                rarityColorCode: entry.rarityColorCode,
-                magicFind: null,
-                shouldTrackDropNumber: entry.shouldTrackDropNumber,
-                isEnabled: settings[entry.isMessageEnabledSettingKey]
-            });
-        }
-    ).setCriteria(entry.trigger).setContains();
-
-    // Triggers on automated party chat message sent by the module.
-    register(
-        "Chat",
-        (rankAndPlayer, event) => playAlertOnDrop({
-            itemName: entry.itemName,
-            rarityColorCode: entry.rarityColorCode,
-            sound: entry.sound,
-            isEnabled: settings[entry.isAlertEnabledSettingKey],
-            player: getColoredPlayerNameFromPartyChat(rankAndPlayer),
-            suppressIfSamePlayer: true
-        })
-    ).setCriteria(getPartyChatMessage(getDropMessagePattern(entry.itemName)));
-});
-
-triggers.DYE_TRIGGERS.forEach(entry => {
-    // Triggers on original "all chat" drop message sent by Hypixel.
-    register(
-        "Chat",
-        (playerNameAndRank, event) => {
-            if (!playerNameAndRank || !playerNameAndRank.removeFormatting().includes(Player.getName())) {
-                return;
-            }
-
-            playAlertOnDrop({
-                itemName: entry.itemName,
-                rarityColorCode: entry.rarityColorCode,
-                sound: entry.sound,
-                isEnabled: settings[entry.isAlertEnabledSettingKey],
-                player: getColoredPlayerNameFromDisplayName(),
-                suppressIfSamePlayer: false
-            });
-
-            sendMessageOnDrop({
-                itemId: entry.itemId,
-                itemName: entry.itemName,
-                rarityColorCode: entry.rarityColorCode,
-                magicFind: null,
-                shouldTrackDropNumber: entry.shouldTrackDropNumber,
-                isEnabled: settings[entry.isMessageEnabledSettingKey]
-            });
-        }
-    ).setCriteria(entry.trigger).setContains();
-
-    // Triggers on automated party chat message sent by the module.
-    register(
-        "Chat",
-        (rankAndPlayer, event) => playAlertOnDrop({
-            itemName: entry.itemName,
-            rarityColorCode: entry.rarityColorCode,
-            sound: entry.sound,
-            isEnabled: settings[entry.isAlertEnabledSettingKey],
-            player: getColoredPlayerNameFromPartyChat(rankAndPlayer),
-            suppressIfSamePlayer: true
-        })
-    ).setCriteria(getPartyChatMessage(getDropMessagePattern(entry.itemName)));
 });

--- a/metadata.json
+++ b/metadata.json
@@ -3,7 +3,7 @@
     "entry": "index.js",
     "author": "MoonTheSadFisher",
     "description": "Hypixel Skyblock fishing utilities for parties.",
-    "version": "1.18.0",
+    "version": "1.19.0",
     "requires": [
         "Vigilance",
         "PogData",

--- a/settings.js
+++ b/settings.js
@@ -348,7 +348,7 @@ class Settings {
 
     @SwitchProperty({
         name: "Alert when no fishing armor equipped",
-        description: `Shows a title when current player is fishing in a non-fishing armor. [Made by ${AQUA}ruki-tryuki${GRAY}]`,
+        description: `Shows a title when current player is fishing in a non-fishing armor.`,
         category: "Alerts",
         subcategory: "Fishing armor"
     })
@@ -384,11 +384,21 @@ class Settings {
     })
     alertOnSpiritMaskUsed = true;
 
+    // ******* ALERTS - Golden Fish ******* //
+
+    @SwitchProperty({
+        name: "Alert when a Golden Fish has spawned",
+        description: `Shows a title when a Golden Fish has spawned.`,
+        category: "Alerts",
+        subcategory: "Golden Fish"
+    })
+    alertOnGoldenFishSpawned = false;
+
     // ******* ALERTS - Worm the Fish ******* //
 
     @SwitchProperty({
         name: "Alert when a Worm the Fish is caught",
-        description: `Shows a title when a Worm the Fish is caught using (Dirt Rod fishing).`,
+        description: `Shows a title when a Worm the Fish is caught (Dirt Rod fishing).`,
         category: "Alerts",
         subcategory: "Worm the Fish"
     })
@@ -743,7 +753,7 @@ class Settings {
 
     @SwitchProperty({
         name: "Sea creatures HP",
-        description: `Shows an overlay with the HP of nearby Thunder / Lord Jawbus / Reindrake / Yeti. ${RED}Hidden if you have no fishing rod in your hotbar!`,
+        description: `Shows an overlay with the HP of nearby Thunder / Lord Jawbus / Plhlegblast / Reindrake / Yeti. ${RED}Hidden if you have no fishing rod in your hotbar!`,
         category: "Overlays",
         subcategory: "Sea creatures HP"
     })
@@ -1036,6 +1046,14 @@ ${RED}Hidden if you have no fishing rod in your hotbar!`,
     })
     highlightCheapBooks = false;
 
+    @SwitchProperty({
+        name: "Highlight matching items in Attribute Fusion",
+        description: `Highlight matching items with the same attribute tier, when combining the gear / attribute shards in the Attribute Fusion menu.`,
+        category: "Inventory",
+        subcategory: "Highlight"
+    })
+    highlightMatchingItemsInAttributeFusion = false;
+
     // ******* INVENTORY - Item tooltip ******* //
 
     @SwitchProperty({
@@ -1066,19 +1084,35 @@ ${RED}Hidden if you have no fishing rod in your hotbar!`,
 
     @SwitchProperty({
         name: "Armor attributes",
-        description: `Render fishing armor attribute name and level as short abbreviations.`,
+        description: `Render attribute name and level as short abbreviations, for Thunder/Magma Lord/Lava Sea Creature armor and equipment.`,
         category: "Inventory",
         subcategory: "Armor attributes"
     })
-    showArmorAttributes = false;
+    showFishingArmorAttributes = false;
 
     @TextProperty({
         name: "Accented armor attributes",
-        description: `Render attributes from this list using another color. Use camel_case to specify an attribute code, and comma as a separator to specify multiple.`,
+        description: `Render attributes from this list using another color. Use lower_case_with_underscore to specify an attribute code, and comma as a separator to specify multiple.`,
         category: "Inventory",
         subcategory: "Armor attributes"
     })
-    accentedArmorAttributes = 'blazing_fortune,magic_find,fishing_experience';
+    accentedFishingArmorAttributes = 'blazing_fortune,magic_find,fishing_experience';
+
+    @SwitchProperty({
+        name: "Crimson armor / equipment attributes",
+        description: `Render attribute name and level as short abbreviations, for different crimson/kuudra armors and equipment.`,
+        category: "Inventory",
+        subcategory: "Armor attributes"
+    })
+    showCrimsonArmorAttributes = false;
+
+    @TextProperty({
+        name: "Accented crimson armor / equipment attributes",
+        description: `Render attributes from this list using another color. Use lower_case_with_underscore to specify an attribute code, and comma as a separator to specify multiple.`,
+        category: "Inventory",
+        subcategory: "Armor attributes"
+    })
+    accentedCrimsonArmorAttributes = 'magic_find,veteran,vitality,dominance,mana_pool,mana_regeneration,lifeline';
 
     // ******* INVENTORY - Fishing rod attributes ******* //
 
@@ -1092,7 +1126,7 @@ ${RED}Hidden if you have no fishing rod in your hotbar!`,
 
     @TextProperty({
         name: "Accented fishing rod attributes",
-        description: `Render attributes from this list using another color. Use camel_case to specify an attribute code, and comma as a separator to specify multiple.`,
+        description: `Render attributes from this list using another color. Use lower_case_with_underscore to specify an attribute code, and comma as a separator to specify multiple.`,
         category: "Inventory",
         subcategory: "Fishing rod attributes"
     })


### PR DESCRIPTION
Features:

- Highlight matching items with the same attribute tier, when combining the gear / attribute shards in the Attribute Fusion menu [disabled by default].
- Render attributes and levels for crimson armor and equipment [disabled by default].
- Added alert on Golden Fish spawn [disabled by default].
- Sea creatures HP tracker - added Plhlegblast.
- Sea creatures HP tracker - make a quiet sound on SC detected.

Bugfixes:

- Fixed Dye drop alert.
- Fixed Prosperity book not being counted in Fishing profit tracker if it's displayed with numbers (Prosperity 1 instead of Prosperity I).
- Fixed some pets counted towards Sea creatures count / Sea creatures HP due to the same name as the mob.

Other:

- Refactored code for Alert on non-fishing armor, highlight cheap books.
- Code for catch/drop alerts is moved to the separate files, so index.js file looks more clean.