### PR TITLE
Release 1.27.0

### DIFF
--- a/constants/fishingProfitItems.js
+++ b/constants/fishingProfitItems.js
@@ -408,6 +408,12 @@ export const FISHING_PROFIT_ITEMS = [
         npcPrice: 25,
     },
     {
+        itemId: 'GOLDEN_BAIT',
+        itemName: 'Golden Bait',
+        itemDisplayName: `${UNCOMMON}Golden Bait`,
+        npcPrice: 10,
+    },
+    {
         itemId: 'WHALE_BAIT',
         itemName: 'Whale Bait',
         itemDisplayName: `${RARE}Whale Bait`,
@@ -495,6 +501,18 @@ export const FISHING_PROFIT_ITEMS = [
         itemId: 'ESSENCE_ICE',
         itemName: 'Ice Essence',
         itemDisplayName: `${UNCOMMON}Ice Essence`,
+        npcPrice: 0,
+    },
+    {
+        itemId: 'BOUNCY_BEACH_BALL',
+        itemName: 'Bouncy Beach Ball',
+        itemDisplayName: `${EPIC}Bouncy Beach Ball`,
+        npcPrice: 0,
+    },
+    {
+        itemId: 'GIANT_BOUNCY_BEACH_BALL',
+        itemName: 'Giant Bouncy Beach Ball',
+        itemDisplayName: `${LEGENDARY}Giant Bouncy Beach Ball`,
         npcPrice: 0,
     },
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -4,7 +4,11 @@
 
 Released: ???
 
+Features:
 - Added 2 variations of the Beach Balls and Golden Bait to the fishing profit tracker.
+
+Bugfixes:
+- Fixed items counting in the fishing profit tracker when dropped but drop was prevented by Hypixel (basically it gets dropped and insta-picked up again).
 
 ## v1.26.0
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -4,7 +4,11 @@
 
 Released: ???
 
+Features:
 - Added 2 variations of the Beach Balls and Golden Bait to the fishing profit tracker.
+
+Bugfixes:
+- Fixed NEU slot binding causing inventory items counting into fishing profit tracker (because it replaces inventory items with Barriers while trying to bind a slot).
 
 ## v1.26.0
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Releases
 
+## v1.27.0
+
+Released: ???
+
 ## v1.26.0
 
 Released: 2025-01-31

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -6,6 +6,7 @@ Released: ???
 
 Features:
 - Added 2 variations of the Beach Balls and Golden Bait to the fishing profit tracker.
+- Added option to show fishing rod's expertise kills in the lore. [disabled by default] 
 
 Bugfixes:
 - Fixed NEU slot binding causing inventory items counting into fishing profit tracker (because it replaces inventory items with Barriers while trying to bind a slot).

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 Released: ???
 
+- Added 2 variations of the Beach Balls and Golden Bait to the fishing profit tracker.
+
 ## v1.26.0
 
 Released: 2025-01-31

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -4,11 +4,7 @@
 
 Released: ???
 
-Features:
 - Added 2 variations of the Beach Balls and Golden Bait to the fishing profit tracker.
-
-Bugfixes:
-- Fixed items counting in the fishing profit tracker when dropped but drop was prevented by Hypixel (basically it gets dropped and insta-picked up again).
 
 ## v1.26.0
 

--- a/docs/Future ideas & requests.md
+++ b/docs/Future ideas & requests.md
@@ -24,7 +24,6 @@
   - Ability to open folder from settings
   - Ability to test sound from settings
   - Toggle setting to enable customization
-- Sea creatures/hour
 - Render mob immunity flag
 - Highlight rare sea creatures
 - Short catch messages and double hook messages
@@ -33,7 +32,7 @@
 - Multiple drops that happen at the same time lead to "You're sending messages too fast" error.
 - Personal cap alert (20 for CH, 5 for Crimson)
 - Expertise widget
-- Fishing XP tracker
+- Fishing XP tracker, skill level tracking above fishing 60
 - Attach Vials drop number to the pchat message
 - Track all mobs caught, not only rare
 - Golden fish timer

--- a/docs/Future ideas & requests.md
+++ b/docs/Future ideas & requests.md
@@ -1,5 +1,4 @@
 - Offer supercrafting or bazaar when items like raw fish goes to inventory (sacks are full)
-- Some items are tracked by profit tracker when dropped, but drop was prevented by SB settings (basically it drops and picks up again).
 - Calculate pet price in profit tracker as difference between lvl 1 and lvl 100
 - Remove double hook reindrake logic because DH is not possible now
 - Probably remove calculation of profits in Pulse Rings

--- a/docs/Future ideas & requests.md
+++ b/docs/Future ideas & requests.md
@@ -1,4 +1,5 @@
 - Offer supercrafting or bazaar when items like raw fish goes to inventory (sacks are full)
+- Some items are tracked by profit tracker when dropped, but drop was prevented by SB settings (basically it drops and picks up again).
 - Calculate pet price in profit tracker as difference between lvl 1 and lvl 100
 - Remove double hook reindrake logic because DH is not possible now
 - Probably remove calculation of profits in Pulse Rings

--- a/features/alerts/alertOnNonFishingArmor.js
+++ b/features/alerts/alertOnNonFishingArmor.js
@@ -4,7 +4,7 @@ import { getWorldName, hasFishingRodInHotbar, isInSkyblock } from "../../utils/p
 import { OFF_SOUND_MODE } from "../../constants/sounds";
 import { DUNGEONS, KUUDRA } from "../../constants/areas";
 import { EntityFishHook } from "../../constants/javaTypes";
-import { getLore } from "../../utils/common";
+import { getLore, isFishingRod } from "../../utils/common";
 
 let lastHookDetectedAt = null;
 
@@ -37,7 +37,7 @@ function alertOnNonFishingArmor(event) {
         // Time for hook to land on water/lava
         setTimeout(function() {
             const heldItem = Player.getHeldItem();
-            if (heldItem?.getName()?.includes('Carnival Rod')) {
+            if (!isFishingRod(heldItem)) {
                 return;
             }
             

--- a/features/inventory/showExpertiseKills.js
+++ b/features/inventory/showExpertiseKills.js
@@ -1,0 +1,27 @@
+import settings from "../../settings";
+import { addLineToLore, isFishingRod, toShortNumber } from "../../utils/common";
+import { isInSkyblock } from "../../utils/playerState";
+
+register("itemTooltip", (lore, item) => showFishingRodExpertiseKills(item));
+
+function showFishingRodExpertiseKills(item) {
+    if (!item || !isInSkyblock() || !settings.showFishingRodExpertiseKills || !isFishingRod(item)) {
+        return;
+    }
+
+    const nbtExtraAttributes = item.getNBT()?.getCompoundTag('tag')?.getCompoundTag('ExtraAttributes');
+    if (!nbtExtraAttributes) {
+        return;
+    }
+
+    const enchantments = nbtExtraAttributes.getCompoundTag('enchantments')?.toObject();
+    if (!enchantments || !enchantments['expertise']) {
+        return;
+    }
+
+    const expertise = nbtExtraAttributes.getInteger('expertise_kills');
+    if (expertise || expertise === 0) {
+        const isMaxed = expertise > 15000;
+        addLineToLore(item, `§r§6Expertise kills: `, `§r§7${toShortNumber(expertise)} / 15K${isMaxed ? ' (Maxed)' : ''}`);
+    }
+}

--- a/features/overlays/fishingProfitTracker.js
+++ b/features/overlays/fishingProfitTracker.js
@@ -9,7 +9,7 @@ import { EntityFishHook } from "../../constants/javaTypes";
 import { getAuctionItemPrices, getPetRarityCode } from "../../utils/auctionPrices";
 import { getBazaarItemPrices } from "../../utils/bazaarPrices";
 import { formatElapsedTime, getCleanItemName, getItemsAddedToSacks, getLore, isInChatOrInventoryGui, isInSacksGui, isInSupercraftGui, splitArray, toShortNumber } from "../../utils/common";
-import { getLastGuisClosed, getLastItemDropped, getLastKatUpgrade, getWorldName, hasFishingRodInHotbar, isInSkyblock } from "../../utils/playerState";
+import { getLastGuisClosed, getLastKatUpgrade, getWorldName, hasFishingRodInHotbar, isInSkyblock } from "../../utils/playerState";
 import { playRareDropSound } from '../../utils/sound';
 
 let isVisible = false;
@@ -638,11 +638,6 @@ function detectInventoryChanges() {
         const lastKatUpgrade = getLastKatUpgrade(); // Ignore pets that are claimed from Kat
         if (lastKatUpgrade.lastPetClaimedAt && new Date() - lastKatUpgrade.lastPetClaimedAt < 7 * 1000 &&
             item.itemDisplayName.removeFormatting().includes(lastKatUpgrade.petDisplayName?.removeFormatting())) { 
-            return true;
-        }
-
-        const lastItemDropped = getLastItemDropped();
-        if (lastItemDropped && new Date() - lastItemDropped < 500) { // Sometimes Hypixel prevents dropping an item, so it drops and returns back to inventory
             return true;
         }
 

--- a/features/overlays/fishingProfitTracker.js
+++ b/features/overlays/fishingProfitTracker.js
@@ -9,7 +9,7 @@ import { EntityFishHook } from "../../constants/javaTypes";
 import { getAuctionItemPrices, getPetRarityCode } from "../../utils/auctionPrices";
 import { getBazaarItemPrices } from "../../utils/bazaarPrices";
 import { formatElapsedTime, getCleanItemName, getItemsAddedToSacks, getLore, isInChatOrInventoryGui, isInSacksGui, isInSupercraftGui, splitArray, toShortNumber } from "../../utils/common";
-import { getLastGuisClosed, getLastKatUpgrade, getWorldName, hasFishingRodInHotbar, isInSkyblock } from "../../utils/playerState";
+import { getLastGuisClosed, getLastItemDropped, getLastKatUpgrade, getWorldName, hasFishingRodInHotbar, isInSkyblock } from "../../utils/playerState";
 import { playRareDropSound } from '../../utils/sound';
 
 let isVisible = false;
@@ -638,6 +638,11 @@ function detectInventoryChanges() {
         const lastKatUpgrade = getLastKatUpgrade(); // Ignore pets that are claimed from Kat
         if (lastKatUpgrade.lastPetClaimedAt && new Date() - lastKatUpgrade.lastPetClaimedAt < 7 * 1000 &&
             item.itemDisplayName.removeFormatting().includes(lastKatUpgrade.petDisplayName?.removeFormatting())) { 
+            return true;
+        }
+
+        const lastItemDropped = getLastItemDropped();
+        if (lastItemDropped && new Date() - lastItemDropped < 500) { // Sometimes Hypixel prevents dropping an item, so it drops and returns back to inventory
             return true;
         }
 

--- a/features/overlays/fishingProfitTracker.js
+++ b/features/overlays/fishingProfitTracker.js
@@ -498,6 +498,11 @@ function detectInventoryChanges() {
             }
         }
 
+        const hasBarrier = (Player?.getInventory()?.getItems() || []).find(i => i?.getName() === 'Barrier'); // NEU slot binding replaces inventory items with Barriers
+        if (hasBarrier) {
+            return;
+        }
+        
         const currentInventory = getFishingProfitItemsInCurrentInventory();
 
         let isInChest = Client.isInGui() && Client.currentGui?.getClassName() === 'GuiChest';

--- a/features/overlays/fishingProfitTracker.js
+++ b/features/overlays/fishingProfitTracker.js
@@ -8,7 +8,7 @@ import { AQUA, BOLD, GOLD, GRAY, RESET, WHITE, YELLOW, RED, GREEN, BLUE } from "
 import { EntityFishHook } from "../../constants/javaTypes";
 import { getAuctionItemPrices, getPetRarityCode } from "../../utils/auctionPrices";
 import { getBazaarItemPrices } from "../../utils/bazaarPrices";
-import { formatElapsedTime, getCleanItemName, getItemsAddedToSacks, getLore, isInChatOrInventoryGui, isInSacksGui, isInSupercraftGui, splitArray, toShortNumber } from "../../utils/common";
+import { formatElapsedTime, getCleanItemName, getItemsAddedToSacks, getLore, isFishingRod, isInChatOrInventoryGui, isInSacksGui, isInSupercraftGui, splitArray, toShortNumber } from "../../utils/common";
 import { getLastGuisClosed, getLastKatUpgrade, getWorldName, hasFishingRodInHotbar, isInSkyblock } from "../../utils/playerState";
 import { playRareDropSound } from '../../utils/sound';
 
@@ -197,7 +197,7 @@ function activateSessionOnPlayersFishingHook() {
         }
     
         const heldItem = Player.getHeldItem();
-        if (heldItem?.getName()?.includes('Carnival Rod')) {
+        if (!isFishingRod(heldItem)) {
             return;
         }
 

--- a/index.js
+++ b/index.js
@@ -36,6 +36,7 @@ import "./features/inventory/showFishingRodAttributes";
 import "./features/inventory/showRarityUpgrade";
 import "./features/inventory/highlightAttributeFusionMatchingItems";
 import "./features/inventory/showPricePerT1Shard";
+import "./features/inventory/showExpertiseKills";
 
 import "./features/chat/announceMobSpawnToAllChat";
 import "./features/chat/messageOnPlayerDeath";

--- a/metadata.json
+++ b/metadata.json
@@ -3,7 +3,7 @@
     "entry": "index.js",
     "author": "MoonTheSadFisher",
     "description": "Hypixel Skyblock fishing utilities for parties.",
-    "version": "1.26.0",
+    "version": "1.27.0",
     "requires": [
         "Vigilance",
         "PogData",

--- a/settings.js
+++ b/settings.js
@@ -1216,6 +1216,14 @@ ${RED}Hidden if you have no fishing rod in your hotbar!`,
     // ******* INVENTORY - Item lore ******* //
 
     @SwitchProperty({
+        name: "Fishing rod expertise",
+        description: `Render expertise kills in fishing rod's lore if it has Expertise enchant.`,
+        category: "Inventory",
+        subcategory: "Item lore"
+    })
+    showFishingRodExpertiseKills = false;
+
+    @SwitchProperty({
         name: "Price per T1 attribute shard",
         description: `Render price per T1 attribute level in the auctioned Attribute Shard's lore, based on item's price. Helps to compare prices for high-tier attribute shards on AH.`,
         category: "Inventory",

--- a/utils/common.js
+++ b/utils/common.js
@@ -289,6 +289,17 @@ export function getCleanItemName(itemName) {
 }
 
 /**
+ * Checks if an item is a fishing rod.
+ * @param {Item} item
+ * @returns {boolean}
+ */
+export function isFishingRod(item) {
+	if (!item) return;
+    const isRod = (!item.getName()?.includes('Carnival Rod') && getLore(item).some(loreLine => loreLine.includes('FISHING ROD') || loreLine.includes('FISHING WEAPON')));
+	return isRod;
+}
+
+/**
  * Formats time elapsed between two dates in days, hours and minutes. Examples: "2d 8h 5m" or "less than 1m"
  * @param {Date} dateFrom - Earlier date
  * @param {Date} dateTo - Later date
@@ -337,7 +348,6 @@ export function getLore(item) {
  * @param {string} prefix - String key to decide whether the line is already present in item's lore
  * @param {string} value - String value
  */
-
 export function addLineToLore(item, prefix, value) {
 	let loreLine = prefix + value;
 

--- a/utils/playerState.js
+++ b/utils/playerState.js
@@ -6,8 +6,6 @@ var hasDirtRodInHand = false;
 var worldName = null;
 var isInHunterArmor = false;
 
-var lastItemDropped = null;
-
 var lastKatUpgrade = {
 	lastPetClaimedAt: null,
 	petDisplayName: null
@@ -77,10 +75,6 @@ register("guiClosed", (gui) => {
 	}).setCriteria(entry); 
 });
 
-register('dropItem', () => {
-	lastItemDropped = new Date();
-});
-
 export function isInSkyblock() {
 	return isInSkyblock;
 }
@@ -107,10 +101,6 @@ export function getLastGuisClosed() {
 
 export function getLastKatUpgrade() {
 	return lastKatUpgrade;
-}
-
-export function getLastItemDropped() {
-	return lastItemDropped;
 }
 
 function setIsInSkyblock() {

--- a/utils/playerState.js
+++ b/utils/playerState.js
@@ -6,6 +6,8 @@ var hasDirtRodInHand = false;
 var worldName = null;
 var isInHunterArmor = false;
 
+var lastItemDropped = null;
+
 var lastKatUpgrade = {
 	lastPetClaimedAt: null,
 	petDisplayName: null
@@ -75,6 +77,10 @@ register("guiClosed", (gui) => {
 	}).setCriteria(entry); 
 });
 
+register('dropItem', () => {
+	lastItemDropped = new Date();
+});
+
 export function isInSkyblock() {
 	return isInSkyblock;
 }
@@ -101,6 +107,10 @@ export function getLastGuisClosed() {
 
 export function getLastKatUpgrade() {
 	return lastKatUpgrade;
+}
+
+export function getLastItemDropped() {
+	return lastItemDropped;
 }
 
 function setIsInSkyblock() {

--- a/utils/playerState.js
+++ b/utils/playerState.js
@@ -1,4 +1,4 @@
-import { getLore } from "./common";
+import { isFishingRod } from "./common";
 
 var isInSkyblock = false;
 var hasFishingRodInHotbar = false;
@@ -133,7 +133,7 @@ function setHasFishingRodInHotbar() {
 	if (!hotbarItems || !hotbarItems.length) {
 		hasFishingRodInHotbar = false;
 	} else {
-		const rods = hotbarItems.filter(i => i && !i.getName()?.includes('Carnival Rod') && getLore(i).some(loreLine => loreLine.includes('FISHING ROD') || loreLine.includes('FISHING WEAPON')));
+		const rods = hotbarItems.filter(i => i && isFishingRod(i));
 		hasFishingRodInHotbar = rods && rods.length;	
 	}
 }


### PR DESCRIPTION
Features:
- Added 2 variations of the Beach Balls and Golden Bait to the fishing profit tracker.
- Added option to show fishing rod's expertise kills in the lore. [disabled by default] 

Bugfixes:
- Fixed NEU slot binding causing inventory items counting into fishing profit tracker (because it replaces inventory items with Barriers while trying to bind a slot).
