### PR TITLE
fix: Removed calculation of Orb of Energy profits as Pulse Rings

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -10,7 +10,10 @@ Features:
 
 Bugfixes:
 - Fixed Frozen Steve catch message not being compacted.
-- Fixed total profit in Fishing Profit Tracker being 0 after leveling up a soulbound pet.
+- Fixed total profit in Fishing Profit Tracker being 0 after leveling up a pet with unknown price.
+
+Other:
+- Removed calculation of Orb of Energy profits as Pulse Rings (justification - it was added when Orb of Energy was soulbound, but now it can be sold on bazaar, so removed recalculation for consistency).
 
 ## v1.34.0
 

--- a/docs/Future ideas & requests.md
+++ b/docs/Future ideas & requests.md
@@ -1,21 +1,21 @@
 - Track catches for Ragnarok in crimson isle tracker (when in hotspot).
-- Track double hooks in Rare Catches Tracker
+- Track double hooks count and % in Rare Catches Tracker
 - Box Wiki Tiki totems, Jawbus followers
 - Hotspot search
 - Offer supercrafting or BZ sell when items like raw fish goes to inventory (sacks are full).
-- Some items are tracked by profit tracker when dropped, but drop was prevented by SB settings (basically it drops and picks up again).
-- Scavenged coins
-- Ice Essence drop from mobs
-- [Bug] Some items are tracked by profit tracker when dropped, but drop was prevented by SB settings (basically it drops and picks up again).
-- Calculate pet price in profit tracker as difference between lvl 1 and lvl 100
+- Track scavenged coins in Fishing Profit Tracker
+- Track Ice Essence drop from mobs in Fishing Profit Tracker
+- [Bug] Some items are tracked by Fishing Profit Tracker when dropped, but drop was prevented by SB settings (basically it drops and picks up again).
+- [Bug] Fishing Profit Tracker recalculates profits/h too often when in "display buttons" mode.
+- [Bug] Some items are tracked by Fishing Profit Tracker when dropped, but drop was prevented by SB settings (basically it drops and picks up again).
+- [Bug] Trading with other players adds items to the profit trackers.
+- Calculate pet price in Fishing Profit Tracker as difference between lvl 1 and lvl 100
   - Also, there are requests to track pet level progress in coins
 - Remove double hook reindrake logic because DH is not possible now
-- Probably remove calculation of profits in Pulse Rings
-- [Bug] Total price is set to 0 in Profit tracker while other lines being normal (very rare and seems random).
-- Sea creatures/hour [Aidan]
+- Sea creatures/hour
 - Disable functionalities in Dungeons, Garden same way as it's done for Kuudra.
 - Rain/Thunder widget
-- Find out price calculation for Kuudra Keys in profit tracker
+- Find out price calculation for Kuudra Keys in Fishing Profit Tracker
 - Achievements (ScathaPro / SBO as reference)
 - Party chat commands
   - !feeshsincejawbus
@@ -33,9 +33,8 @@
   - Ability to test sound from settings
   - Toggle setting to enable customization
 - Render mob immunity flag
-- Highlight rare sea creatures
+- Highlight / box rare sea creatures (make this not visible through walls)
 - Total and session tracker, or ability to load named session
-- Trading with other players adds items to the profit trackers
 - Multiple drops that happen at the same time lead to "You're sending messages too fast" error.
 - Personal cap alert (20 for CH, 5 for Crimson)
 - Expertise widget

--- a/features/overlays/fishingProfitTracker.js
+++ b/features/overlays/fishingProfitTracker.js
@@ -248,18 +248,8 @@ function refreshPrices() {
                 return;
             }
 
-            if (item.itemId === 'ORB_OF_ENERGY') { // Calculate Orbs of Energy price as Pulse Rings + remainder in Orb of Energy
-                const pulseRingPrices = getAuctionItemPrices('PULSE_RING');
-                const pulseRingPrice = pulseRingPrices?.lbin || 0;
-                const pulseRingsCount = pulseRingPrice ? Math.floor(value.amount / 256) : 0;
-                const remainder = pulseRingsCount ? value.amount % 256 : value.amount;
-
-                const itemPrice = getItemPrice(item);
-                value.totalItemProfit = (pulseRingsCount * pulseRingPrice) + (remainder * itemPrice);
-            } else {
-                const itemPrice = getItemPrice(item);
-                value.totalItemProfit = value.amount * itemPrice;    
-            }
+            const itemPrice = getItemPrice(item);
+            value.totalItemProfit = value.amount * itemPrice;  
         });
     
         const total = Object.values(persistentData.fishingProfit.profitTrackerItems).reduce((accumulator, currentValue) => { return accumulator + currentValue.totalItemProfit }, 0);


### PR DESCRIPTION
Removed calculation of Orb of Energy profits as Pulse Rings (justification - it was added when Orb of Energy was soulbound, but now it can be sold on bazaar, so removed recalculation for consistency).