### PR TITLE
fix: Fixed issue of hotspot double announcement

### DIFF
--- a/features/alerts/alertOnHotspotGone.js
+++ b/features/alerts/alertOnHotspotGone.js
@@ -23,9 +23,9 @@ function playAlertOnHotspotGone() {
 			return;
 		}
 		
-        const nearbyHotspots = findHotspotsInRange(Player.getPlayer(), 30);
+        const nearbyHotspots = findHotspotsInRange(Player.getPlayer(), 20);
 
-        if (lastClosestHotspot && lastClosestHotspot.entity.distanceTo(Player.getPlayer()) > 30) { // Player moved away
+        if (lastClosestHotspot && lastClosestHotspot.entity.distanceTo(Player.getPlayer()) > 20) { // Player moved away
             lastClosestHotspot = null;
         }
         


### PR DESCRIPTION
- Fixed double announcement of Hotspot found when moving between 2 nearby hotspots
- Fixed "Hotspot gone" when player moves away from Hotspot and nametag is not visible