### PR TITLE
fix: Fixed wrong pet profit sorting of /feeshPetLevelUpPrices command

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 Released: ???
 
-
+- Fixed wrong pet profit sorting of /feeshPetLevelUpPrices command.
 
 ## v1.25.0
 

--- a/features/commands/calculateFishingPetsPrices.js
+++ b/features/commands/calculateFishingPetsPrices.js
@@ -66,12 +66,14 @@ export function calculateFishingPetPrices() {
             const level100AuctionPrices = getAuctionItemPrices(level100ItemId);
             const level100Price = level100AuctionPrices?.lbin || 0;
 
+            const diff =  level1Price && level100Price ? level100Price - level1Price : 0;
+
             return {
                 petDisplayName: pet.petDisplayName,
                 level1Price: level1Price,
                 level100Price: level100Price,
-                coinsPerXp: (level100Price / MAX_XP) * pet.xpGainMultiplier,
-                diff: level1Price && level100Price ? level100Price - level1Price : 0
+                coinsPerXp: diff ? (diff / MAX_XP) * pet.xpGainMultiplier : 0,
+                diff: diff
             };       
         }).sort((a, b) => b.coinsPerXp - a.coinsPerXp);
 


### PR DESCRIPTION
Fixed wrong pet profit sorting of /feeshPetLevelUpPrices command.