### PR TITLE
feat: Added option to compact sea creature catch messages

### DIFF
--- a/constants/seaCreatures.js
+++ b/constants/seaCreatures.js
@@ -65,7 +65,7 @@ export const ALL_SEA_CREATURES_NAMES = [
     'Lord Jawbus',
     'Jawbus Follower',
     'Plhlegblast',
-    'Mithril Grubber',
+    'Small Mithril Grubber',
     'Medium Mithril Grubber',
     'Large Mithril Grubber',
     'Bloated Mithril Grubber',

--- a/constants/seaCreatures.js
+++ b/constants/seaCreatures.js
@@ -65,7 +65,7 @@ export const ALL_SEA_CREATURES_NAMES = [
     'Lord Jawbus',
     'Jawbus Follower',
     'Plhlegblast',
-    'Small Mithril Grubber',
+    'Mithril Grubber', // A sea creature is called Small Mithril Grubber, but corrupted one is Corrupted Mithril Grubber (without "Small")
     'Medium Mithril Grubber',
     'Large Mithril Grubber',
     'Bloated Mithril Grubber',

--- a/constants/triggers.js
+++ b/constants/triggers.js
@@ -1,7 +1,7 @@
 import * as drops from './drops';
 import * as sounds from './sounds';
 import * as seaCreatures from './seaCreatures';
-import { GREEN, GOLD, DARK_PURPLE, LIGHT_PURPLE, BLUE, RED, BOLD, RESET, COMMON, RARE, EPIC, LEGENDARY, MYTHIC, GRAY, AQUA, YELLOW, DARK_RED, DARK_AQUA, WHITE, UNCOMMON } from './formatting';
+import { GREEN, GOLD, DARK_PURPLE, LIGHT_PURPLE, BLUE, RED, BOLD, RESET, GRAY, AQUA, YELLOW, DARK_RED, DARK_AQUA, WHITE, COMMON, UNCOMMON, RARE, EPIC, LEGENDARY, MYTHIC } from './formatting';
 
 // WATER SEA CREATURES
 
@@ -118,6 +118,8 @@ export const GUARDIAN_PET_COMMON_MESSAGE = `${DARK_PURPLE}${BOLD}GREAT CATCH! ${
 
 // OTHER
 
+export const DOUBLE_HOOK_MESSAGES = [ '&r&eIt\'s a &r&aDouble Hook&r&e! Woot woot!&r', '&r&eIt\'s a &r&aDouble Hook&r&e!&r' ];
+
 export const KILLED_BY_THUNDER_MESSAGE = `${RESET}${GRAY}You were killed by Thunder${RESET}${GRAY}${RESET}${GRAY}.`; // &r&7You were killed by Thunder&r&7&r&7.
 export const KILLED_BY_LORD_JAWBUS_MESSAGE = `${RESET}${GRAY}You were killed by Lord Jawbus${RESET}${GRAY}${RESET}${GRAY}.`; // &r&7You were killed by Lord Jawbus&r&7&r&7.
 
@@ -134,6 +136,282 @@ export const WORKSHOP_CLOSING_MESSAGE = `${RESET}${RED}[Important] ${RESET}${YEL
 
 export const GOOD_CATCH_ICE_ESSENCE_MESSAGE = `${RESET}${GOLD}${BOLD}GOOD CATCH! ${RESET}${AQUA}You found ${RESET}${AQUA}` + "${count}" + ` Ice Essence${RESET}${AQUA}.${RESET}`; // &r&6&lGOOD CATCH! &r&bYou found &r&b70 Ice Essence&r&b.&r
 export const GREAT_CATCH_ICE_ESSENCE_MESSAGE = `${RESET}${DARK_PURPLE}${BOLD}GREAT CATCH! ${RESET}${AQUA}You found ${RESET}${AQUA}` + "${count}" + ` Ice Essence${RESET}${AQUA}.${RESET}`;
+
+export const ALL_CATCHES_TRIGGERS = [
+    // WATER SEA CREATURES
+    {
+        trigger: WATER_HYDRA_MESSAGE,
+        seaCreature: `Water Hydra`,
+        rarityColorCode: LEGENDARY,
+    },
+    {
+        trigger: SEA_EMPEROR_MESSAGE,
+        seaCreature: `Sea Emperor`,
+        rarityColorCode: LEGENDARY,
+    },
+    {
+        trigger: CARROT_KING_MESSAGE,
+        seaCreature: `Carrot King`,
+        rarityColorCode: RARE,
+    },
+    {
+        trigger: SQUID_MESSAGE,
+        seaCreature: `Squid`,
+        rarityColorCode: COMMON,
+    },
+    {
+        trigger: NIGHT_SQUID_MESSAGE,
+        seaCreature: `Night Squid`,
+        rarityColorCode: COMMON,
+    },
+    {
+        trigger: SEA_WALKER_MESSAGE,
+        seaCreature: `Sea Walker`,
+        rarityColorCode: COMMON,
+    },
+    {
+        trigger: SEA_GUARDIAN_MESSAGE,
+        seaCreature: `Sea Guardian`,
+        rarityColorCode: COMMON,
+    },
+    {
+        trigger: SEA_WITCH_MESSAGE,
+        seaCreature: `Sea Witch`,
+        rarityColorCode: UNCOMMON,
+    },
+    {
+        trigger: SEA_ARCHER_MESSAGE,
+        seaCreature: `Sea Archer`,
+        rarityColorCode: UNCOMMON,
+    },
+    {
+        trigger: RIDER_OF_THE_DEEP_MESSAGE,
+        seaCreature: `Rider of the Deep`,
+        rarityColorCode: UNCOMMON,
+    },
+    {
+        trigger: CATFISH_MESSAGE,
+        seaCreature: `Catfish`,
+        rarityColorCode: RARE,
+    },
+    {
+        trigger: SEA_LEECH_MESSAGE,
+        seaCreature: `Sea Leech`,
+        rarityColorCode: RARE,
+    },
+    {
+        trigger: GUARDIAN_DEFENDER_MESSAGE,
+        seaCreature: `Guardian Defender`,
+        rarityColorCode: EPIC,
+    },
+    {
+        trigger: DEEP_SEA_PROTECTOR_MESSAGE,
+        seaCreature: `Deep Sea Protector`,
+        rarityColorCode: EPIC,
+    },
+    {
+        trigger: AGARIMOO_MESSAGE,
+        seaCreature: `Agarimoo`,
+        rarityColorCode: RARE,
+    },
+    // FISHING FESTIVAL SEA CREATURES
+    {
+        trigger: GREAT_WHITE_SHARK_MESSAGE,
+        seaCreature: `Great White Shark`,
+        rarityColorCode: LEGENDARY,
+    },
+    {
+        trigger: NURSE_SHARK_MESSAGE,
+        seaCreature: `Nurse Shark`,
+        rarityColorCode: UNCOMMON,
+    },
+    {
+        trigger: BLUE_SHARK_MESSAGE,
+        seaCreature: `Blue Shark`,
+        rarityColorCode: RARE,
+    },
+    {
+        trigger: TIGER_SHARK_MESSAGE,
+        seaCreature: `Tiger Shark`,
+        rarityColorCode: EPIC,
+    },
+    // WINTER SEA CREATURES
+    {
+        trigger: YETI_MESSAGE,
+        seaCreature: `Yeti`,
+        rarityColorCode: LEGENDARY,
+    },
+    {
+        trigger: REINDRAKE_MESSAGE,
+        seaCreature: `Reindrake`,
+        rarityColorCode: LEGENDARY,
+    },
+    {
+        trigger: NUTCRACKER_MESSAGE,
+        seaCreature: `Nutcracker`,
+        rarityColorCode: RARE,
+    },
+    {
+        trigger: FROZEN_STEVE_MESSAGE,
+        seaCreature: `Frozen Steve`,
+        rarityColorCode: COMMON,
+    },
+    {
+        trigger: FROSTY_MESSAGE,
+        seaCreature: `Frosty`,
+        rarityColorCode: COMMON,
+    },
+    {
+        trigger: GRINCH_MESSAGE,
+        seaCreature: `Grinch`,
+        rarityColorCode: UNCOMMON,
+    },
+    // SPOOKY SEA CREATURES
+    {
+        trigger: PHANTOM_FISHER_MESSAGE,
+        seaCreature: `Phantom Fisher`,
+        rarityColorCode: LEGENDARY,
+    },
+    {
+        trigger: GRIM_REAPER_MESSAGE,
+        seaCreature: `Grim Reaper`,
+        rarityColorCode: LEGENDARY,
+    },
+    {
+        trigger: SCARECROW_MESSAGE,
+        seaCreature: `Scarecrow`,
+        rarityColorCode: COMMON,
+    },
+    {
+        trigger: NIGHTMARE_MESSAGE,
+        seaCreature: `Nightmare`,
+        rarityColorCode: RARE,
+    },
+    {
+        trigger: WEREWOLF_MESSAGE,
+        seaCreature: `Werewolf`,
+        rarityColorCode: EPIC,
+    },
+    // CRIMSON ISLE SEA CREATURES
+    {
+        trigger: THUNDER_MESSAGE,
+        seaCreature: `Thunder`,
+        rarityColorCode: MYTHIC,
+    },
+    {
+        trigger: LORD_JAWBUS_MESSAGE,
+        seaCreature: `Lord Jawbus`,
+        rarityColorCode: MYTHIC,
+    },
+    {
+        trigger: PLHLEGBLAST_MESSAGE,
+        seaCreature: `Plhlegblast`,
+        rarityColorCode: LEGENDARY,
+    },
+    {
+        trigger: MAGMA_SLUG_MESSAGE,
+        seaCreature: `Magma Slug`,
+        rarityColorCode: UNCOMMON,
+    },
+    {
+        trigger: MOOGMA_MESSAGE,
+        seaCreature: `Moogma`,
+        rarityColorCode: UNCOMMON,
+    },
+    {
+        trigger: LAVA_LEECH_MESSAGE,
+        seaCreature: `Lava Leech`,
+        rarityColorCode: RARE,
+    },
+    {
+        trigger: PYROCLASTIC_WORM_MESSAGE,
+        seaCreature: `Pyroclastic Worm`,
+        rarityColorCode: RARE,
+    },
+    {
+        trigger: LAVA_FLAME_MESSAGE,
+        seaCreature: `Lava Flame`,
+        rarityColorCode: RARE,
+    },
+    {
+        trigger: FIRE_EEL_MESSAGE,
+        seaCreature: `Fire Eel`,
+        rarityColorCode: RARE,
+    },
+    {
+        trigger: TAURUS_MESSAGE,
+        seaCreature: `Taurus`,
+        rarityColorCode: EPIC,
+    },
+    // OASIS SEA CREATURES
+    {
+        trigger: OASIS_RABBIT_MESSAGE,
+        seaCreature: `Oasis Rabbit`,
+        rarityColorCode: UNCOMMON,
+    },
+    {
+        trigger: OASIS_SHEEP_MESSAGE,
+        seaCreature: `Oasis Sheep`,
+        rarityColorCode: UNCOMMON,
+    },
+    // CRYSTAL HOLLOWS SEA CREATURES
+    {
+        trigger: ABYSSAL_MINER_MESSAGE,
+        seaCreature: `Abyssal Miner`,
+        rarityColorCode: LEGENDARY,
+    },
+    {
+        trigger: WATER_WORM_MESSAGE,
+        seaCreature: `Water Worm`,
+        rarityColorCode: RARE,
+    },
+    {
+        trigger: POISONED_WATER_WORM_MESSAGE,
+        seaCreature: `Poisoned Water Worm`,
+        rarityColorCode: RARE,
+    },
+    {
+        trigger: POISONED_WATER_WORM_MESSAGE,
+        seaCreature: `Poisoned Water Worm`,
+        rarityColorCode: RARE,
+    },
+    {
+        trigger: FLAMING_WORM_MESSAGE,
+        seaCreature: `Flaming Worm`,
+        rarityColorCode: RARE,
+    },
+    {
+        trigger: LAVA_BLAZE_MESSAGE,
+        seaCreature: `Lava Blaze`,
+        rarityColorCode: EPIC,
+    },
+    {
+        trigger: LAVA_PIGMAN_MESSAGE,
+        seaCreature: `Lava Pigman`,
+        rarityColorCode: EPIC,
+    },
+    // ABANDONED QUARRY SEA CREATURES
+    {
+        trigger: SMALL_MITHRIL_GRUBBER_MESSAGE,
+        seaCreature: `Small Mithril Grubber`,
+        rarityColorCode: UNCOMMON,
+    },
+    {
+        trigger: MEDIUM_MITHRIL_GRUBBER_MESSAGE,
+        seaCreature: `Medium Mithril Grubber`,
+        rarityColorCode: UNCOMMON,
+    },
+    {
+        trigger: LARGE_MITHRIL_GRUBBER_MESSAGE,
+        seaCreature: `Large Mithril Grubber`,
+        rarityColorCode: UNCOMMON,
+    },
+    {
+        trigger: BLOATED_MITHRIL_GRUBBER_MESSAGE,
+        seaCreature: `Bloated Mithril Grubber`,
+        rarityColorCode: UNCOMMON,
+    },
+];
 
 export const RARE_CATCH_TRIGGERS = [
     {

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -5,6 +5,7 @@
 Released: ???
 
 Features:
+- Added option to compact sea creature catch messages [disabled by default]. It shortens double hook message and catch message that says what sea creature you caught.
 
 Bugfixes:
 - Changed Plhlegblast's rarity to legendary in the alert and Rare Catches tracker.

--- a/docs/Future ideas & requests.md
+++ b/docs/Future ideas & requests.md
@@ -1,4 +1,4 @@
-- Offer supercrafting or bazaar when items like raw fish goes to inventory (sacks are full)
+- Offer supercrafting of bazaar when items like raw fish goes to inventory (sacks are full)
 - Some items are tracked by profit tracker when dropped, but drop was prevented by SB settings (basically it drops and picks up again).
 - Calculate pet price in profit tracker as difference between lvl 1 and lvl 100
 - Remove double hook reindrake logic because DH is not possible now
@@ -26,7 +26,6 @@
   - Toggle setting to enable customization
 - Render mob immunity flag
 - Highlight rare sea creatures
-- Short catch messages and double hook messages
 - Total and session tracker
 - Trading with other players adds items to the profit trackers
 - Multiple drops that happen at the same time lead to "You're sending messages too fast" error.

--- a/features/chat/compactCatchMessages.js
+++ b/features/chat/compactCatchMessages.js
@@ -1,0 +1,47 @@
+import settings from "../../settings";
+import { AQUA, BOLD, GRAY, RESET } from "../../constants/formatting";
+import * as triggers from "../../constants/triggers";
+import { getArticle, isDoubleHook } from "../../utils/common";
+import { isInSkyblock } from '../../utils/playerState';
+
+triggers.DOUBLE_HOOK_MESSAGES.forEach(entry => {
+    register("Chat", (event) => compactDoubleHookChatMessage(event)).setCriteria(entry);
+});
+
+triggers.ALL_CATCHES_TRIGGERS.forEach(entry => {
+    register("Chat", (event) => compactSeaCreatureCatchChatMessage(entry, event)).setCriteria(entry.trigger).setContains();
+});
+
+function compactDoubleHookChatMessage(event) {
+    try {
+        if (!settings.compactCatchMessages || !isInSkyblock()) {
+            return;
+        }
+
+        cancel(event);
+    } catch (e) {
+		console.error(e);
+		console.log(`[FeeshNotifier] Failed to compact double hook message.`);
+	}
+}
+
+function compactSeaCreatureCatchChatMessage(entry, event) {
+    try {
+        if (!settings.compactCatchMessages || !isInSkyblock()) {
+            return;
+        }
+
+        const isDoubleHooked = isDoubleHook();
+        const seaCreatureNameStr = `${entry.rarityColorCode}${BOLD}${entry.seaCreature}`;
+        const doubleHookStr = isDoubleHooked
+            ? `${AQUA}${BOLD}DOUBLE HOOK! `
+            : '';
+        const message = `${doubleHookStr}${GRAY}${getArticle(entry.seaCreature)} ${seaCreatureNameStr}${RESET}${GRAY} has spawned.`;
+
+        cancel(event);
+        ChatLib.chat(message);
+    } catch (e) {
+		console.error(e);
+		console.log(`[FeeshNotifier] Failed to compact sea creature catch message.`);
+	}
+}

--- a/index.js
+++ b/index.js
@@ -41,6 +41,7 @@ import "./features/inventory/showExpertiseKills";
 import "./features/chat/announceMobSpawnToAllChat";
 import "./features/chat/messageOnPlayerDeath";
 import "./features/chat/messageOnRevenant";
+import "./features/chat/compactCatchMessages";
 
 register('worldLoad', () => {
     Client.showTitle('', '', 1, 1, 1); // Shitty fix for a title not showing for the 1st time

--- a/settings.js
+++ b/settings.js
@@ -341,6 +341,16 @@ class Settings {
     })
     messageOnDeath = true;
 
+    // ******* CHAT - Compact messages ******* //
+
+    @SwitchProperty({
+        name: "Compact sea creature catch messages",
+        description: 'Shortens double hook message and catch message that says what sea creature you caught.',
+        category: "Chat",
+        subcategory: "Compact messages"
+    })
+    compactCatchMessages = false;
+
     // ******* ALERTS - Totem ******* //
 
     @SwitchProperty({

--- a/utils/common.js
+++ b/utils/common.js
@@ -1,5 +1,6 @@
 import { RED, DARK_GRAY, BLUE, WHITE, BOLD, RESET } from '../constants/formatting';
 import { NBTTagString } from '../constants/javaTypes';
+import { DOUBLE_HOOK_MESSAGES } from '../constants/triggers';
 
 // Double hook reindrakes may produce the following messages history:
 // [CHAT] &r&eIt's a &r&aDouble Hook&r&e!&r
@@ -16,14 +17,13 @@ import { NBTTagString } from '../constants/javaTypes';
 // [CHAT] &r&c&lYou hear a massive rumble as Thunder emerges.&r
 
 export function isDoubleHook() {
-	const doubleHookMessages = [ '&r&eIt\'s a &r&aDouble Hook&r&e! Woot woot!&r', '&r&eIt\'s a &r&aDouble Hook&r&e!&r' ];
 	const history = ChatLib.getChatLines()?.filter(l => // Those messages appear between double hook and catch messages for Reindrake / Thunder
 		l !== '&r' &&
 		l !== '&r&c&lWOAH! &r&cA &r&4Reindrake &r&cwas summoned from the depths!&r' &&
 		l !== '&r&e> Your bottle of thunder has fully charged!&r'
 	);
 	const isDoubleHooked = (!!history && history.length > 1)
-		? doubleHookMessages.includes(history[1])
+		? DOUBLE_HOOK_MESSAGES.includes(history[1])
 		: false;
 	return isDoubleHooked;
 }
@@ -393,7 +393,12 @@ export function getItemAttributes(item) {
     return attributes;
 }
 
-function getArticle(str) {
+/**
+ * Get suitable article (A/An) depending on the passed string.
+ * @param {string} str
+ * @returns {string} Article (A/An)
+ */
+export function getArticle(str) {
     const isFirstLetterVowel = ['a', 'e', 'i', 'o', 'u'].indexOf(str[0].toLowerCase()) !== -1;
 	return isFirstLetterVowel ? 'An' : 'A';
 }


### PR DESCRIPTION
Added option to compact sea creature catch messages [disabled by default]. It shortens double hook message and catch message that says what sea creature you caught.