### PR TITLE
Revert "fix: Fixed items counting in the fishing profit tracker when dropped but drop was prevented by Hypixel"

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -4,11 +4,7 @@
 
 Released: ???
 
-Features:
 - Added 2 variations of the Beach Balls and Golden Bait to the fishing profit tracker.
-
-Bugfixes:
-- Fixed items counting in the fishing profit tracker when dropped but drop was prevented by Hypixel (basically it gets dropped and insta-picked up again).
 
 ## v1.26.0
 

--- a/docs/Future ideas & requests.md
+++ b/docs/Future ideas & requests.md
@@ -1,4 +1,5 @@
 - Offer supercrafting or bazaar when items like raw fish goes to inventory (sacks are full)
+- Some items are tracked by profit tracker when dropped, but drop was prevented by SB settings (basically it drops and picks up again).
 - Calculate pet price in profit tracker as difference between lvl 1 and lvl 100
 - Remove double hook reindrake logic because DH is not possible now
 - Probably remove calculation of profits in Pulse Rings

--- a/features/overlays/fishingProfitTracker.js
+++ b/features/overlays/fishingProfitTracker.js
@@ -9,7 +9,7 @@ import { EntityFishHook } from "../../constants/javaTypes";
 import { getAuctionItemPrices, getPetRarityCode } from "../../utils/auctionPrices";
 import { getBazaarItemPrices } from "../../utils/bazaarPrices";
 import { formatElapsedTime, getCleanItemName, getItemsAddedToSacks, getLore, isInChatOrInventoryGui, isInSacksGui, isInSupercraftGui, splitArray, toShortNumber } from "../../utils/common";
-import { getLastGuisClosed, getLastItemDropped, getLastKatUpgrade, getWorldName, hasFishingRodInHotbar, isInSkyblock } from "../../utils/playerState";
+import { getLastGuisClosed, getLastKatUpgrade, getWorldName, hasFishingRodInHotbar, isInSkyblock } from "../../utils/playerState";
 import { playRareDropSound } from '../../utils/sound';
 
 let isVisible = false;
@@ -638,11 +638,6 @@ function detectInventoryChanges() {
         const lastKatUpgrade = getLastKatUpgrade(); // Ignore pets that are claimed from Kat
         if (lastKatUpgrade.lastPetClaimedAt && new Date() - lastKatUpgrade.lastPetClaimedAt < 7 * 1000 &&
             item.itemDisplayName.removeFormatting().includes(lastKatUpgrade.petDisplayName?.removeFormatting())) { 
-            return true;
-        }
-
-        const lastItemDropped = getLastItemDropped();
-        if (lastItemDropped && new Date() - lastItemDropped < 500) { // Sometimes Hypixel prevents dropping an item, so it drops and returns back to inventory
             return true;
         }
 

--- a/utils/playerState.js
+++ b/utils/playerState.js
@@ -6,8 +6,6 @@ var hasDirtRodInHand = false;
 var worldName = null;
 var isInHunterArmor = false;
 
-var lastItemDropped = null;
-
 var lastKatUpgrade = {
 	lastPetClaimedAt: null,
 	petDisplayName: null
@@ -77,10 +75,6 @@ register("guiClosed", (gui) => {
 	}).setCriteria(entry); 
 });
 
-register('dropItem', () => {
-	lastItemDropped = new Date();
-});
-
 export function isInSkyblock() {
 	return isInSkyblock;
 }
@@ -107,10 +101,6 @@ export function getLastGuisClosed() {
 
 export function getLastKatUpgrade() {
 	return lastKatUpgrade;
-}
-
-export function getLastItemDropped() {
-	return lastItemDropped;
 }
 
 function setIsInSkyblock() {


### PR DESCRIPTION
Reverts Sleepy-Panda/FeeshNotifier#55

Revert because drop item event triggers weirdly when switching between GUIs