### PR TITLE
feat: Added option to see price per T1 attribute level in the auctioned Attribute Shard's lore

### DIFF
--- a/constants/javaTypes.js
+++ b/constants/javaTypes.js
@@ -6,3 +6,4 @@ export const EntityFireworkRocket = Java.type("net.minecraft.entity.item.EntityF
 export const GuiInventory = Java.type("net.minecraft.client.gui.inventory.GuiInventory");
 export const GuiChat = Java.type("net.minecraft.client.gui.GuiChat");
 export const EntityJoinWorldEvent = Java.type("net.minecraftforge.event.entity.EntityJoinWorldEvent");
+export const NBTTagString = Java.type("net.minecraft.nbt.NBTTagString");

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -7,9 +7,9 @@ Released: ???
 Features:
 
 - Added option to reset Fishing Profit Tracker, Rare Catches Tracker, Crimson Isle Tracker, Jerry Workshop Tracker on closing the game. [disabled by default]
+- Added option to see price per T1 attribute level in the auctioned Attribute Shard's lore, based on item's price (e.g. for T3 shard it shows its price divided by 4). Helps to compare prices for high-tier attribute shards on AH. [disabled by default]
 - Changed output of /feeshGearCraftPrices command, now it shows price per base item.
 - Changed output of /feeshPetLevelUpPrices command, now it considers that Reindeer requires 2x less time to level up.
-
 
 ## v1.23.0
 

--- a/features/inventory/highlightAttributeFusionMatchingItems.js
+++ b/features/inventory/highlightAttributeFusionMatchingItems.js
@@ -1,4 +1,5 @@
 import settings from "../../settings";
+import { getItemAttributes } from "../../utils/common";
 import { isInSkyblock } from "../../utils/playerState";
 
 const CRIMSON_ARMOR_NAMES = [
@@ -60,24 +61,13 @@ function highlightAttributeFusionMatchingItems(slot, gui) {
     var targetItemAttributes = getItemAttributes(targetItem);
     var inventoryItemAttributes = getItemAttributes(item);
 
-    if (targetItemAttributes.some(a => inventoryItemAttributes.includes(a))) {
+    if (haveSameAttribute(targetItemAttributes, inventoryItemAttributes)) {
         Renderer.drawRect(Renderer.color(0, 255, 0, 150), slot.getDisplayX(), slot.getDisplayY(), 16, 16);
     }
 }
 
-function getItemAttributes(item) {
-    const itemAttributes = item?.getNBT()?.getCompoundTag('tag')?.getCompoundTag('ExtraAttributes')?.getCompoundTag('attributes')?.toObject();
-    if (!itemAttributes) {
-        return [];
-    }
-
-    var stringifiedAttributes = [];
-    Object.keys(itemAttributes).sort().forEach(attributeCode => {
-        const attributeLevel = itemAttributes[attributeCode];
-        stringifiedAttributes.push(`${attributeCode.toLowerCase()}:${attributeLevel}`);
-    });
-
-    return stringifiedAttributes;
+function haveSameAttribute(itemAttributes1, itemAttributes2) {
+    return itemAttributes1.some(a1 => itemAttributes2.some(a2 => a2.attributeCode === a1.attributeCode && a2.attributeLevel === a1.attributeLevel));
 }
 
 // ID examples: FIERY_CRIMSON_CHESTPLATE, AURORA_HELMET, etc.

--- a/features/inventory/showArmorAttributes.js
+++ b/features/inventory/showArmorAttributes.js
@@ -1,6 +1,7 @@
 import settings from "../../settings";
 import { BOLD, GREEN, WHITE } from "../../constants/formatting";
 import { isInSkyblock } from "../../utils/playerState";
+import { getItemAttributes } from "../../utils/common";
 
 register('renderItemIntoGui', (item, x, y, event) => {
     showArmorAttributes(item, x, y);
@@ -33,22 +34,18 @@ function showArmorAttributes(item, x, y) {
         return;
     }
 
-    const attributes = item.getNBT()?.getCompoundTag('tag')?.getCompoundTag('ExtraAttributes')?.getCompoundTag('attributes')?.toObject();
-    if (!attributes) {
+    const highlightedAttributeCodesString = isFishingGear ? (settings.accentedFishingArmorAttributes || '') : (settings.accentedCrimsonArmorAttributes || '');
+    const highlightedAttributeCodes = highlightedAttributeCodesString.split(',');
+
+    const itemAttributes = getItemAttributes(item);
+    if (!itemAttributes || !itemAttributes.length) {
         return;
     }
 
     let attributeAbbreviations = [];
-    const highlightedAttributeCodesString = isFishingGear ? (settings.accentedFishingArmorAttributes || '') : (settings.accentedCrimsonArmorAttributes || '');
-    const highlightedAttributeCodes = highlightedAttributeCodesString.split(',');
-
-    Object.keys(attributes).sort().forEach(attributeCode => {
-        const attributeLevel = attributes[attributeCode];
-        if (attributeCode === 'mending') {
-            attributeCode = 'vitality';
-        }
-        const color = highlightedAttributeCodes.includes(attributeCode) ? GREEN + BOLD : WHITE + BOLD;
-        const attributeAbbreviation = `${color}${attributeCode.split('_', 2).map(a => a.substring(0, 1).toUpperCase()).join('')}${attributeLevel}`;
+    itemAttributes.forEach(attribute => {
+        const color = highlightedAttributeCodes.includes(attribute.attributeCode) ? GREEN + BOLD : WHITE + BOLD;
+        const attributeAbbreviation = `${color}${attribute.attributeCode.split('_', 2).map(a => a.substring(0, 1).toUpperCase()).join('')}${attribute.attributeLevel}`;
         attributeAbbreviations.push(attributeAbbreviation);
     });
 

--- a/features/inventory/showFishingRodAttributes.js
+++ b/features/inventory/showFishingRodAttributes.js
@@ -1,5 +1,6 @@
 import { BOLD, GREEN, WHITE } from "../../constants/formatting";
 import settings from "../../settings";
+import { getItemAttributes } from "../../utils/common";
 import { isInSkyblock } from "../../utils/playerState";
 
 register('renderItemIntoGui', (item, x, y, event) => {
@@ -24,19 +25,18 @@ function showFishingRodAttributes(item, x, y) {
         return;
     }
 
-    const attributes = item.getNBT()?.getCompoundTag('tag')?.getCompoundTag('ExtraAttributes')?.getCompoundTag('attributes')?.toObject();
-    if (!attributes) {
+    const highlightedAttributeCodesString = settings.accentedFishingRodAttributes || '';
+    const highlightedAttributeCodes = highlightedAttributeCodesString.split(',');
+
+    const itemAttributes = getItemAttributes(item);
+    if (!itemAttributes || !itemAttributes.length) {
         return;
     }
 
     let attributeAbbreviations = [];
-    const highlightedAttributeCodesString = settings.accentedFishingRodAttributes || '';
-    const highlightedAttributeCodes = highlightedAttributeCodesString.split(',');
-
-    Object.keys(attributes).sort().forEach(attributeCode => {
-        const attributeLevel = attributes[attributeCode];
-        const color = highlightedAttributeCodes.includes(attributeCode) ? GREEN + BOLD : WHITE + BOLD;
-        const attributeAbbreviation = `${color}${attributeCode.split('_', 2).map(a => a.substring(0, 1).toUpperCase()).join('')}${attributeLevel}`;
+    itemAttributes.forEach(attribute => {
+        const color = highlightedAttributeCodes.includes(attribute.attributeCode) ? GREEN + BOLD : WHITE + BOLD;
+        const attributeAbbreviation = `${color}${attribute.attributeCode.split('_', 2).map(a => a.substring(0, 1).toUpperCase()).join('')}${attribute.attributeLevel}`;
         attributeAbbreviations.push(attributeAbbreviation);
     });
 

--- a/features/inventory/showPricePerT1Shard.js
+++ b/features/inventory/showPricePerT1Shard.js
@@ -1,0 +1,40 @@
+import settings from "../../settings";
+import { getItemAttributes, addLineToLore, getLore, toShortNumber } from "../../utils/common";
+import { isInSkyblock } from "../../utils/playerState";
+
+register("itemTooltip", (lore, item) => {
+    if (!item || !isInSkyblock() || !settings.showPricePerT1Attribute) {
+        return;
+    }
+
+    const currentGui = Player.getContainer()?.getName()?.toLowerCase();
+    if (!currentGui?.includes("auctions") && !currentGui?.includes("auction view") && !currentGui?.includes("confirm purchase")) {
+        return;
+    }
+
+    if (item.getName()?.removeFormatting() !== 'Attribute Shard') {
+        return;
+    }
+
+    const itemAttributes = getItemAttributes(item);
+    if (!itemAttributes || !itemAttributes.length) {
+        return;
+    }
+
+    const attributeLevel = itemAttributes[0]?.attributeLevel;
+    if (!attributeLevel) {
+        return;
+    }
+
+    const t1ShardsCount = Math.pow(2, attributeLevel - 1);
+    const priceLine = getLore(item)?.find(loreLine => loreLine?.removeFormatting().startsWith('Buy it now: ') || loreLine?.removeFormatting().startsWith('Top bid: ') || loreLine?.removeFormatting().startsWith('Starting bid: '));
+
+    if (!priceLine) {
+        return;
+    }
+
+    const priceStr = priceLine.removeFormatting()?.replace(/[^0-9]/g, '');
+    const pricePerT1Shard = Math.floor(+priceStr / t1ShardsCount);
+
+    addLineToLore(item, `§r§6Price per T1 attribute: `, `§r§7${toShortNumber(pricePerT1Shard)} coins`);
+});

--- a/index.js
+++ b/index.js
@@ -35,6 +35,7 @@ import "./features/inventory/showArmorAttributes";
 import "./features/inventory/showFishingRodAttributes";
 import "./features/inventory/showRarityUpgrade";
 import "./features/inventory/highlightAttributeFusionMatchingItems";
+import "./features/inventory/showPricePerT1Shard";
 
 import "./features/chat/announceMobSpawnToAllChat";
 import "./features/chat/messageOnPlayerDeath";

--- a/settings.js
+++ b/settings.js
@@ -1213,6 +1213,16 @@ ${RED}Hidden if you have no fishing rod in your hotbar!`,
     })
     accentedFishingRodAttributes = 'double_hook,fishing_speed,trophy_hunter';
 
+    // ******* INVENTORY - Item lore ******* //
+
+    @SwitchProperty({
+        name: "Price per T1 attribute shard",
+        description: `Render price per T1 attribute level in the auctioned Attribute Shard's lore, based on item's price. Helps to compare prices for high-tier attribute shards on AH.`,
+        category: "Inventory",
+        subcategory: "Item lore"
+    })
+    showPricePerT1Attribute = false;
+
     // ******* COMMANDS ******* //
 
     @ButtonProperty({

--- a/utils/common.js
+++ b/utils/common.js
@@ -1,4 +1,5 @@
 import { RED, DARK_GRAY, BLUE, WHITE, BOLD, RESET } from '../constants/formatting';
+import { NBTTagString } from '../constants/javaTypes';
 
 // Double hook reindrakes may produce the following messages history:
 // [CHAT] &r&eIt's a &r&aDouble Hook&r&e!&r
@@ -298,6 +299,49 @@ export function getLore(item) {
 	}
 
     return item.getNBT().getCompoundTag('tag')?.getCompoundTag('display')?.toObject()?.Lore || [];
+}
+
+// Credits VolcAddons
+// Adds a line combined from prefix and value, to the item's lore.
+export function addLineToLore(item, prefix, value) {
+	let loreLine = prefix + value;
+
+	const loreTag = item.getNBT()?.getCompoundTag('tag')?.getCompoundTag('display')?.getTagMap()?.get('Lore');
+	if (!loreTag) {
+		return;
+	}
+
+	const list = new NBTTagList(loreTag);
+
+	for (let i = 0; i < list.getTagCount(); i++) {
+		if (list.getStringTagAt(i).includes(prefix)) {
+			list.set(i, new NBTTagString(loreLine));
+			return;
+		}
+	}
+
+	list.appendTag(new NBTTagString(loreLine));
+}
+
+// Returns attributes array in format { "attributeCode": "life_regeneration", "attributeLevel|: 5 }
+export function getItemAttributes(item) {
+	if (!item) {
+		return [];
+	}
+
+    const itemAttributes = item?.getNBT()?.getCompoundTag('tag')?.getCompoundTag('ExtraAttributes')?.getCompoundTag('attributes')?.toObject();
+    if (!itemAttributes) {
+        return [];
+    }
+
+    var attributes = [];
+    Object.keys(itemAttributes).sort().forEach(attributeCode => {
+        const level = itemAttributes[attributeCode];
+		const code = attributeCode === 'mending' ? 'vitality' : attributeCode.toLowerCase();
+		attributes.push({ attributeCode: code, attributeLevel: level });
+    });
+
+    return attributes;
 }
 
 function getArticle(str) {


### PR DESCRIPTION
Added option to see price per T1 attribute level in the auctioned Attribute Shard's lore, based on item's price (e.g. for T3 shard it shows its price divided by 4). Helps to compare prices for high-tier attribute shards on AH. [disabled by default]

Also, reused attributes extraction logic between all functionalities.