### PR TITLE
feat: Alert on Hotspot gone + Chat message on Hotspot found

### DIFF
--- a/constants/areas.js
+++ b/constants/areas.js
@@ -5,5 +5,13 @@ export const DWARVEN_MINES = 'Dwarven Mines';
 export const ABANDONED_QUARRY = 'Abandoned Quarry';
 export const BACKWATER_BAYOU = 'Backwater Bayou';
 export const JERRY_WORKSHOP = 'Jerry\'s Workshop';
+export const SPIDERS_DEN = 'Spider\'s Den';
 export const KUUDRA = 'Kuudra';
 export const DUNGEONS = 'Catacombs';
+
+export const HOTSPOT_WORLDS = [
+    BACKWATER_BAYOU,
+    CRIMSON_ISLE,
+    HUB,
+    SPIDERS_DEN
+];

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -5,6 +5,8 @@
 Released: ???
 
 Features:
+- Added alert when the Hotspot you recently fished in, is gone.
+- Added option to share Hotspot location and its perk to ALL chat or PARTY chat on chat message click. You need to be close to the hotspot in order to trigger it.
 
 Bugfixes:
 - Added Severed Pincer drop to Fishing Profit Tracker.

--- a/features/alerts/alertOnHotspotGone.js
+++ b/features/alerts/alertOnHotspotGone.js
@@ -1,0 +1,77 @@
+import settings from "../../settings";
+import { OFF_SOUND_MODE } from "../../constants/sounds";
+import { getWorldName, hasFishingRodInHotbar, isInSkyblock } from "../../utils/playerState";
+import { HOTSPOT_WORLDS } from "../../constants/areas";
+import { GOLD, LIGHT_PURPLE, RESET, WHITE, YELLOW } from "../../constants/formatting";
+import { EntityArmorStand, EntityFishHook } from "../../constants/javaTypes";
+import { isFishingHookActive } from "../../utils/common";
+
+let lastClosestHotspot = null;
+let lastClosestHotspotPerk = null;
+
+register("step", (event) => playAlertOnHotspotGone()).setDelay(1);
+register("worldUnload", () => {
+    lastClosestHotspot = null;
+    lastClosestHotspotPerk = null;
+});
+
+function playAlertOnHotspotGone() {
+	try {
+		if (!settings.alertOnHotspotGone ||
+            !HOTSPOT_WORLDS.includes(getWorldName()) ||
+            !hasFishingRodInHotbar() ||
+            !isInSkyblock()
+        ) {
+			return;
+		}
+		
+        let currentHotspots = [];
+
+        const armorStands = World.getAllEntitiesOfType(EntityArmorStand).filter(entity => entity.distanceTo(Player.getPlayer()) <= 30);
+        armorStands.forEach(entity => {
+            const plainName = entity?.getName()?.removeFormatting();
+            if (plainName === 'HOTSPOT') {
+                currentHotspots.push({
+                    entity: entity,
+                    perk: armorStands.find(e => e.getX() === entity.getX() && e.getY() < entity.getY()&& entity.getY() - e.getY() < 2 && e.getZ() === entity.getZ() && e.getPitch() === entity.getPitch())?.getName()
+                });
+            }
+        });
+
+        if (lastClosestHotspot && lastClosestHotspot.distanceTo(Player.getPlayer()) > 30) { // Player moved away
+            lastClosestHotspot = null;
+            lastClosestHotspotPerk = null;
+        } else if (lastClosestHotspot && lastClosestHotspot.distanceTo(Player.getPlayer()) <= 30 && 
+            !currentHotspots.find(ch => ch.entity.getX() === lastClosestHotspot.getX() && ch.entity.getY() === lastClosestHotspot.getY() && ch.entity.getZ() === lastClosestHotspot.getZ())
+        ) {
+            playAlert();
+            lastClosestHotspot = null;
+            lastClosestHotspotPerk = null;
+        }
+
+        const isHookActive = isFishingHookActive();
+        if (isHookActive) {
+            const playerHook = World.getAllEntitiesOfType(EntityFishHook).find(e => Player.getPlayer().field_71104_cf == e.getEntity()); // field_71104_cf = fishEntity
+
+            const closestHotspot = currentHotspots
+                .filter(h => h.entity.distanceTo(playerHook) <= 5)
+                .sort((a, b) => a.entity.distanceTo(playerHook) < b.entity.distanceTo(playerHook))
+                .find(() => true);
+
+            lastClosestHotspot = closestHotspot?.entity;
+            lastClosestHotspotPerk = closestHotspot?.perk || null;
+        }
+	} catch (e) {
+		console.error(e);
+		console.log(`[FeeshNotifier] Failed to play alert on Hotspot gone.`);
+	}
+}
+
+function playAlert() {
+    Client.showTitle(`${YELLOW}Hotspot is gone`, '', 1, 30, 1);
+    ChatLib.chat(`${GOLD}[FeeshNotifier] ${LIGHT_PURPLE}Hotspot ${lastClosestHotspotPerk} ${RESET}${WHITE}is gone, time to find another one!`);
+        
+    if (settings.soundMode !== OFF_SOUND_MODE) {
+        World.playSound('random.orb', 1, 1);
+    }
+}

--- a/features/alerts/alertOnHotspotGone.js
+++ b/features/alerts/alertOnHotspotGone.js
@@ -23,9 +23,9 @@ function playAlertOnHotspotGone() {
 			return;
 		}
 		
-        const nearbyHotspots = findHotspotsInRange(Player.getPlayer(), 20);
+        const nearbyHotspots = findHotspotsInRange(Player.getPlayer(), 30);
 
-        if (lastClosestHotspot && lastClosestHotspot.entity.distanceTo(Player.getPlayer()) > 20) { // Player moved away
+        if (lastClosestHotspot && lastClosestHotspot.entity.distanceTo(Player.getPlayer()) > 30) { // Player moved away
             lastClosestHotspot = null;
         }
         

--- a/features/alerts/alertOnHotspotGone.js
+++ b/features/alerts/alertOnHotspotGone.js
@@ -23,7 +23,7 @@ function playAlertOnHotspotGone() {
 			return;
 		}
 		
-        const nearbyHotspots = findHotspotsInRange(Player.getPlayer(), 30);
+        const nearbyHotspots = findHotspotsInRange(Player.getPlayer(), 20);
 
         if (lastClosestHotspot && lastClosestHotspot.entity.distanceTo(Player.getPlayer()) > 20) { // Player moved away
             lastClosestHotspot = null;

--- a/features/chat/announceMobSpawnToAllChat.js
+++ b/features/chat/announceMobSpawnToAllChat.js
@@ -1,7 +1,7 @@
 import settings from '../../settings';
 import * as triggers from '../../constants/triggers';
 import * as seaCreatures from '../../constants/seaCreatures';
-import { isDoubleHook } from '../../utils/common';
+import { getMessageId, getZoneName, isDoubleHook } from '../../utils/common';
 import { isInSkyblock } from '../../utils/playerState';
 
 const chatCommand = 'ac';
@@ -40,8 +40,8 @@ function announceMobSpawnToAllChat(seaCreature, isAnnounceToAllChatEnabledSettin
 
 function getMessage(seaCreature, isDoubleHooked) {
     const location = `x: ${Math.round(Player.getX())}, y: ${Math.round(Player.getY())}, z: ${Math.round(Player.getZ())}`;
-    const zone = Scoreboard.getLines().find((line) => line.getName().includes('⏣'));
-    const messageId = ` @${(Math.random() + 1).toString(36).substring(4)}`; // Inspired by VolcAddons - to prevent "You cannot say the same message twice" error
+    const zone = getZoneName();
+    const messageId = getMessageId();
 
     let message = '';
     message += `${location} | ${seaCreature} ${isDoubleHooked ? 'x2' : '' }${zone ? ' at ' + zone.getName().removeFormatting() : ''} | ${messageId}`;

--- a/features/chat/messageOnHotspotFound.js
+++ b/features/chat/messageOnHotspotFound.js
@@ -23,6 +23,7 @@ function sendMessageOnHotspotFound() {
 		}
 		
         const closestHotspot = findClosestHotspotInRange(Player.getPlayer(), 6);
+        console.log(new Date() + ' ' + JSON.stringify(lastClosestHotspot?.position?.x) + ' ' + JSON.stringify(closestHotspot?.position?.x));
 
         if ((!lastClosestHotspot && closestHotspot) ||
             (lastClosestHotspot && closestHotspot &&
@@ -31,6 +32,7 @@ function sendMessageOnHotspotFound() {
                 closestHotspot.position.z !== lastClosestHotspot.position.z
             )
         ) {
+            console.log('Alert');
             sendChatMessage(closestHotspot.position, closestHotspot.perk);
         }
 
@@ -44,7 +46,10 @@ function sendMessageOnHotspotFound() {
 }
 
 function sendChatMessage(position, perk) {
-    if (!position || !perk) return;
+    if (!position || !perk) {
+        ChatLib.chat('DEBUG - no perk found') // TODO
+        return;
+    }
 
     const message = getMessage(position, perk);
     new Message(

--- a/features/chat/messageOnHotspotFound.js
+++ b/features/chat/messageOnHotspotFound.js
@@ -23,16 +23,14 @@ function sendMessageOnHotspotFound() {
 		}
 		
         const closestHotspot = findClosestHotspotInRange(Player.getPlayer(), 6);
-        console.log(new Date() + ' ' + JSON.stringify(lastClosestHotspot?.position?.x) + ' ' + JSON.stringify(closestHotspot?.position?.x));
 
         if ((!lastClosestHotspot && closestHotspot) ||
-            (lastClosestHotspot && closestHotspot &&
-                closestHotspot.position.x !== lastClosestHotspot.position.x &&
-                closestHotspot.position.y !== lastClosestHotspot.position.y &&
-                closestHotspot.position.z !== lastClosestHotspot.position.z
+            (lastClosestHotspot && closestHotspot && !(
+                closestHotspot.position.x === lastClosestHotspot.position.x &&
+                closestHotspot.position.y === lastClosestHotspot.position.y &&
+                closestHotspot.position.z === lastClosestHotspot.position.z)
             )
         ) {
-            console.log('Alert');
             sendChatMessage(closestHotspot.position, closestHotspot.perk);
         }
 
@@ -47,17 +45,16 @@ function sendMessageOnHotspotFound() {
 
 function sendChatMessage(position, perk) {
     if (!position || !perk) {
-        ChatLib.chat('DEBUG - no perk found') // TODO
         return;
     }
 
     const message = getMessage(position, perk);
     new Message(
         `${GOLD}[FeeshNotifier] ${WHITE}You found ${perk} ${RESET}${LIGHT_PURPLE}Hotspot${WHITE}.\n`,
-        new TextComponent(`${BLUE}${BOLD}[Click to share to PARTY chat]\n`)
+        new TextComponent(`${WHITE}${BOLD}[Share to ${BLUE}${BOLD}PARTY ${WHITE}${BOLD}chat]\n`)
             .setClickAction('run_command')
             .setClickValue('/pc ' + message),
-        new TextComponent(`${WHITE}${BOLD}[Click to share to ALL chat]`)
+        new TextComponent(`${WHITE}${BOLD}[Share to ALL chat]`)
             .setClickAction('run_command')
             .setClickValue('/ac ' + message),
     ).chat();

--- a/features/chat/messageOnHotspotFound.js
+++ b/features/chat/messageOnHotspotFound.js
@@ -1,0 +1,92 @@
+import settings from "../../settings";
+import { getWorldName, isInSkyblock } from "../../utils/playerState";
+import { HOTSPOT_WORLDS } from "../../constants/areas";
+import { BLUE, BOLD, GOLD, LIGHT_PURPLE, RESET, WHITE } from "../../constants/formatting";
+import { EntityArmorStand } from "../../constants/javaTypes";
+import { getMessageId, getZoneName } from "../../utils/common";
+
+let lastClosestHotspot = null;
+
+register("step", (event) => sendMessageOnHotspotFound()).setDelay(1);
+register("worldUnload", () => {
+    lastClosestHotspot = null;
+});
+
+function findClosestHotspotTo(entity, radius) {
+    if (!entity || !radius) return;
+
+    const armorStands = World.getAllEntitiesOfType(EntityArmorStand).filter(as => as.distanceTo(entity) <= radius);
+    const closestHotspotArmorStand = armorStands
+        .filter(as => as?.getName()?.removeFormatting() === 'HOTSPOT')
+        .sort((a, b) => a.distanceTo(entity) < b.distanceTo(entity))
+        .find(() => true); // Find first or null
+
+    const closestHotspot = closestHotspotArmorStand
+        ? {
+            position: closestHotspotArmorStand.getPos(),
+            perk: armorStands.find(e =>
+                e.getX() === closestHotspotArmorStand.getX() &&
+                e.getY() < closestHotspotArmorStand.getY() &&
+                closestHotspotArmorStand.getY() - e.getY() < 2 &&
+                e.getZ() === closestHotspotArmorStand.getZ() &&
+                e.getPitch() === closestHotspotArmorStand.getPitch())?.getName()
+        }
+        : null;
+
+    return closestHotspot;
+}
+
+function sendMessageOnHotspotFound() {
+	try {
+		if (!settings.messageOnHotspotFound ||
+            !HOTSPOT_WORLDS.includes(getWorldName()) ||
+            !isInSkyblock()
+        ) {
+			return;
+		}
+		
+        const closestHotspot = findClosestHotspotTo(Player.getPlayer(), 6);
+
+        if ((!lastClosestHotspot && closestHotspot) ||
+            (lastClosestHotspot && closestHotspot &&
+                closestHotspot.position.x !== lastClosestHotspot.position.x &&
+                closestHotspot.position.y !== lastClosestHotspot.position.y &&
+                closestHotspot.position.z !== lastClosestHotspot.position.z
+            )
+        ) {
+            sendChatMessage(closestHotspot.position, closestHotspot.perk);
+        }
+
+        if (closestHotspot) { // Do not share the same hotspot
+            lastClosestHotspot = closestHotspot;
+        }
+	} catch (e) {
+		console.error(e);
+		console.log(`[FeeshNotifier] Failed to send message on Hotspot found.`);
+	}
+}
+
+function sendChatMessage(position, perk) {
+    if (!position || !perk) return;
+
+    const message = getMessage(position, perk);
+    new Message(
+        `${GOLD}[FeeshNotifier] ${WHITE}You found ${perk} ${RESET}${LIGHT_PURPLE}Hotspot${WHITE}.\n`,
+        new TextComponent(`${BLUE}${BOLD}[Click to share to PARTY chat]\n`)
+            .setClickAction('run_command')
+            .setClickValue('/pc ' + message),
+        new TextComponent(`${WHITE}${BOLD}[Click to share to ALL chat]`)
+            .setClickAction('run_command')
+            .setClickValue('/ac ' + message),
+    ).chat();
+}
+
+function getMessage(position, perk) {
+    const location = `x: ${Math.round(position.x)}, y: ${Math.round(position.y)}, z: ${Math.round(position.z)}`;
+    const zone = getZoneName();
+    const messageId = getMessageId();
+
+    let message = '';
+    message += `${location} | ${perk ? perk.removeFormatting() + ' ' : ''}Hotspot ${zone ? ' at ' + zone.getName().removeFormatting() : ''} | ${messageId}`;
+    return message;
+}

--- a/features/overlays/legionAndBobbingTimeTracker.js
+++ b/features/overlays/legionAndBobbingTimeTracker.js
@@ -4,7 +4,7 @@ import { EntityFishHook } from "../../constants/javaTypes";
 import { overlayCoordsData } from "../../data/overlayCoords";
 import { getWorldName, hasFishingRodInHotbar, isInSkyblock } from "../../utils/playerState";
 import { KUUDRA } from "../../constants/areas";
-import { getPlayerNamesInRange } from "../../utils/common";
+import { getPlayerNamesInRange } from "../../utils/entityDetection";
 
 let playersCount = 0;
 let fishingHooksCount = 0;

--- a/index.js
+++ b/index.js
@@ -16,6 +16,7 @@ import "./features/alerts/alertOnThunderBottleCharged";
 import "./features/alerts/alertOnSpiritMaskUsed";
 import "./features/alerts/alertOnGoldenFish";
 import "./features/alerts/alertOnFishingBagDisabled";
+import "./features/alerts/alertOnHotspotGone";
 
 import "./features/overlays/rareCatchesTracker";
 import "./features/overlays/totemTracker";
@@ -45,6 +46,7 @@ import "./features/inventory/showExpBoostPercentage";
 import "./features/chat/announceMobSpawnToAllChat";
 import "./features/chat/messageOnPlayerDeath";
 import "./features/chat/messageOnRevenant";
+import "./features/chat/messageOnHotspotFound";
 import "./features/chat/compactCatchMessages";
 
 register('worldLoad', () => {

--- a/metadata.json
+++ b/metadata.json
@@ -3,7 +3,7 @@
     "entry": "index.js",
     "author": "MoonTheSadFisher",
     "description": "Hypixel Skyblock fishing utilities for parties.",
-    "version": "1.31.1",
+    "version": "1.32.0",
     "requires": [
         "Amaterasu",
         "PogData",

--- a/settings.js
+++ b/settings.js
@@ -66,6 +66,14 @@ const config = new DefaultConfig("FeeshNotifier", "config/settings.json")
     subcategory: "Player's death",
     value: true
 })
+.addSwitch({
+    category: "Chat",
+    configName: "messageOnHotspotFound",
+    title: "Offer sharing the found hotspots",
+    description: "Shows clickable chat message that offers sharing Hotspot location and its perk to ALL chat or PARTY chat. You need to be close to the hotspot to trigger it.",
+    subcategory: "Hotspot",
+    value: true
+})
 
 .addSwitch({
     category: "Chat",
@@ -479,6 +487,14 @@ const config = new DefaultConfig("FeeshNotifier", "config/settings.json")
     title: "Alert when a Spirit Mask is ready after being used",
     description: "Shows a title and plays a sound when your Spirit Mask's Second Wind ability is back after it was activated.",
     subcategory: "Spirit Mask"
+})
+.addSwitch({
+    category: "Alerts",
+    configName: "alertOnHotspotGone",
+    title: "Alert when the hotspot is gone",
+    description: "Shows a title and plays a sound when the hotspot you recently fished in, is gone.",
+    subcategory: "Hotspot",
+    value: true
 })
 .addSwitch({
     category: "Alerts",

--- a/settings.js
+++ b/settings.js
@@ -70,7 +70,7 @@ const config = new DefaultConfig("FeeshNotifier", "config/settings.json")
     category: "Chat",
     configName: "messageOnHotspotFound",
     title: "Offer sharing the found hotspots",
-    description: "Shows clickable chat message that offers sharing Hotspot location and its perk to ALL chat or PARTY chat. You need to be close to the hotspot to trigger it.",
+    description: "Shows clickable chat message that offers sharing Hotspot location and its perk to ALL chat or PARTY chat. You need to be close to the hotspot in order to trigger it.",
     subcategory: "Hotspot",
     value: true
 })

--- a/utils/common.js
+++ b/utils/common.js
@@ -233,21 +233,6 @@ export function isInSupercraftGui() {
 	return (!!chestName && chestName.endsWith('Recipe'));
 }
 
-export function getPlayerNamesInRange(distance) {
-	const players = World
-		.getAllPlayers()
-		.filter(player =>
-			(player.getUUID().version() === 4 || player.getUUID().version() === 1) && // Players and Watchdog have version 4, nicked players have version 1, this is done to exclude NPCs
-			player.ping === 1 && // -1 is watchdog and ghost players, also there is a ghost player with high ping value when joining a world
-			player.name != Player.getName() && // Exclude current player because they do not count for legion
-			player.distanceTo(Player.getPlayer()) <= distance
-		)
-		.map(player => player.name)
-		.filter((x, i, a) => a.indexOf(x) == i); // Distinct, sometimes the players are duplicated in the list
-		
-	return players;
-}
-
 export function getItemsAddedToSacks(eventMessage) {
 	let items = [];
 
@@ -300,6 +285,14 @@ export function isFishingRod(item) {
 }
 
 /**
+ * Gets current player's fishing hook entity.
+ * @returns {EntityFishHook}
+ */
+export function getPlayerFishingHook() {
+	return World.getAllEntitiesOfType(EntityFishHook).find(e => Player.getPlayer().field_71104_cf == e.getEntity()); // field_71104_cf = fishEntity
+}
+
+/**
  * Checks if a fishing rod is casted (fishing hook is in water or lava).
  * @returns {boolean}
  */
@@ -309,7 +302,7 @@ export function isFishingHookActive() {
         return false;
     }
 
-	const playerHook = World.getAllEntitiesOfType(EntityFishHook).find(e => Player.getPlayer().field_71104_cf == e.getEntity()); // field_71104_cf = fishEntity
+	const playerHook = getPlayerFishingHook();
 	if (!playerHook) {
 		return false;
 	}

--- a/utils/common.js
+++ b/utils/common.js
@@ -430,6 +430,24 @@ export function getArticle(str) {
 	return isFirstLetterVowel ? 'An' : 'A';
 }
 
+/**
+ * Get random characters substring to make message content unique and prevent "You cannot say the same message twice" error. Inspired by VolcAddons
+ * @returns {string} Random substring
+ */
+export function getMessageId() {
+	const messageId = ` @${(Math.random() + 1).toString(36).substring(4)}`;
+	return messageId;
+}
+
+/**
+ * Get current zone name.
+ * @returns {string} Formatted zone name if exists, or empty string
+ */
+export function getZoneName() {
+	const zoneLine = Scoreboard.getLines().find((line) => line.getName().includes('⏣'));
+	return zoneLine || '';
+}
+
 function getCurrentGuiChestName() {
 	if (Client.isInGui() && Client.currentGui?.getClassName() === 'GuiChest') {
 		const chestName = Client.currentGui?.get()?.field_147002_h?.func_85151_d()?.func_145748_c_()?.text;

--- a/utils/entityDetection.js
+++ b/utils/entityDetection.js
@@ -1,0 +1,77 @@
+import { EntityArmorStand } from '../constants/javaTypes';
+
+/**
+ * Find all Hotspots within the specified range from the specified entity.
+ * @returns {Array} Hotspots in the format { entity, position, perk }
+ */
+export function findHotspotsInRange(entity, distance) {
+	if (!entity || !distance) return;
+
+	const armorStands = World.getAllEntitiesOfType(EntityArmorStand).filter(as => as.distanceTo(entity) <= distance);
+	const closeHotspotArmorStands = armorStands
+		.filter(as => as?.getName()?.removeFormatting() === 'HOTSPOT')
+		.sort((a, b) => a.distanceTo(entity) < b.distanceTo(entity))
+		.map(as => {
+			const obj = {
+				entity: as,
+				position: as.getPos(),
+				perk: armorStands.find(e =>
+					e.getX() === as.getX() &&
+					e.getY() < as.getY() &&
+					as.getY() - e.getY() < 2 &&
+					e.getZ() === as.getZ() &&
+					e.getPitch() === as.getPitch())?.getName()
+			};
+			return obj;
+		});
+
+	return closeHotspotArmorStands;
+}
+
+/**
+ * Find the closest Hotspot in the specified range from the specified entity.
+ * @returns {Array} Hotspot in the format { entity, position, perk }
+ */
+export function findClosestHotspotInRange(entity, distance) {
+	if (!entity || !distance) return;
+
+	const armorStands = World.getAllEntitiesOfType(EntityArmorStand).filter(as => as.distanceTo(entity) <= distance);
+	const closestHotspotArmorStand = armorStands
+		.filter(as => as?.getName()?.removeFormatting() === 'HOTSPOT')
+		.sort((a, b) => a.distanceTo(entity) < b.distanceTo(entity))
+		.find(() => true); // Find first or null
+
+	const closestHotspot = closestHotspotArmorStand
+		? {
+			entity: closestHotspotArmorStand,
+			position: closestHotspotArmorStand.getPos(),
+			perk: armorStands.find(e =>
+				e.getX() === closestHotspotArmorStand.getX() &&
+				e.getY() < closestHotspotArmorStand.getY() &&
+				closestHotspotArmorStand.getY() - e.getY() < 2 &&
+				e.getZ() === closestHotspotArmorStand.getZ() &&
+				e.getPitch() === closestHotspotArmorStand.getPitch())?.getName()
+		}
+		: null;
+
+	return closestHotspot;
+}
+
+/**
+ * Find the players within the specified range from the current player.
+ * @returns {Array} Array of player names
+ */
+export function getPlayerNamesInRange(distance) {
+	const players = World
+		.getAllPlayers()
+		.filter(player =>
+			(player.getUUID().version() === 4 || player.getUUID().version() === 1) && // Players and Watchdog have version 4, nicked players have version 1, this is done to exclude NPCs
+			player.ping === 1 && // -1 is watchdog and ghost players, also there is a ghost player with high ping value when joining a world
+			player.name != Player.getName() && // Exclude current player because they do not count for legion
+			player.distanceTo(Player.getPlayer()) <= distance
+		)
+		.map(player => player.name)
+		.filter((x, i, a) => a.indexOf(x) == i); // Distinct, sometimes the players are duplicated in the list
+		
+	return players;
+}

--- a/utils/entityDetection.js
+++ b/utils/entityDetection.js
@@ -18,7 +18,7 @@ export function findHotspotsInRange(entity, distance) {
 				perk: armorStands.find(e =>
 					e.getX() === as.getX() &&
 					e.getY() < as.getY() &&
-					as.getY() - e.getY() < 2 &&
+					as.getY() - e.getY() <= 1 &&
 					e.getZ() === as.getZ() &&
 					e.getPitch() === as.getPitch())?.getName()
 			};
@@ -48,7 +48,7 @@ export function findClosestHotspotInRange(entity, distance) {
 			perk: armorStands.find(e =>
 				e.getX() === closestHotspotArmorStand.getX() &&
 				e.getY() < closestHotspotArmorStand.getY() &&
-				closestHotspotArmorStand.getY() - e.getY() < 2 &&
+				closestHotspotArmorStand.getY() - e.getY() <= 1 &&
 				e.getZ() === closestHotspotArmorStand.getZ() &&
 				e.getPitch() === closestHotspotArmorStand.getPitch())?.getName()
 		}


### PR DESCRIPTION
- Added alert when the Hotspot you recently fished in, is gone.
- Added option to share Hotspot location and its perk to ALL chat or PARTY chat on chat message click. You need to be close to the hotspot in order to trigger it.
- 
Refactoring:
- Moved some logic to new entity detection script.