### PR TITLE
fix: Get rid of Item.getLore() calls

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -7,6 +7,11 @@ Features:
 - Added alert on Periwinkle Dye and Bone Dye drop, also added them to Fishing profit tracker when it's obtained while fishing.
 - Track Ice Essence fished up from water on Jerry's Workshop.
 
+Bugfixes:
+
+- Fixed Skyhanni's Estimated Item Value flashinh in NEU PV when module is loaded.
+  - It's caused by CT's Item.getLore() called, it somehow interferes with other mods.
+
 ## v1.22.0
 
 Released: 2025-01-19

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -9,7 +9,7 @@ Features:
 
 Bugfixes:
 
-- Fixed Skyhanni's Estimated Item Value flashinh in NEU PV when module is loaded.
+- Fixed Skyhanni's Estimated Item Value flashing in NEU PV when module is loaded.
   - It's caused by CT's Item.getLore() called, it somehow interferes with other mods.
 
 ## v1.22.0

--- a/features/alerts/alertOnNonFishingArmor.js
+++ b/features/alerts/alertOnNonFishingArmor.js
@@ -4,6 +4,7 @@ import { getWorldName, hasFishingRodInHotbar, isInSkyblock } from "../../utils/p
 import { OFF_SOUND_MODE } from "../../constants/sounds";
 import { DUNGEONS, KUUDRA } from "../../constants/areas";
 import { EntityFishHook } from "../../constants/javaTypes";
+import { getLore } from "../../utils/common";
 
 let lastHookDetectedAt = null;
 
@@ -49,8 +50,7 @@ function alertOnNonFishingArmor(event) {
             if (playerHook.isInWater() || playerHook.isInLava()) { // For regular rods, the player's hook must be in lava or water
                 isHookActive = true;
             } else {
-                const loreLines = heldItem?.getLore() || [];
-                const isDirtRod = loreLines.length ? loreLines[0].includes('Dirt Rod') : false;
+                const isDirtRod = heldItem?.getName()?.includes('Dirt Rod');
                 if (isDirtRod) { // For dirt rod, the player's hook can be in dirt
                     isHookActive = true;
                 }
@@ -73,8 +73,8 @@ function alertOnNonFishingArmor(event) {
 }
 
 function isPlayerWearingFishingArmor() {
-    const armor = Player.armor;
-    const armorPieces = [ armor.getHelmet(), armor.getChestplate(), armor.getLeggings(), armor.getBoots() ];
+    const armor = Player?.armor;
+    const armorPieces = [ armor?.getHelmet(), armor?.getChestplate(), armor?.getLeggings(), armor?.getBoots() ];
     const fishingArmorCount = armorPieces.filter(armorPiece => isFishingArmor(armorPiece)).length;
 
     return (fishingArmorCount >= 3);
@@ -85,15 +85,16 @@ function isFishingArmor(item) {
         return false;
     }
 
-    const itemLore = item.getLore();
-    if (!itemLore || !itemLore.length) {
+    const itemName = item.getName();
+    const itemLore = getLore(item);
+    if (!itemName || !itemLore || !itemLore.length) {
         return false;
     }
 
-    if (itemLore[0].includes("Hunter") || itemLore[0].includes("Squid Hat")) {
+    if (itemName.includes("Hunter") || itemName.includes("Squid Hat")) {
         return true;
     }
 
-    const isFishingArmor = itemLore.slice(1).some(loreLine => (loreLine.includes("Sea Creature Chance:") || loreLine.includes("Fishing Speed:")));
+    const isFishingArmor = itemLore.some(loreLine => (loreLine.includes("Sea Creature Chance:") || loreLine.includes("Fishing Speed:")));
     return isFishingArmor;
 }

--- a/features/overlays/fishingProfitTracker.js
+++ b/features/overlays/fishingProfitTracker.js
@@ -8,7 +8,7 @@ import { AQUA, BOLD, GOLD, GRAY, RESET, WHITE, YELLOW, RED, GREEN, BLUE } from "
 import { EntityFishHook } from "../../constants/javaTypes";
 import { getAuctionItemPrices, getPetRarityCode } from "../../utils/auctionPrices";
 import { getBazaarItemPrices } from "../../utils/bazaarPrices";
-import { formatElapsedTime, getCleanItemName, getItemsAddedToSacks, isInChatOrInventoryGui, isInSacksGui, isInSupercraftGui, splitArray, toShortNumber } from "../../utils/common";
+import { formatElapsedTime, getCleanItemName, getItemsAddedToSacks, getLore, isInChatOrInventoryGui, isInSacksGui, isInSupercraftGui, splitArray, toShortNumber } from "../../utils/common";
 import { getLastGuisClosed, getLastKatUpgrade, getWorldName, hasFishingRodInHotbar, isInSkyblock } from "../../utils/playerState";
 import { playRareDropSound } from '../../utils/sound';
 
@@ -200,8 +200,7 @@ function activateSessionOnPlayersFishingHook() {
             return;
         }
 
-        const loreLines = heldItem?.getLore() || [];
-        const isDirtRod = loreLines.length ? loreLines[0].includes('Dirt Rod') : false;
+        const isDirtRod = heldItem?.getName()?.includes('Dirt Rod');
         if (isDirtRod) { // For dirt rod, the player's hook can be in dirt
             activateTimer();
         }
@@ -538,13 +537,13 @@ function detectInventoryChanges() {
             let slotItemName = getCleanItemName(item?.getName());
 
             if (slotItemName === 'Attribute Shard' || slotItemName === 'Enchanted Book') {
-                const loreLines = item.getLore();
-                const description = loreLines[1].removeFormatting();
+                const loreLines = getLore(item);
+                const description = loreLines[0].removeFormatting();
                 slotItemName += ` (${description})`;
             }
 
             if (slotItemName === 'Fishing Exp Boost') {
-                const loreLines = item.getLore();
+                const loreLines = getLore(item);
                 const description = loreLines.find(line => line.endsWith('PET ITEM')).removeFormatting().split(' ')[0];
                 slotItemName += ` (${description})`;
             }

--- a/utils/common.js
+++ b/utils/common.js
@@ -291,6 +291,15 @@ export function formatTimeElapsedBetweenDates(dateFrom, dateTo = new Date()) {
 		: `${days > 0 ? days + 'd ' : ''}${days > 0 || hours > 0 ? hours + 'h ' : ''}${days > 0 || hours > 0 || minutes > 0 ? minutes + 'm' : ''}`;
 }
 
+// Native getLore() interferes with other mods, e.g. it causes Skyhanni's estimated item value overlay to flash in /pv
+export function getLore(item) {
+	if (!item) {
+		return [];
+	}
+
+    return item.getNBT().getCompoundTag('tag')?.getCompoundTag('display')?.toObject()?.Lore || [];
+}
+
 function getArticle(str) {
     const isFirstLetterVowel = ['a', 'e', 'i', 'o', 'u'].indexOf(str[0].toLowerCase()) !== -1;
 	return isFirstLetterVowel ? 'An' : 'A';

--- a/utils/playerState.js
+++ b/utils/playerState.js
@@ -1,3 +1,5 @@
+import { getLore } from "./common";
+
 var isInSkyblock = false;
 var hasFishingRodInHotbar = false;
 var hasDirtRodInHand = false;
@@ -131,7 +133,7 @@ function setHasFishingRodInHotbar() {
 	if (!hotbarItems || !hotbarItems.length) {
 		hasFishingRodInHotbar = false;
 	} else {
-		const rods = hotbarItems.filter(i => i && !i.getName()?.includes('Carnival Rod') && i.getLore().some(loreLine => loreLine.includes('FISHING ROD') || loreLine.includes('FISHING WEAPON')));
+		const rods = hotbarItems.filter(i => i && !i.getName()?.includes('Carnival Rod') && getLore(i).some(loreLine => loreLine.includes('FISHING ROD') || loreLine.includes('FISHING WEAPON')));
 		hasFishingRodInHotbar = rods && rods.length;	
 	}
 }
@@ -146,8 +148,7 @@ function setHasDirtRodInHand() {
 	if (!heldItem) {
 		hasDirtRodInHand = false;
 	} else {
-		const loreLines = heldItem.getLore();
-		const isDirtRod = loreLines.length ? loreLines[0].includes('Dirt Rod') : false;
+		const isDirtRod = heldItem?.getName()?.includes('Dirt Rod');
 		hasDirtRodInHand = isDirtRod;
 	}
 }
@@ -158,23 +159,19 @@ function setIsInHunterArmor() {
 		return;
 	}
 
-	const armor = Player.armor;
-	const helmetLoreLines = armor.getHelmet()?.getLore();
-	const chestplateLoreLines = armor.getChestplate()?.getLore();
-	const leggingsLoreLines = armor.getLeggings()?.getLore();
-	const bootsLoreLines = armor.getBoots()?.getLore();
+	const armor = Player?.armor;
+	const helmetName = armor?.getHelmet()?.getName();
+	const chestplateName = armor?.getChestplate()?.getName();
+	const leggingsName = armor?.getLeggings()?.getName();
+	const bootsName = armor?.getBoots()?.getName();
 	const hunter = 'Hunter';
 
-	if (!helmetLoreLines || !helmetLoreLines.length ||
-		!chestplateLoreLines || !chestplateLoreLines.length ||
-		!leggingsLoreLines || !leggingsLoreLines.length ||
-		!bootsLoreLines || !bootsLoreLines.length
-	) {
+	if (!helmetName || !chestplateName || !leggingsName || !bootsName) {
 		isInHunterArmor = false;
 		return;
 	}
 
-	if (helmetLoreLines[0].includes(hunter) && chestplateLoreLines[0].includes(hunter) && leggingsLoreLines[0].includes(hunter) && bootsLoreLines[0].includes(hunter)) {
+	if (helmetName.includes(hunter) && chestplateName.includes(hunter) && leggingsName.includes(hunter) && bootsName.includes(hunter)) {
 		isInHunterArmor = true;
 	} else {
 		isInHunterArmor = false;


### PR DESCRIPTION
- Fixed Skyhanni's Estimated Item Value flashing in NEU PV when module is loaded.
  - It's caused by CT's Item.getLore() called, it somehow interferes with other mods.