### PR TITLE
Sea creatures HP tracker: made mob's HP nametag more compact

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Releases
 
+## v1.22.0
+
+Features:
+
+- Sea creatures HP tracker: made mob's HP nametag more compact, also show it only when mob is in <= 30 blocks range (so if you see the nametag - you're in lootshare range).
+
 ## v1.21.0
 
 Released: 2025-01-18

--- a/features/overlays/seaCreaturesHpTracker.js
+++ b/features/overlays/seaCreaturesHpTracker.js
@@ -6,6 +6,7 @@ import { getWorldName, hasFishingRodInHotbar, isInSkyblock } from "../../utils/p
 import { CRIMSON_ISLE, JERRY_WORKSHOP } from "../../constants/areas";
 import { OFF_SOUND_MODE } from "../../constants/sounds";
 
+const LOOTSHARE_DISTANCE = 30;
 const TRACKED_MOBS = [
     {
         world: CRIMSON_ISLE,
@@ -53,12 +54,17 @@ function trackSeaCreaturesHp() {
         const entities = World.getAllEntitiesOfType(EntityArmorStand);
     
         entities.forEach(entity => {
+            const player = Player.getPlayer();
             const name = entity?.getName();
             const plainName = entity?.getName()?.removeFormatting();
     
             if (plainName.includes('[Lv') && plainName.includes('❤') && // Distinguish mobs from pets (e.g. Squid)
-                TRACKED_MOBS.filter(m => m.world === worldName).some(m => plainName.includes(m.mobShortName))) {
-                currentMobs.push(name);
+                TRACKED_MOBS.filter(m => m.world === worldName).some(m => plainName.includes(m.mobShortName)) &&
+                (plainName.includes('Reindrake') || entity.distanceTo(player) <= LOOTSHARE_DISTANCE)
+            ) {
+                // Original nametag: §e﴾ §8[§7Lv400§8] §c§lThunder§r§r §e17M§f/§a35M§c❤ §e﴿ §b✯
+                const cleanName = name.replace('§e﴾ ', '').replace(' §e﴿', '').trim().split('] ')[1];
+                currentMobs.push(cleanName);          
             }
         });
     

--- a/moveAllOverlays.js
+++ b/moveAllOverlays.js
@@ -45,7 +45,7 @@ ${GRAY}- ${LIGHT_PURPLE}Lord Jawbus: ${WHITE}2`,
     {
         toggleSettingKey: 'seaCreaturesHpOverlay',
         guiSettings: overlayCoordsData.seaCreaturesHpOverlay,
-        sampleText: `${YELLOW}${BOLD}Sea creatures HP\n${GRAY}[Lv600] ${RED}${BOLD}Lord Jawbus ${RESET}${GREEN}76m${WHITE}/${GREEN}100m${RED}❤`,
+        sampleText: `${YELLOW}${BOLD}Sea creatures HP\n${RED}${BOLD}Lord Jawbus ${RESET}${GREEN}76m${WHITE}/${GREEN}100m${RED}❤`,
         isActive: false,
         width: 0,
         height: 0


### PR DESCRIPTION
Sea creatures HP tracker: made mob's HP nametag more compact, also show it only when mob is in <= 30 blocks range (so if you see the nametag - you're in lootshare range)