### PR TITLE
fix: Added NPC sell price to Speckled Teacup in Fishing Profit Tracker

### DIFF
--- a/constants/fishingProfitItems.js
+++ b/constants/fishingProfitItems.js
@@ -1586,7 +1586,7 @@ export const FISHING_PROFIT_ITEMS = [
         itemId: 'SPECKLED_TEACUP',
         itemName: 'Speckled Teacup',
         itemDisplayName: `${SPECIAL}Speckled Teacup`,
-        npcPrice: 0,
+        npcPrice: 100000,
     },
 
     // Runes

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -5,6 +5,7 @@
 Released: ???
 
 - Fixed wrong pet profit sorting of /feeshPetLevelUpPrices command.
+- Added NPC sell price to Speckled Teacup in Fishing Profit Tracker.
 
 ## v1.25.0
 


### PR DESCRIPTION
Added NPC sell price to Speckled Teacup in Fishing Profit Tracker.