### PR TITLE
Release 1.28.0

### DIFF
--- a/constants/seaCreatures.js
+++ b/constants/seaCreatures.js
@@ -65,7 +65,7 @@ export const ALL_SEA_CREATURES_NAMES = [
     'Lord Jawbus',
     'Jawbus Follower',
     'Plhlegblast',
-    'Mithril Grubber',
+    'Mithril Grubber', // A sea creature is called Small Mithril Grubber, but corrupted one is Corrupted Mithril Grubber (without "Small")
     'Medium Mithril Grubber',
     'Large Mithril Grubber',
     'Bloated Mithril Grubber',

--- a/constants/triggers.js
+++ b/constants/triggers.js
@@ -1,7 +1,7 @@
 import * as drops from './drops';
 import * as sounds from './sounds';
 import * as seaCreatures from './seaCreatures';
-import { GREEN, GOLD, DARK_PURPLE, LIGHT_PURPLE, BLUE, RED, BOLD, RESET, COMMON, RARE, EPIC, LEGENDARY, MYTHIC, GRAY, AQUA, YELLOW, DARK_RED, DARK_AQUA, WHITE, UNCOMMON } from './formatting';
+import { GREEN, GOLD, DARK_PURPLE, LIGHT_PURPLE, BLUE, RED, BOLD, RESET, GRAY, AQUA, YELLOW, DARK_RED, DARK_AQUA, WHITE, COMMON, UNCOMMON, RARE, EPIC, LEGENDARY, MYTHIC } from './formatting';
 
 // WATER SEA CREATURES
 
@@ -118,6 +118,8 @@ export const GUARDIAN_PET_COMMON_MESSAGE = `${DARK_PURPLE}${BOLD}GREAT CATCH! ${
 
 // OTHER
 
+export const DOUBLE_HOOK_MESSAGES = [ '&r&eIt\'s a &r&aDouble Hook&r&e! Woot woot!&r', '&r&eIt\'s a &r&aDouble Hook&r&e!&r' ];
+
 export const KILLED_BY_THUNDER_MESSAGE = `${RESET}${GRAY}You were killed by Thunder${RESET}${GRAY}${RESET}${GRAY}.`; // &r&7You were killed by Thunder&r&7&r&7.
 export const KILLED_BY_LORD_JAWBUS_MESSAGE = `${RESET}${GRAY}You were killed by Lord Jawbus${RESET}${GRAY}${RESET}${GRAY}.`; // &r&7You were killed by Lord Jawbus&r&7&r&7.
 
@@ -134,6 +136,282 @@ export const WORKSHOP_CLOSING_MESSAGE = `${RESET}${RED}[Important] ${RESET}${YEL
 
 export const GOOD_CATCH_ICE_ESSENCE_MESSAGE = `${RESET}${GOLD}${BOLD}GOOD CATCH! ${RESET}${AQUA}You found ${RESET}${AQUA}` + "${count}" + ` Ice Essence${RESET}${AQUA}.${RESET}`; // &r&6&lGOOD CATCH! &r&bYou found &r&b70 Ice Essence&r&b.&r
 export const GREAT_CATCH_ICE_ESSENCE_MESSAGE = `${RESET}${DARK_PURPLE}${BOLD}GREAT CATCH! ${RESET}${AQUA}You found ${RESET}${AQUA}` + "${count}" + ` Ice Essence${RESET}${AQUA}.${RESET}`;
+
+export const ALL_CATCHES_TRIGGERS = [
+    // WATER SEA CREATURES
+    {
+        trigger: WATER_HYDRA_MESSAGE,
+        seaCreature: `Water Hydra`,
+        rarityColorCode: LEGENDARY,
+    },
+    {
+        trigger: SEA_EMPEROR_MESSAGE,
+        seaCreature: `Sea Emperor`,
+        rarityColorCode: LEGENDARY,
+    },
+    {
+        trigger: CARROT_KING_MESSAGE,
+        seaCreature: `Carrot King`,
+        rarityColorCode: RARE,
+    },
+    {
+        trigger: SQUID_MESSAGE,
+        seaCreature: `Squid`,
+        rarityColorCode: COMMON,
+    },
+    {
+        trigger: NIGHT_SQUID_MESSAGE,
+        seaCreature: `Night Squid`,
+        rarityColorCode: COMMON,
+    },
+    {
+        trigger: SEA_WALKER_MESSAGE,
+        seaCreature: `Sea Walker`,
+        rarityColorCode: COMMON,
+    },
+    {
+        trigger: SEA_GUARDIAN_MESSAGE,
+        seaCreature: `Sea Guardian`,
+        rarityColorCode: COMMON,
+    },
+    {
+        trigger: SEA_WITCH_MESSAGE,
+        seaCreature: `Sea Witch`,
+        rarityColorCode: UNCOMMON,
+    },
+    {
+        trigger: SEA_ARCHER_MESSAGE,
+        seaCreature: `Sea Archer`,
+        rarityColorCode: UNCOMMON,
+    },
+    {
+        trigger: RIDER_OF_THE_DEEP_MESSAGE,
+        seaCreature: `Rider of the Deep`,
+        rarityColorCode: UNCOMMON,
+    },
+    {
+        trigger: CATFISH_MESSAGE,
+        seaCreature: `Catfish`,
+        rarityColorCode: RARE,
+    },
+    {
+        trigger: SEA_LEECH_MESSAGE,
+        seaCreature: `Sea Leech`,
+        rarityColorCode: RARE,
+    },
+    {
+        trigger: GUARDIAN_DEFENDER_MESSAGE,
+        seaCreature: `Guardian Defender`,
+        rarityColorCode: EPIC,
+    },
+    {
+        trigger: DEEP_SEA_PROTECTOR_MESSAGE,
+        seaCreature: `Deep Sea Protector`,
+        rarityColorCode: EPIC,
+    },
+    {
+        trigger: AGARIMOO_MESSAGE,
+        seaCreature: `Agarimoo`,
+        rarityColorCode: RARE,
+    },
+    // FISHING FESTIVAL SEA CREATURES
+    {
+        trigger: GREAT_WHITE_SHARK_MESSAGE,
+        seaCreature: `Great White Shark`,
+        rarityColorCode: LEGENDARY,
+    },
+    {
+        trigger: NURSE_SHARK_MESSAGE,
+        seaCreature: `Nurse Shark`,
+        rarityColorCode: UNCOMMON,
+    },
+    {
+        trigger: BLUE_SHARK_MESSAGE,
+        seaCreature: `Blue Shark`,
+        rarityColorCode: RARE,
+    },
+    {
+        trigger: TIGER_SHARK_MESSAGE,
+        seaCreature: `Tiger Shark`,
+        rarityColorCode: EPIC,
+    },
+    // WINTER SEA CREATURES
+    {
+        trigger: YETI_MESSAGE,
+        seaCreature: `Yeti`,
+        rarityColorCode: LEGENDARY,
+    },
+    {
+        trigger: REINDRAKE_MESSAGE,
+        seaCreature: `Reindrake`,
+        rarityColorCode: LEGENDARY,
+    },
+    {
+        trigger: NUTCRACKER_MESSAGE,
+        seaCreature: `Nutcracker`,
+        rarityColorCode: RARE,
+    },
+    {
+        trigger: FROZEN_STEVE_MESSAGE,
+        seaCreature: `Frozen Steve`,
+        rarityColorCode: COMMON,
+    },
+    {
+        trigger: FROSTY_MESSAGE,
+        seaCreature: `Frosty`,
+        rarityColorCode: COMMON,
+    },
+    {
+        trigger: GRINCH_MESSAGE,
+        seaCreature: `Grinch`,
+        rarityColorCode: UNCOMMON,
+    },
+    // SPOOKY SEA CREATURES
+    {
+        trigger: PHANTOM_FISHER_MESSAGE,
+        seaCreature: `Phantom Fisher`,
+        rarityColorCode: LEGENDARY,
+    },
+    {
+        trigger: GRIM_REAPER_MESSAGE,
+        seaCreature: `Grim Reaper`,
+        rarityColorCode: LEGENDARY,
+    },
+    {
+        trigger: SCARECROW_MESSAGE,
+        seaCreature: `Scarecrow`,
+        rarityColorCode: COMMON,
+    },
+    {
+        trigger: NIGHTMARE_MESSAGE,
+        seaCreature: `Nightmare`,
+        rarityColorCode: RARE,
+    },
+    {
+        trigger: WEREWOLF_MESSAGE,
+        seaCreature: `Werewolf`,
+        rarityColorCode: EPIC,
+    },
+    // CRIMSON ISLE SEA CREATURES
+    {
+        trigger: THUNDER_MESSAGE,
+        seaCreature: `Thunder`,
+        rarityColorCode: MYTHIC,
+    },
+    {
+        trigger: LORD_JAWBUS_MESSAGE,
+        seaCreature: `Lord Jawbus`,
+        rarityColorCode: MYTHIC,
+    },
+    {
+        trigger: PLHLEGBLAST_MESSAGE,
+        seaCreature: `Plhlegblast`,
+        rarityColorCode: LEGENDARY,
+    },
+    {
+        trigger: MAGMA_SLUG_MESSAGE,
+        seaCreature: `Magma Slug`,
+        rarityColorCode: UNCOMMON,
+    },
+    {
+        trigger: MOOGMA_MESSAGE,
+        seaCreature: `Moogma`,
+        rarityColorCode: UNCOMMON,
+    },
+    {
+        trigger: LAVA_LEECH_MESSAGE,
+        seaCreature: `Lava Leech`,
+        rarityColorCode: RARE,
+    },
+    {
+        trigger: PYROCLASTIC_WORM_MESSAGE,
+        seaCreature: `Pyroclastic Worm`,
+        rarityColorCode: RARE,
+    },
+    {
+        trigger: LAVA_FLAME_MESSAGE,
+        seaCreature: `Lava Flame`,
+        rarityColorCode: RARE,
+    },
+    {
+        trigger: FIRE_EEL_MESSAGE,
+        seaCreature: `Fire Eel`,
+        rarityColorCode: RARE,
+    },
+    {
+        trigger: TAURUS_MESSAGE,
+        seaCreature: `Taurus`,
+        rarityColorCode: EPIC,
+    },
+    // OASIS SEA CREATURES
+    {
+        trigger: OASIS_RABBIT_MESSAGE,
+        seaCreature: `Oasis Rabbit`,
+        rarityColorCode: UNCOMMON,
+    },
+    {
+        trigger: OASIS_SHEEP_MESSAGE,
+        seaCreature: `Oasis Sheep`,
+        rarityColorCode: UNCOMMON,
+    },
+    // CRYSTAL HOLLOWS SEA CREATURES
+    {
+        trigger: ABYSSAL_MINER_MESSAGE,
+        seaCreature: `Abyssal Miner`,
+        rarityColorCode: LEGENDARY,
+    },
+    {
+        trigger: WATER_WORM_MESSAGE,
+        seaCreature: `Water Worm`,
+        rarityColorCode: RARE,
+    },
+    {
+        trigger: POISONED_WATER_WORM_MESSAGE,
+        seaCreature: `Poisoned Water Worm`,
+        rarityColorCode: RARE,
+    },
+    {
+        trigger: POISONED_WATER_WORM_MESSAGE,
+        seaCreature: `Poisoned Water Worm`,
+        rarityColorCode: RARE,
+    },
+    {
+        trigger: FLAMING_WORM_MESSAGE,
+        seaCreature: `Flaming Worm`,
+        rarityColorCode: RARE,
+    },
+    {
+        trigger: LAVA_BLAZE_MESSAGE,
+        seaCreature: `Lava Blaze`,
+        rarityColorCode: EPIC,
+    },
+    {
+        trigger: LAVA_PIGMAN_MESSAGE,
+        seaCreature: `Lava Pigman`,
+        rarityColorCode: EPIC,
+    },
+    // ABANDONED QUARRY SEA CREATURES
+    {
+        trigger: SMALL_MITHRIL_GRUBBER_MESSAGE,
+        seaCreature: `Small Mithril Grubber`,
+        rarityColorCode: UNCOMMON,
+    },
+    {
+        trigger: MEDIUM_MITHRIL_GRUBBER_MESSAGE,
+        seaCreature: `Medium Mithril Grubber`,
+        rarityColorCode: UNCOMMON,
+    },
+    {
+        trigger: LARGE_MITHRIL_GRUBBER_MESSAGE,
+        seaCreature: `Large Mithril Grubber`,
+        rarityColorCode: UNCOMMON,
+    },
+    {
+        trigger: BLOATED_MITHRIL_GRUBBER_MESSAGE,
+        seaCreature: `Bloated Mithril Grubber`,
+        rarityColorCode: UNCOMMON,
+    },
+];
 
 export const RARE_CATCH_TRIGGERS = [
     {

--- a/constants/triggers.js
+++ b/constants/triggers.js
@@ -227,7 +227,7 @@ export const RARE_CATCH_TRIGGERS = [
         seaCreature: seaCreatures.PLHLEGBLAST,
         isMessageEnabledSettingKey: 'messageOnPlhlegblastCatch',
         isAlertEnabledSettingKey: 'alertOnPlhlegblastCatch',
-        rarityColorCode: COMMON
+        rarityColorCode: LEGENDARY
     },
     {
         trigger: VANQUISHER_MESSAGE,

--- a/constants/triggers.js
+++ b/constants/triggers.js
@@ -227,6 +227,7 @@ export const RARE_CATCH_TRIGGERS = [
         seaCreature: seaCreatures.PLHLEGBLAST,
         isMessageEnabledSettingKey: 'messageOnPlhlegblastCatch',
         isAlertEnabledSettingKey: 'alertOnPlhlegblastCatch',
+        isAnnounceToAllChatEnabledSettingKey: 'announceToAllChatOnPlhlegblastCatch',
         rarityColorCode: LEGENDARY
     },
     {

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -7,6 +7,7 @@ Released: ???
 Features:
 
 Bugfixes:
+- Changed Plhlegblast's rarity to legendary in the alert and Rare Catches tracker.
 
 ## v1.27.0
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -5,6 +5,7 @@
 Released: ???
 
 Features:
+- Added option to compact sea creature catch messages [disabled by default]. It shortens double hook message and catch message that says what sea creature you caught.
 - Added option to share the location to ALL chat on Plhlegblast catch [disabled by default].
 
 Bugfixes:

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -5,6 +5,7 @@
 Released: ???
 
 Features:
+- Added option to share the location to ALL chat on Plhlegblast catch [disabled by default].
 
 Bugfixes:
 - Changed Plhlegblast's rarity to legendary in the alert and Rare Catches tracker.

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,8 +1,16 @@
 # Releases
 
-## v1.27.0
+## v1.28.0
 
 Released: ???
+
+Features:
+
+Bugfixes:
+
+## v1.27.0
+
+Released: 2025-02-10
 
 Features:
 - Added 2 variations of the Beach Balls and Golden Bait to the fishing profit tracker.

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -7,6 +7,7 @@ Released: ???
 Features:
 - Added option to compact sea creature catch messages [disabled by default]. It shortens double hook message and catch message that says what sea creature you caught.
 - Added option to share the location to ALL chat on Plhlegblast catch [disabled by default].
+- Added option to show caught trophy fish rarities in Odger's Trophy Fishing GUI. [disabled by default] 
 
 Bugfixes:
 - Changed Plhlegblast's rarity to legendary in the alert and Rare Catches tracker.

--- a/docs/Future ideas & requests.md
+++ b/docs/Future ideas & requests.md
@@ -1,4 +1,4 @@
-- Offer supercrafting or bazaar when items like raw fish goes to inventory (sacks are full)
+- Offer supercrafting of bazaar when items like raw fish goes to inventory (sacks are full)
 - Some items are tracked by profit tracker when dropped, but drop was prevented by SB settings (basically it drops and picks up again).
 - Calculate pet price in profit tracker as difference between lvl 1 and lvl 100
 - Remove double hook reindrake logic because DH is not possible now
@@ -26,7 +26,6 @@
   - Toggle setting to enable customization
 - Render mob immunity flag
 - Highlight rare sea creatures
-- Short catch messages and double hook messages
 - Total and session tracker
 - Trading with other players adds items to the profit trackers
 - Multiple drops that happen at the same time lead to "You're sending messages too fast" error.

--- a/features/chat/announceMobSpawnToAllChat.js
+++ b/features/chat/announceMobSpawnToAllChat.js
@@ -6,7 +6,7 @@ import { isInSkyblock } from '../../utils/playerState';
 
 const chatCommand = 'ac';
 
-const mobTriggers = triggers.RARE_CATCH_TRIGGERS.filter(t => t.seaCreature === seaCreatures.THUNDER || t.seaCreature === seaCreatures.LORD_JAWBUS || t.seaCreature === seaCreatures.VANQUISHER);
+const mobTriggers = triggers.RARE_CATCH_TRIGGERS.filter(t => t.seaCreature === seaCreatures.THUNDER || t.seaCreature === seaCreatures.LORD_JAWBUS || t.seaCreature === seaCreatures.PLHLEGBLAST || t.seaCreature === seaCreatures.VANQUISHER);
 
 mobTriggers.forEach(entry => {
     register(

--- a/features/chat/compactCatchMessages.js
+++ b/features/chat/compactCatchMessages.js
@@ -1,0 +1,47 @@
+import settings from "../../settings";
+import { AQUA, BOLD, GRAY, RESET } from "../../constants/formatting";
+import * as triggers from "../../constants/triggers";
+import { getArticle, isDoubleHook } from "../../utils/common";
+import { isInSkyblock } from '../../utils/playerState';
+
+triggers.DOUBLE_HOOK_MESSAGES.forEach(entry => {
+    register("Chat", (event) => compactDoubleHookChatMessage(event)).setCriteria(entry);
+});
+
+triggers.ALL_CATCHES_TRIGGERS.forEach(entry => {
+    register("Chat", (event) => compactSeaCreatureCatchChatMessage(entry, event)).setCriteria(entry.trigger).setContains();
+});
+
+function compactDoubleHookChatMessage(event) {
+    try {
+        if (!settings.compactCatchMessages || !isInSkyblock()) {
+            return;
+        }
+
+        cancel(event);
+    } catch (e) {
+		console.error(e);
+		console.log(`[FeeshNotifier] Failed to compact double hook message.`);
+	}
+}
+
+function compactSeaCreatureCatchChatMessage(entry, event) {
+    try {
+        if (!settings.compactCatchMessages || !isInSkyblock()) {
+            return;
+        }
+
+        const isDoubleHooked = isDoubleHook();
+        const seaCreatureNameStr = `${entry.rarityColorCode}${BOLD}${entry.seaCreature}`;
+        const doubleHookStr = isDoubleHooked
+            ? `${AQUA}${BOLD}DOUBLE HOOK! `
+            : '';
+        const message = `${doubleHookStr}${GRAY}${getArticle(entry.seaCreature)} ${seaCreatureNameStr}${RESET}${GRAY} has spawned.`;
+
+        cancel(event);
+        ChatLib.chat(message);
+    } catch (e) {
+		console.error(e);
+		console.log(`[FeeshNotifier] Failed to compact sea creature catch message.`);
+	}
+}

--- a/features/inventory/showCaughtTrophyFishRaritiesInOdger.js
+++ b/features/inventory/showCaughtTrophyFishRaritiesInOdger.js
@@ -1,0 +1,52 @@
+
+import { AQUA, DARK_GRAY, GOLD, GRAY } from "../../constants/formatting";
+import settings from "../../settings";
+import { getLore } from "../../utils/common";
+import { isInSkyblock } from "../../utils/playerState";
+
+register('renderSlot', (slot, gui, event) => {
+    showMissingTrophyFishRarities(slot, gui);
+});
+
+function showMissingTrophyFishRarities(slot, gui) {
+    if (!slot || !gui || !(gui instanceof net.minecraft.client.gui.inventory.GuiChest) || !settings.showCaughtTrophyFishRaritiesInOdger || !isInSkyblock()) {
+        return;
+    }
+
+    const chestName = gui?.field_147002_h?.func_85151_d()?.func_145748_c_()?.text?.removeFormatting();
+    if (!chestName || chestName !== 'Trophy Fishing') {
+        return;
+    }
+
+    if (slot.getIndex() < 10 || slot.getIndex() > 45) {
+        return;
+    }
+
+    const item = slot.getItem();
+    if (!item) {
+        return;
+    }
+
+    // Bronze ✖, Bronze ✔
+    let caughtRarities = '';
+    const lore = getLore(item);
+
+    if (lore?.find(line => line?.removeFormatting()?.includes('Undiscovered'))) {
+        return;
+    }
+
+    if (lore?.find(line => line?.removeFormatting()?.includes('Bronze ✔'))) caughtRarities += `${DARK_GRAY}•`;
+    if (lore?.find(line => line?.removeFormatting()?.includes('Silver ✔'))) caughtRarities += `${GRAY}•`;
+    if (lore?.find(line => line?.removeFormatting()?.includes('Gold ✔'))) caughtRarities += `${GOLD}•`;
+    if (lore?.find(line => line?.removeFormatting()?.includes('Diamond ✔'))) caughtRarities += `${AQUA}•`;
+
+    Tessellator.pushMatrix();
+    Tessellator.disableLighting();
+
+    Renderer.translate(slot.getDisplayX(), slot.getDisplayY(), 275); // z coord = 275 to be on top of the item icon and below the tooltip
+    Renderer.scale(1.3, 1.3);
+    Renderer.drawString(caughtRarities, 0, 8, true);
+
+    Tessellator.enableLighting();
+    Tessellator.popMatrix();
+}

--- a/index.js
+++ b/index.js
@@ -41,6 +41,7 @@ import "./features/inventory/showExpertiseKills";
 import "./features/chat/announceMobSpawnToAllChat";
 import "./features/chat/messageOnPlayerDeath";
 import "./features/chat/messageOnRevenant";
+import "./features/chat/compactCatchMessages";
 
 register('worldLoad', () => {
     Client.showTitle('', '', 1, 1, 1); // Shitty fix for a title not showing for the 1st time

--- a/index.js
+++ b/index.js
@@ -37,6 +37,7 @@ import "./features/inventory/showRarityUpgrade";
 import "./features/inventory/highlightAttributeFusionMatchingItems";
 import "./features/inventory/showPricePerT1Shard";
 import "./features/inventory/showExpertiseKills";
+import "./features/inventory/showCaughtTrophyFishRaritiesInOdger";
 
 import "./features/chat/announceMobSpawnToAllChat";
 import "./features/chat/messageOnPlayerDeath";

--- a/metadata.json
+++ b/metadata.json
@@ -3,7 +3,7 @@
     "entry": "index.js",
     "author": "MoonTheSadFisher",
     "description": "Hypixel Skyblock fishing utilities for parties.",
-    "version": "1.27.0",
+    "version": "1.28.0",
     "requires": [
         "Vigilance",
         "PogData",

--- a/settings.js
+++ b/settings.js
@@ -1178,6 +1178,14 @@ ${RED}Hidden if you have no fishing rod in your hotbar!`,
     })
     showRarityUpgrade = false;
 
+    @SwitchProperty({
+        name: "Caught trophy fish rarities",
+        description: `Render caught trophy fish rarities in Odger's Trophy Fishing GUI.`,
+        category: "Inventory",
+        subcategory: "Item tooltip"
+    })
+    showCaughtTrophyFishRaritiesInOdger = false;
+
     // ******* INVENTORY - Armor attributes ******* //
 
     @SwitchProperty({

--- a/settings.js
+++ b/settings.js
@@ -185,6 +185,13 @@ class Settings {
     announceToAllChatOnLordJawbusCatch = false;
 
     @SwitchProperty({
+        name: "Share the location to ALL chat on PLHLEGBLAST catch",
+        category: "Chat",
+        subcategory: "Rare Catches - All Chat"
+    })
+    announceToAllChatOnPlhlegblastCatch = false;
+
+    @SwitchProperty({
         name: "Share the location to ALL chat on VANQUISHER spawn",
         category: "Chat",
         subcategory: "Rare Catches - All Chat"

--- a/settings.js
+++ b/settings.js
@@ -335,7 +335,7 @@ class Settings {
 
     @SwitchProperty({
         name: "Send a message when you are killed by Thunder / Lord Jawbus",
-        description: `${GRAY}Sends a message to the ${BLUE}party chat ${GRAY}when when you are killed by Thunder / Lord Jawbus. It enables the alerts for your party members so they can wait for you.`,
+        description: `${GRAY}Sends a message to the ${BLUE}party chat ${GRAY}when you are killed by Thunder / Lord Jawbus. It enables the alerts for your party members so they can wait for you.`,
         category: "Chat",
         subcategory: "Player's death"
     })

--- a/settings.js
+++ b/settings.js
@@ -348,6 +348,16 @@ class Settings {
     })
     messageOnDeath = true;
 
+    // ******* CHAT - Compact messages ******* //
+
+    @SwitchProperty({
+        name: "Compact sea creature catch messages",
+        description: 'Shortens double hook message and catch message that says what sea creature you caught.',
+        category: "Chat",
+        subcategory: "Compact messages"
+    })
+    compactCatchMessages = false;
+
     // ******* ALERTS - Totem ******* //
 
     @SwitchProperty({

--- a/utils/common.js
+++ b/utils/common.js
@@ -1,5 +1,6 @@
 import { RED, DARK_GRAY, BLUE, WHITE, BOLD, RESET } from '../constants/formatting';
 import { NBTTagString } from '../constants/javaTypes';
+import { DOUBLE_HOOK_MESSAGES } from '../constants/triggers';
 
 // Double hook reindrakes may produce the following messages history:
 // [CHAT] &r&eIt's a &r&aDouble Hook&r&e!&r
@@ -16,14 +17,13 @@ import { NBTTagString } from '../constants/javaTypes';
 // [CHAT] &r&c&lYou hear a massive rumble as Thunder emerges.&r
 
 export function isDoubleHook() {
-	const doubleHookMessages = [ '&r&eIt\'s a &r&aDouble Hook&r&e! Woot woot!&r', '&r&eIt\'s a &r&aDouble Hook&r&e!&r' ];
 	const history = ChatLib.getChatLines()?.filter(l => // Those messages appear between double hook and catch messages for Reindrake / Thunder
 		l !== '&r' &&
 		l !== '&r&c&lWOAH! &r&cA &r&4Reindrake &r&cwas summoned from the depths!&r' &&
 		l !== '&r&e> Your bottle of thunder has fully charged!&r'
 	);
 	const isDoubleHooked = (!!history && history.length > 1)
-		? doubleHookMessages.includes(history[1])
+		? DOUBLE_HOOK_MESSAGES.includes(history[1])
 		: false;
 	return isDoubleHooked;
 }
@@ -393,7 +393,12 @@ export function getItemAttributes(item) {
     return attributes;
 }
 
-function getArticle(str) {
+/**
+ * Get suitable article (A/An) depending on the passed string.
+ * @param {string} str
+ * @returns {string} Article (A/An)
+ */
+export function getArticle(str) {
     const isFirstLetterVowel = ['a', 'e', 'i', 'o', 'u'].indexOf(str[0].toLowerCase()) !== -1;
 	return isFirstLetterVowel ? 'An' : 'A';
 }


### PR DESCRIPTION
Features:
- Added option to compact sea creature catch messages [disabled by default]. It shortens double hook message and catch message that says what sea creature you caught.
- Added option to share the location to ALL chat on Plhlegblast catch [disabled by default].
- Added option to show caught trophy fish rarities in Odger's Trophy Fishing GUI. [disabled by default] 

Bugfixes:
- Changed Plhlegblast's rarity to legendary in the alert and Rare Catches tracker.