### PR TITLE
feat: Added option to show fishing rod's expertise kills in the lore

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -6,6 +6,7 @@ Released: ???
 
 Features:
 - Added 2 variations of the Beach Balls and Golden Bait to the fishing profit tracker.
+- Added option to show fishing rod's expertise kills in the lore. [disabled by default] 
 
 Bugfixes:
 - Fixed NEU slot binding causing inventory items counting into fishing profit tracker (because it replaces inventory items with Barriers while trying to bind a slot).

--- a/features/alerts/alertOnNonFishingArmor.js
+++ b/features/alerts/alertOnNonFishingArmor.js
@@ -4,7 +4,7 @@ import { getWorldName, hasFishingRodInHotbar, isInSkyblock } from "../../utils/p
 import { OFF_SOUND_MODE } from "../../constants/sounds";
 import { DUNGEONS, KUUDRA } from "../../constants/areas";
 import { EntityFishHook } from "../../constants/javaTypes";
-import { getLore } from "../../utils/common";
+import { getLore, isFishingRod } from "../../utils/common";
 
 let lastHookDetectedAt = null;
 
@@ -37,7 +37,7 @@ function alertOnNonFishingArmor(event) {
         // Time for hook to land on water/lava
         setTimeout(function() {
             const heldItem = Player.getHeldItem();
-            if (heldItem?.getName()?.includes('Carnival Rod')) {
+            if (!isFishingRod(heldItem)) {
                 return;
             }
             

--- a/features/inventory/showExpertiseKills.js
+++ b/features/inventory/showExpertiseKills.js
@@ -1,0 +1,27 @@
+import settings from "../../settings";
+import { addLineToLore, isFishingRod, toShortNumber } from "../../utils/common";
+import { isInSkyblock } from "../../utils/playerState";
+
+register("itemTooltip", (lore, item) => showFishingRodExpertiseKills(item));
+
+function showFishingRodExpertiseKills(item) {
+    if (!item || !isInSkyblock() || !settings.showFishingRodExpertiseKills || !isFishingRod(item)) {
+        return;
+    }
+
+    const nbtExtraAttributes = item.getNBT()?.getCompoundTag('tag')?.getCompoundTag('ExtraAttributes');
+    if (!nbtExtraAttributes) {
+        return;
+    }
+
+    const enchantments = nbtExtraAttributes.getCompoundTag('enchantments')?.toObject();
+    if (!enchantments || !enchantments['expertise']) {
+        return;
+    }
+
+    const expertise = nbtExtraAttributes.getInteger('expertise_kills');
+    if (expertise || expertise === 0) {
+        const isMaxed = expertise > 15000;
+        addLineToLore(item, `§r§6Expertise kills: `, `§r§7${toShortNumber(expertise)} / 15K${isMaxed ? ' (Maxed)' : ''}`);
+    }
+}

--- a/features/overlays/fishingProfitTracker.js
+++ b/features/overlays/fishingProfitTracker.js
@@ -8,7 +8,7 @@ import { AQUA, BOLD, GOLD, GRAY, RESET, WHITE, YELLOW, RED, GREEN, BLUE } from "
 import { EntityFishHook } from "../../constants/javaTypes";
 import { getAuctionItemPrices, getPetRarityCode } from "../../utils/auctionPrices";
 import { getBazaarItemPrices } from "../../utils/bazaarPrices";
-import { formatElapsedTime, getCleanItemName, getItemsAddedToSacks, getLore, isInChatOrInventoryGui, isInSacksGui, isInSupercraftGui, splitArray, toShortNumber } from "../../utils/common";
+import { formatElapsedTime, getCleanItemName, getItemsAddedToSacks, getLore, isFishingRod, isInChatOrInventoryGui, isInSacksGui, isInSupercraftGui, splitArray, toShortNumber } from "../../utils/common";
 import { getLastGuisClosed, getLastKatUpgrade, getWorldName, hasFishingRodInHotbar, isInSkyblock } from "../../utils/playerState";
 import { playRareDropSound } from '../../utils/sound';
 
@@ -197,7 +197,7 @@ function activateSessionOnPlayersFishingHook() {
         }
     
         const heldItem = Player.getHeldItem();
-        if (heldItem?.getName()?.includes('Carnival Rod')) {
+        if (!isFishingRod(heldItem)) {
             return;
         }
 

--- a/index.js
+++ b/index.js
@@ -36,6 +36,7 @@ import "./features/inventory/showFishingRodAttributes";
 import "./features/inventory/showRarityUpgrade";
 import "./features/inventory/highlightAttributeFusionMatchingItems";
 import "./features/inventory/showPricePerT1Shard";
+import "./features/inventory/showExpertiseKills";
 
 import "./features/chat/announceMobSpawnToAllChat";
 import "./features/chat/messageOnPlayerDeath";

--- a/settings.js
+++ b/settings.js
@@ -1216,6 +1216,14 @@ ${RED}Hidden if you have no fishing rod in your hotbar!`,
     // ******* INVENTORY - Item lore ******* //
 
     @SwitchProperty({
+        name: "Fishing rod expertise",
+        description: `Render expertise kills in fishing rod's lore if it has Expertise enchant.`,
+        category: "Inventory",
+        subcategory: "Item lore"
+    })
+    showFishingRodExpertiseKills = false;
+
+    @SwitchProperty({
         name: "Price per T1 attribute shard",
         description: `Render price per T1 attribute level in the auctioned Attribute Shard's lore, based on item's price. Helps to compare prices for high-tier attribute shards on AH.`,
         category: "Inventory",

--- a/utils/common.js
+++ b/utils/common.js
@@ -289,6 +289,17 @@ export function getCleanItemName(itemName) {
 }
 
 /**
+ * Checks if an item is a fishing rod.
+ * @param {Item} item
+ * @returns {boolean}
+ */
+export function isFishingRod(item) {
+	if (!item) return;
+    const isRod = (!item.getName()?.includes('Carnival Rod') && getLore(item).some(loreLine => loreLine.includes('FISHING ROD') || loreLine.includes('FISHING WEAPON')));
+	return isRod;
+}
+
+/**
  * Formats time elapsed between two dates in days, hours and minutes. Examples: "2d 8h 5m" or "less than 1m"
  * @param {Date} dateFrom - Earlier date
  * @param {Date} dateTo - Later date
@@ -337,7 +348,6 @@ export function getLore(item) {
  * @param {string} prefix - String key to decide whether the line is already present in item's lore
  * @param {string} value - String value
  */
-
 export function addLineToLore(item, prefix, value) {
 	let loreLine = prefix + value;
 

--- a/utils/playerState.js
+++ b/utils/playerState.js
@@ -1,4 +1,4 @@
-import { getLore } from "./common";
+import { isFishingRod } from "./common";
 
 var isInSkyblock = false;
 var hasFishingRodInHotbar = false;
@@ -133,7 +133,7 @@ function setHasFishingRodInHotbar() {
 	if (!hotbarItems || !hotbarItems.length) {
 		hasFishingRodInHotbar = false;
 	} else {
-		const rods = hotbarItems.filter(i => i && !i.getName()?.includes('Carnival Rod') && getLore(i).some(loreLine => loreLine.includes('FISHING ROD') || loreLine.includes('FISHING WEAPON')));
+		const rods = hotbarItems.filter(i => i && isFishingRod(i));
 		hasFishingRodInHotbar = rods && rods.length;	
 	}
 }


### PR DESCRIPTION
Added option to show fishing rod's expertise kills in the lore. [disabled by default] 