### PR TITLE
fix: Changed display name of Fishing Exp Boost items in Fishing Profit Tracker

### DIFF
--- a/constants/fishingProfitItems.js
+++ b/constants/fishingProfitItems.js
@@ -922,20 +922,20 @@ export const FISHING_PROFIT_ITEMS = [
     {
         itemId: 'PET_ITEM_FISHING_SKILL_BOOST_UNCOMMON',
         itemName: 'Fishing Exp Boost (UNCOMMON)',
-        itemDisplayName: `${UNCOMMON}Fishing Exp Boost`,
+        itemDisplayName: `${UNCOMMON}Fishing Exp Boost +30%`,
         npcPrice: 0,
     },
     {
         itemId: 'PET_ITEM_FISHING_SKILL_BOOST_RARE',
         itemName: 'Fishing Exp Boost (RARE)',
-        itemDisplayName: `${RARE}Fishing Exp Boost`,
+        itemDisplayName: `${RARE}Fishing Exp Boost +40%`,
         npcPrice: 0,
         shouldAnnounceRareDrop: true,
     },
     {
         itemId: 'PET_ITEM_FISHING_SKILL_BOOST_EPIC',
         itemName: 'Fishing Exp Boost (EPIC)',
-        itemDisplayName: `${EPIC}Fishing Exp Boost`,
+        itemDisplayName: `${EPIC}Fishing Exp Boost +50%`,
         npcPrice: 0,
         shouldAnnounceRareDrop: true,
     },

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -5,10 +5,10 @@
 Released: ???
 
 Features:
-
 - Added alert when Spirit Mask is back after being activated [disabled by default].
 
 Bugfixes:
+- Changed display name of Fishing Exp Boost items in Fishing Profit Tracker, so now it displays boost % and looks better when copy-pasting drop message.
 
 ## v1.29.0
 


### PR DESCRIPTION
Changed display name of Fishing Exp Boost items in Fishing Profit Tracker, so now it displays boost % and looks better when copy-pasting drop message.