### PR TITLE
fix: Changed total profit in Fishing Profit Tracker being 0 after leveling up a soulbound pet

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -7,6 +7,7 @@ Released: ???
 Features:
 
 Bugfixes:
+- Changed total profit in Fishing Profit Tracker being 0 after leveling up a soulbound pet.
 
 ## v1.34.0
 

--- a/features/overlays/fishingProfitTracker.js
+++ b/features/overlays/fishingProfitTracker.js
@@ -440,7 +440,7 @@ function onPetReachedMaxLevel(level, petDisplayName) {
         const itemIdMaxLevel = baseItemId + ';' + rarityCode + '+' + level; // FLYING_FISH;4+100 GOLDEN_DRAGON;4+200
         const item = persistentData.fishingProfit.profitTrackerItems[itemIdMaxLevel];
         const auctionPrices = getAuctionItemPrices(itemIdMaxLevel);
-        const itemPrice = auctionPrices?.lbin;
+        const itemPrice = auctionPrices?.lbin || 0;
 
         const currentAmount = item?.amount || 0;
         const currentProfit = item?.totalItemProfit || 0;


### PR DESCRIPTION
Changed total profit in Fishing Profit Tracker being 0 after leveling up a soulbound pet. Pet price was calculated as null, so it gives null as total profit.