### PR TITLE
fix: Fixed NEU slot binding causing inventory items counting into fishing profit tracker

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -4,7 +4,11 @@
 
 Released: ???
 
+Features:
 - Added 2 variations of the Beach Balls and Golden Bait to the fishing profit tracker.
+
+Bugfixes:
+- Fixed NEU slot binding causing inventory items counting into fishing profit tracker (because it replaces inventory items with Barriers while trying to bind a slot).
 
 ## v1.26.0
 

--- a/features/overlays/fishingProfitTracker.js
+++ b/features/overlays/fishingProfitTracker.js
@@ -498,6 +498,11 @@ function detectInventoryChanges() {
             }
         }
 
+        const hasBarrier = (Player?.getInventory()?.getItems() || []).find(i => i?.getName() === 'Barrier'); // NEU slot binding replaces inventory items with Barriers
+        if (hasBarrier) {
+            return;
+        }
+        
         const currentInventory = getFishingProfitItemsInCurrentInventory();
 
         let isInChest = Client.isInGui() && Client.currentGui?.getClassName() === 'GuiChest';


### PR DESCRIPTION
Fixed NEU slot binding causing inventory items counting into fishing profit tracker (because it replaces inventory items with Barriers while trying to bind a slot).