### PR TITLE
Release 1.35.0

### DIFF
--- a/constants/triggers.js
+++ b/constants/triggers.js
@@ -33,7 +33,7 @@ export const TIGER_SHARK_MESSAGE = `${GREEN}A striped beast bounds from the dept
 export const YETI_MESSAGE = `${GREEN}What is this creature!?`; // &aWhat is this creature!?
 export const REINDRAKE_MESSAGE = `${GREEN}A Reindrake forms from the depths.`; // &aA Reindrake forms from the depths.
 export const NUTCRACKER_MESSAGE = `${GREEN}You found a forgotten Nutcracker laying beneath the ice.`;
-export const FROZEN_STEVE_MESSAGE = `${GREEN}Frozen Steve fell into the pond long ago, never to &r&aresurface...until${RESET}${GREEN} now!`;
+export const FROZEN_STEVE_MESSAGE = `${GREEN}Frozen Steve fell into the pond long ago, never to resurface...until now!`;
 export const FROSTY_MESSAGE = `${GREEN}It's a snowman! He looks harmless.`;
 export const GRINCH_MESSAGE = `${GREEN}The Grinch stole Jerry's ${RESET}${GREEN}Gifts...get${RESET}${GREEN} them back!`;
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -8,7 +8,8 @@ Features:
 - Added setting to ignore renderong of attributes for specific items. Search for "Ignored items" in Attributes section, and fill in item names to not see attributes on them.
 
 Bugfixes:
-- Changed total profit in Fishing Profit Tracker being 0 after leveling up a soulbound pet.
+- Fixed Frozen Steve catch message not being compacted.
+- Fixed total profit in Fishing Profit Tracker being 0 after leveling up a soulbound pet.
 
 ## v1.34.0
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -5,7 +5,8 @@
 Released: ???
 
 Features:
-- Added setting to ignore renderong of attributes for specific items. Search for "Ignored items" in Attributes section, and fill in item names to not see attributes on them.
+- Added setting to ignore rendering of attributes for specific items. Search for "Ignored items" in Attributes section, and fill in item names to not see attributes on them.
+- Added setting to display overlay buttons (Reset / Pause) on top of the overlay. Search for "Buttons position" setting in Overlays section.
 
 Bugfixes:
 - Fixed Frozen Steve catch message not being compacted.

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -10,7 +10,8 @@ Features:
 
 Bugfixes:
 - Fixed Frozen Steve catch message not being compacted.
-- Fixed total profit in Fishing Profit Tracker being 0 after leveling up a pet with unknown price.
+- Fixed total profit in Fishing Profit Tracker being 0 after leveling up a soulbound pet.
+- Fixed error when new item is added to bazaar by SB and has not full details exposed from the Hypixel API.
 
 Other:
 - Removed calculation of Orb of Energy profits as Pulse Rings (justification - it was added when Orb of Energy was soulbound, but now it can be sold on bazaar, so removed recalculation for consistency).

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,8 +1,16 @@
 # Releases
 
-## v1.34.0
+## v1.35.0
 
 Released: ???
+
+Features:
+
+Bugfixes:
+
+## v1.34.0
+
+Released: 2025-04-01
 
 Features:
 - Added option to render attribute name / level for Attribute Shards [disabled by default].

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -5,6 +5,7 @@
 Released: ???
 
 Features:
+- Added setting to ignore renderong of attributes for specific items. Search for "Ignored items" in Attributes section, and fill in item names to not see attributes on them.
 
 Bugfixes:
 - Changed total profit in Fishing Profit Tracker being 0 after leveling up a soulbound pet.

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -7,6 +7,7 @@ Released: ???
 Features:
 
 Bugfixes:
+- Changed total profit in Fishing Profit Tracker being 0 after leveling up a soulbound pet.
 
 ## v1.34.0
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -10,7 +10,10 @@ Features:
 
 Bugfixes:
 - Fixed Frozen Steve catch message not being compacted.
-- Fixed total profit in Fishing Profit Tracker being 0 after leveling up a soulbound pet.
+- Fixed total profit in Fishing Profit Tracker being 0 after leveling up a pet with unknown price.
+
+Other:
+- Removed calculation of Orb of Energy profits as Pulse Rings (justification - it was added when Orb of Energy was soulbound, but now it can be sold on bazaar, so removed recalculation for consistency).
 
 ## v1.34.0
 

--- a/docs/Future ideas & requests.md
+++ b/docs/Future ideas & requests.md
@@ -1,21 +1,21 @@
 - Track catches for Ragnarok in crimson isle tracker (when in hotspot).
-- Track double hooks in Rare Catches Tracker
+- Track double hooks count and % in Rare Catches Tracker
 - Box Wiki Tiki totems, Jawbus followers
 - Hotspot search
 - Offer supercrafting or BZ sell when items like raw fish goes to inventory (sacks are full).
-- Some items are tracked by profit tracker when dropped, but drop was prevented by SB settings (basically it drops and picks up again).
-- Scavenged coins
-- Ice Essence drop from mobs
-- [Bug] Some items are tracked by profit tracker when dropped, but drop was prevented by SB settings (basically it drops and picks up again).
-- Calculate pet price in profit tracker as difference between lvl 1 and lvl 100
+- Track scavenged coins in Fishing Profit Tracker
+- Track Ice Essence drop from mobs in Fishing Profit Tracker
+- [Bug] Some items are tracked by Fishing Profit Tracker when dropped, but drop was prevented by SB settings (basically it drops and picks up again).
+- [Bug] Fishing Profit Tracker recalculates profits/h too often when in "display buttons" mode.
+- [Bug] Some items are tracked by Fishing Profit Tracker when dropped, but drop was prevented by SB settings (basically it drops and picks up again).
+- [Bug] Trading with other players adds items to the profit trackers.
+- Calculate pet price in Fishing Profit Tracker as difference between lvl 1 and lvl 100
   - Also, there are requests to track pet level progress in coins
 - Remove double hook reindrake logic because DH is not possible now
-- Probably remove calculation of profits in Pulse Rings
-- [Bug] Total price is set to 0 in Profit tracker while other lines being normal (very rare and seems random).
-- Sea creatures/hour [Aidan]
+- Sea creatures/hour
 - Disable functionalities in Dungeons, Garden same way as it's done for Kuudra.
 - Rain/Thunder widget
-- Find out price calculation for Kuudra Keys in profit tracker
+- Find out price calculation for Kuudra Keys in Fishing Profit Tracker
 - Achievements (ScathaPro / SBO as reference)
 - Party chat commands
   - !feeshsincejawbus
@@ -33,9 +33,8 @@
   - Ability to test sound from settings
   - Toggle setting to enable customization
 - Render mob immunity flag
-- Highlight rare sea creatures
+- Highlight / box rare sea creatures (make this not visible through walls)
 - Total and session tracker, or ability to load named session
-- Trading with other players adds items to the profit trackers
 - Multiple drops that happen at the same time lead to "You're sending messages too fast" error.
 - Personal cap alert (20 for CH, 5 for Crimson)
 - Expertise widget

--- a/features/inventory/showAttributes.js
+++ b/features/inventory/showAttributes.js
@@ -4,6 +4,14 @@ import { isInSkyblock } from "../../utils/playerState";
 import { getItemAttributes } from "../../utils/common";
 import { registerIf } from "../../utils/registers";
 
+let ignoredItemNames = [];
+
+setIgnoredItemNames();
+
+settings.getConfig().onCloseGui(() => {
+    setIgnoredItemNames();
+});
+
 registerIf(
     register('renderItemIntoGui', (item, x, y, event) => showAttributes(item, x, y)),
     () => (settings.showAttributesOnFishingGear || settings.showAttributesOnFishingRod || settings.showAttributesOnShard || settings.showAttributesOnEverythingElse) && isInSkyblock()
@@ -19,6 +27,10 @@ function showAttributes(item, x, y) {
     const name = item.getName()?.removeFormatting();
     if (!name || name === 'AUCTION FOR ITEM:') {
         return;
+    }
+
+    if (ignoredItemNames.length) {
+        if (ignoredItemNames.some(itemName => name.toLowerCase().includes(itemName.toLowerCase().trim()))) return;
     }
 
     let highlightedAttributeCodesString = '';
@@ -77,4 +89,14 @@ function getAttributeAbbreviation(attribute) {
             : (a === 'vitality' ? 'Vi' : a.substring(0, 1).toUpperCase()))
         .join('');
     return `${attributeAbbreviation}${attribute.attributeLevel}`;
+}
+
+function setIgnoredItemNames() {
+    if (settings.showAttributesIgnoredItems) {
+        const itemNames = settings.showAttributesIgnoredItems.split(',').filter(i => !!i);
+        ignoredItemNames = itemNames;
+        return;
+    }
+
+    ignoredItemNames = [];
 }

--- a/features/overlays/abandonedQuarryTracker.js
+++ b/features/overlays/abandonedQuarryTracker.js
@@ -3,9 +3,10 @@ import { overlayCoordsData } from "../../data/overlayCoords";
 import { ABANDONED_QUARRY } from "../../constants/areas";
 import { AQUA, BOLD, GOLD, GRAY, GREEN, RED, WHITE, YELLOW } from "../../constants/formatting";
 import { ANY_MITHRIL_GRUBBER_MESSAGE } from "../../constants/triggers";
-import { formatElapsedTime, formatNumberWithSpaces, isDoubleHook, isFishingHookActive, isInChatOrInventoryGui } from "../../utils/common";
+import { formatElapsedTime, formatNumberWithSpaces, isDoubleHook, isFishingHookActive } from "../../utils/common";
 import { getLastGuisClosed, getZoneName, hasFishingRodInHotbar, isInSkyblock } from "../../utils/playerState";
 import { BLOATED_MITHRIL_GRUBBER, LARGE_MITHRIL_GRUBBER, MEDIUM_MITHRIL_GRUBBER, SMALL_MITHRIL_GRUBBER } from "../../constants/seaCreatures";
+import { createButtonsDisplay, toggleButtonsDisplay } from "../../utils/overlays";
 
 const SMALL_MITHRIL_GRUBBER_KEY = SMALL_MITHRIL_GRUBBER.toUpperCase();
 const MEDIUM_MITHRIL_GRUBBER_KEY = MEDIUM_MITHRIL_GRUBBER.toUpperCase();
@@ -32,24 +33,7 @@ let isSessionActive = false;
 let lastHookSeenAt = null;
 let previousMithrilPowder = null;
 
-// DisplayLine is initialized once in order to avoid multiple method calls on click.
-let buttonsDisplay = new Display().hide();
-
-let pauseTrackerDisplayLine = new DisplayLine(`${YELLOW}[Click to pause]`).setShadow(true);
-pauseTrackerDisplayLine.registerClicked((x, y, mouseButton, buttonState) => {
-    if (mouseButton === 0 && buttonState === false) { // When left mouse button is UP. 0 is left mouse button, false is UP, true is DOWN. 
-        pauseAbandonedQuarryTracker();
-    }
-});
-buttonsDisplay.addLine(pauseTrackerDisplayLine);
-
-let resetTrackerDisplayLine = new DisplayLine(`${RED}[Click to reset]`).setShadow(true);
-resetTrackerDisplayLine.registerClicked((x, y, mouseButton, buttonState) => {
-    if (mouseButton === 0 && buttonState === false) { // When left mouse button is UP. 0 is left mouse button, false is UP, true is DOWN. 
-        resetAbandonedQuarryTracker(false);
-    }
-});
-buttonsDisplay.addLine(resetTrackerDisplayLine);
+const buttonsDisplay = createButtonsDisplay(true, () => resetAbandonedQuarryTracker(false), true, () => pauseAbandonedQuarryTracker());
 
 register("Chat", (seaCreature, event) => {
     const isDoubleHooked = isDoubleHook();
@@ -298,14 +282,5 @@ function renderMithrilGrubberPowderTrackerOverlay() {
         .setScale(overlayCoordsData.abandonedQuarryTrackerOverlay.scale);
     overlay.draw();
 
-    const shouldShowButtons = isInChatOrInventoryGui();
-    if (shouldShowButtons) {
-        resetTrackerDisplayLine.setScale(overlayCoordsData.abandonedQuarryTrackerOverlay.scale - 0.2);
-        pauseTrackerDisplayLine.setScale(overlayCoordsData.abandonedQuarryTrackerOverlay.scale - 0.2);
-        buttonsDisplay
-            .setRenderX(overlayCoordsData.abandonedQuarryTrackerOverlay.x)
-            .setRenderY(overlayCoordsData.abandonedQuarryTrackerOverlay.y + overlay.getHeight() + 2).show();
-    } else {
-        buttonsDisplay.hide();
-    }
+    toggleButtonsDisplay(buttonsDisplay, overlay, overlayCoordsData.abandonedQuarryTrackerOverlay);
 }

--- a/features/overlays/crimsonIsleTracker.js
+++ b/features/overlays/crimsonIsleTracker.js
@@ -3,11 +3,12 @@ import * as triggers from '../../constants/triggers';
 import * as seaCreatures from '../../constants/seaCreatures';
 import { persistentData } from "../../data/data";
 import { overlayCoordsData } from "../../data/overlayCoords";
-import { BOLD, GOLD, LIGHT_PURPLE, RED, WHITE, UNDERLINE, GRAY, DARK_RED, DARK_GRAY, RESET } from "../../constants/formatting";
+import { BOLD, GOLD, LIGHT_PURPLE, RED, WHITE, GRAY, DARK_RED, DARK_GRAY, RESET } from "../../constants/formatting";
 import { getWorldName, hasFishingRodInHotbar, isInSkyblock } from "../../utils/playerState";
-import { formatDate, formatNumberWithSpaces, formatTimeElapsedBetweenDates, isDoubleHook, isInChatOrInventoryGui } from "../../utils/common";
+import { formatDate, formatNumberWithSpaces, formatTimeElapsedBetweenDates, isDoubleHook } from "../../utils/common";
 import { CRIMSON_ISLE } from "../../constants/areas";
 import { MEME_SOUND_MODE, NORMAL_SOUND_MODE, SAD_TROMBONE_SOUND_SOURCE } from "../../constants/sounds";
+import { createButtonsDisplay, toggleButtonsDisplay } from "../../utils/overlays";
 
 triggers.REGULAR_CRIMSON_CATCH_TRIGGERS.forEach(entry => {
     register("Chat", (event) => trackRegularSeaCreatureCatch()).setCriteria(entry.trigger).setContains();
@@ -35,17 +36,7 @@ register("gameUnload", () => {
     }
 });
 
-// DisplayLine is initialized once in order to avoid multiple method calls on click.
-let resetTrackerDisplay = new Display().hide();
-let resetTrackerDisplayLine = new DisplayLine(`${RED}[Click to reset]`).setShadow(true);
-resetTrackerDisplayLine.registerClicked((x, y, mouseButton, buttonState) => {
-    if (mouseButton === 0 && buttonState === false) { // When left mouse button is UP. 0 is left mouse button, false is UP, true is DOWN. 
-        resetCrimsonIsleTracker(false);
-    }
-});
-resetTrackerDisplayLine.registerHovered(() => resetTrackerDisplayLine.setText(`${RED}${UNDERLINE}[Click to reset]`).setShadow(true));
-resetTrackerDisplayLine.registerMouseLeave(() => resetTrackerDisplayLine.setText(`${RED}[Click to reset]`).setShadow(true));
-resetTrackerDisplay.addLine(resetTrackerDisplayLine);
+const buttonsDisplay = createButtonsDisplay(true, () => resetCrimsonIsleTracker(false), false, null);
 
 export function resetCrimsonIsleTracker(isConfirmed) {
     try {
@@ -264,7 +255,7 @@ function renderCrimsonIsleTrackerOverlay() {
         !hasFishingRodInHotbar() ||
         allOverlaysGui.isOpen()
     ) {
-        resetTrackerDisplay.hide();
+        buttonsDisplay.hide();
         return;
     }
 
@@ -295,13 +286,5 @@ function renderCrimsonIsleTrackerOverlay() {
         .setScale(overlayCoordsData.crimsonIsleTrackerOverlay.scale);
     overlay.draw();
 
-    const shouldShowReset = isInChatOrInventoryGui();
-    if (shouldShowReset) {
-        resetTrackerDisplayLine.setScale(overlayCoordsData.crimsonIsleTrackerOverlay.scale - 0.2);
-        resetTrackerDisplay
-            .setRenderX(overlayCoordsData.crimsonIsleTrackerOverlay.x)
-            .setRenderY(overlayCoordsData.crimsonIsleTrackerOverlay.y + overlay.getHeight() + 2).show();
-    } else {
-        resetTrackerDisplay.hide();
-    }
+    toggleButtonsDisplay(buttonsDisplay, overlay, overlayCoordsData.crimsonIsleTrackerOverlay);
 }

--- a/features/overlays/fishingProfitTracker.js
+++ b/features/overlays/fishingProfitTracker.js
@@ -440,7 +440,7 @@ function onPetReachedMaxLevel(level, petDisplayName) {
         const itemIdMaxLevel = baseItemId + ';' + rarityCode + '+' + level; // FLYING_FISH;4+100 GOLDEN_DRAGON;4+200
         const item = persistentData.fishingProfit.profitTrackerItems[itemIdMaxLevel];
         const auctionPrices = getAuctionItemPrices(itemIdMaxLevel);
-        const itemPrice = auctionPrices?.lbin;
+        const itemPrice = auctionPrices?.lbin || 0;
 
         const currentAmount = item?.amount || 0;
         const currentProfit = item?.totalItemProfit || 0;

--- a/features/overlays/fishingProfitTracker.js
+++ b/features/overlays/fishingProfitTracker.js
@@ -4,12 +4,13 @@ import { persistentData } from "../../data/data";
 import { overlayCoordsData } from "../../data/overlayCoords";
 import { CRIMSON_ISLE, JERRY_WORKSHOP, KUUDRA } from "../../constants/areas";
 import { FISHING_PROFIT_ITEMS } from "../../constants/fishingProfitItems";
-import { AQUA, BOLD, GOLD, GRAY, RESET, WHITE, YELLOW, RED, GREEN, BLUE } from "../../constants/formatting";
+import { AQUA, BOLD, GOLD, GRAY, RESET, WHITE, RED, GREEN, BLUE } from "../../constants/formatting";
 import { getAuctionItemPrices, getPetRarityCode } from "../../utils/auctionPrices";
 import { getBazaarItemPrices } from "../../utils/bazaarPrices";
 import { formatElapsedTime, getCleanItemName, getItemsAddedToSacks, getLore, isFishingHookActive, isInChatOrInventoryGui, isInSacksGui, isInSupercraftGui, splitArray, toShortNumber } from "../../utils/common";
 import { getLastGuisClosed, getLastKatUpgrade, getWorldName, hasFishingRodInHotbar, isInSkyblock } from "../../utils/playerState";
 import { playRareDropSound } from '../../utils/sound';
+import { createButtonsDisplay, getButtonsDisplayRenderY } from '../../utils/overlays';
 
 let isVisible = false;
 let areActionsVisible = false;
@@ -60,6 +61,7 @@ register("gameUnload", () => {
     }
 });
 
+const buttonsDisplay = createButtonsDisplay(true, () => resetFishingProfitTracker(false), true, () => pauseFishingProfitTracker());
 let profitTrackerDisplay = new Display().hide();
 
 export function resetFishingProfitTracker(isConfirmed) {
@@ -651,6 +653,7 @@ function refreshTrackerDisplayData() {
                 clearDisplay();
                 profitTrackerDisplay.hide();  
             }
+            buttonsDisplay.hide();
             return;
         }
     
@@ -698,6 +701,7 @@ function refreshTrackerDisplayData() {
         }
         
         clearDisplay();
+
         profitTrackerDisplay.addLine(new DisplayLine(`${AQUA}${BOLD}Fishing profit tracker`).setShadow(true).setScale(overlayCoordsData.fishingProfitTrackerOverlay.scale));
 
         displayTrackerData.entriesToShow.forEach((entry) => {
@@ -733,28 +737,23 @@ function refreshTrackerDisplayData() {
         profitTrackerDisplay.addLine(new DisplayLine(`\n${AQUA}Total: ${GOLD}${BOLD}${toShortNumber(displayTrackerData.totalProfit)} ${RESET}${GRAY}(${GOLD}${toShortNumber(displayTrackerData.profitPerHour)}${GRAY}/h)`).setShadow(true).setScale(overlayCoordsData.fishingProfitTrackerOverlay.scale));
         profitTrackerDisplay.addLine(new DisplayLine(getElapsedTimeLineText(displayTrackerData.elapsedTime)).setShadow(true).setScale(overlayCoordsData.fishingProfitTrackerOverlay.scale));  
 
-        if (areActionsVisible) {
-            let pauseTrackerDisplayLine = new DisplayLine(`\n${YELLOW}[Click to pause]`).setShadow(true).setScale(overlayCoordsData.fishingProfitTrackerOverlay.scale - 0.2);
-            pauseTrackerDisplayLine.registerClicked((x, y, mouseButton, buttonState) => {
-                if (mouseButton === 0 && buttonState === false) { // When left mouse button is UP. 0 is left mouse button, false is UP, true is DOWN. 
-                    pauseFishingProfitTracker();
-                }
-            });
-            profitTrackerDisplay.addLine(pauseTrackerDisplayLine);
-            
-            let resetTrackerDisplayLine = new DisplayLine(`${RED}[Click to reset]`).setShadow(true).setScale(overlayCoordsData.fishingProfitTrackerOverlay.scale - 0.2);
-            resetTrackerDisplayLine.registerClicked((x, y, mouseButton, buttonState) => {
-                if (mouseButton === 0 && buttonState === false) {
-                    resetFishingProfitTracker(false);
-                }
-            });
-            profitTrackerDisplay.addLine(resetTrackerDisplayLine);
-        }
-
         profitTrackerDisplay
             .setRenderX(overlayCoordsData.fishingProfitTrackerOverlay.x)
             .setRenderY(overlayCoordsData.fishingProfitTrackerOverlay.y)
             .show();
+
+        if (areActionsVisible) {
+            Client.scheduleTask(1, () => { // To let Display recalculate its .getHeight()
+            const buttonsY = getButtonsDisplayRenderY(buttonsDisplay, profitTrackerDisplay, overlayCoordsData.fishingProfitTrackerOverlay);
+            buttonsDisplay.getLines().forEach(line => { line.setScale(overlayCoordsData.fishingProfitTrackerOverlay.scale - 0.2); });
+            buttonsDisplay
+                .setRenderX(overlayCoordsData.fishingProfitTrackerOverlay.x)
+                .setRenderY(buttonsY)
+                .show();
+            });
+        } else {
+            buttonsDisplay.hide();
+        }
     } catch (e) {
 		console.error(e);
 		console.log(`[FeeshNotifier] [ProfitTracker] Failed to refresh tracker data.`);

--- a/features/overlays/fishingProfitTracker.js
+++ b/features/overlays/fishingProfitTracker.js
@@ -248,18 +248,8 @@ function refreshPrices() {
                 return;
             }
 
-            if (item.itemId === 'ORB_OF_ENERGY') { // Calculate Orbs of Energy price as Pulse Rings + remainder in Orb of Energy
-                const pulseRingPrices = getAuctionItemPrices('PULSE_RING');
-                const pulseRingPrice = pulseRingPrices?.lbin || 0;
-                const pulseRingsCount = pulseRingPrice ? Math.floor(value.amount / 256) : 0;
-                const remainder = pulseRingsCount ? value.amount % 256 : value.amount;
-
-                const itemPrice = getItemPrice(item);
-                value.totalItemProfit = (pulseRingsCount * pulseRingPrice) + (remainder * itemPrice);
-            } else {
-                const itemPrice = getItemPrice(item);
-                value.totalItemProfit = value.amount * itemPrice;    
-            }
+            const itemPrice = getItemPrice(item);
+            value.totalItemProfit = value.amount * itemPrice;  
         });
     
         const total = Object.values(persistentData.fishingProfit.profitTrackerItems).reduce((accumulator, currentValue) => { return accumulator + currentValue.totalItemProfit }, 0);

--- a/features/overlays/jerryWorkshopTracker.js
+++ b/features/overlays/jerryWorkshopTracker.js
@@ -3,10 +3,11 @@ import * as triggers from '../../constants/triggers';
 import * as seaCreatures from '../../constants/seaCreatures';
 import { persistentData } from "../../data/data";
 import { overlayCoordsData } from "../../data/overlayCoords";
-import { BOLD, GOLD, RED, WHITE, UNDERLINE, DARK_PURPLE, GRAY, AQUA, DARK_GRAY, LIGHT_PURPLE } from "../../constants/formatting";
+import { BOLD, GOLD, RED, WHITE, DARK_PURPLE, GRAY, AQUA, DARK_GRAY, LIGHT_PURPLE } from "../../constants/formatting";
 import { getWorldName, hasFishingRodInHotbar, isInSkyblock } from "../../utils/playerState";
-import { formatDate, formatNumberWithSpaces, formatTimeElapsedBetweenDates, isInChatOrInventoryGui } from "../../utils/common";
+import { formatDate, formatNumberWithSpaces, formatTimeElapsedBetweenDates } from "../../utils/common";
 import { JERRY_WORKSHOP } from "../../constants/areas";
+import { createButtonsDisplay, toggleButtonsDisplay } from "../../utils/overlays";
 
 let remainingWorkshopTime = null;
 let sawWorkshopClosingMessage = false;
@@ -47,17 +48,7 @@ register("gameUnload", () => {
     }
 });
 
-// DisplayLine is initialized once in order to avoid multiple method calls on click.
-let resetTrackerDisplay = new Display().hide();
-let resetTrackerDisplayLine = new DisplayLine(`${RED}[Click to reset]`).setShadow(true);
-resetTrackerDisplayLine.registerClicked((x, y, mouseButton, buttonState) => {
-    if (mouseButton === 0 && buttonState === false) { // When left mouse button is UP. 0 is left mouse button, false is UP, true is DOWN. 
-        resetJerryWorkshopTracker(false);
-    }
-});
-resetTrackerDisplayLine.registerHovered(() => resetTrackerDisplayLine.setText(`${RED}${UNDERLINE}[Click to reset]`).setShadow(true));
-resetTrackerDisplayLine.registerMouseLeave(() => resetTrackerDisplayLine.setText(`${RED}[Click to reset]`).setShadow(true));
-resetTrackerDisplay.addLine(resetTrackerDisplayLine);
+const buttonsDisplay = createButtonsDisplay(true, () => resetJerryWorkshopTracker(false), false, null);
 
 export function resetJerryWorkshopTracker(isConfirmed) {
     try {
@@ -230,7 +221,7 @@ function renderJerryWorkshopOverlay() {
         !hasFishingRodInHotbar() ||
         allOverlaysGui.isOpen()
     ) {
-        resetTrackerDisplay.hide();
+        buttonsDisplay.hide();
         return;
     }
 
@@ -259,13 +250,5 @@ function renderJerryWorkshopOverlay() {
         .setScale(overlayCoordsData.jerryWorkshopTrackerOverlay.scale);
     overlay.draw();
 
-    const shouldShowReset = isInChatOrInventoryGui();
-    if (shouldShowReset) {
-        resetTrackerDisplayLine.setScale(overlayCoordsData.jerryWorkshopTrackerOverlay.scale - 0.2);
-        resetTrackerDisplay
-            .setRenderX(overlayCoordsData.jerryWorkshopTrackerOverlay.x)
-            .setRenderY(overlayCoordsData.jerryWorkshopTrackerOverlay.y + overlay.getHeight() + 2).show();
-    } else {
-        resetTrackerDisplay.hide();
-    }
+    toggleButtonsDisplay(buttonsDisplay, overlay, overlayCoordsData.jerryWorkshopTrackerOverlay);
 }

--- a/features/overlays/magmaCoreProfitTracker.js
+++ b/features/overlays/magmaCoreProfitTracker.js
@@ -3,9 +3,10 @@ import * as triggers from '../../constants/triggers';
 import { overlayCoordsData } from "../../data/overlayCoords";
 import { BOLD, GOLD, RED, WHITE, BLUE, YELLOW, GREEN, AQUA, GRAY } from "../../constants/formatting";
 import { getWorldName, hasFishingRodInHotbar, isInSkyblock } from "../../utils/playerState";
-import {  formatElapsedTime, formatNumberWithSpaces, isDoubleHook, isInChatOrInventoryGui, toShortNumber } from "../../utils/common";
+import {  formatElapsedTime, formatNumberWithSpaces, isDoubleHook, toShortNumber } from "../../utils/common";
 import { CRYSTAL_HOLLOWS } from "../../constants/areas";
 import { getBazaarItemPrices } from "../../utils/bazaarPrices";
+import { createButtonsDisplay, toggleButtonsDisplay } from "../../utils/overlays";
 
 var totalMagmaCoresCount = 0;
 var lastAddedMagmaCoresCount = 0;
@@ -43,24 +44,7 @@ register('step', () => refreshTrackerData()).setDelay(5);
 
 register('renderOverlay', () => renderMagmaCoreTrackerOverlay());
 
-// DisplayLine is initialized once in order to avoid multiple method calls on click.
-let buttonsDisplay = new Display().hide();
-
-let pauseTrackerDisplayLine = new DisplayLine(`${YELLOW}[Click to pause]`).setShadow(true);
-pauseTrackerDisplayLine.registerClicked((x, y, mouseButton, buttonState) => {
-    if (mouseButton === 0 && buttonState === false) { // When left mouse button is UP. 0 is left mouse button, false is UP, true is DOWN. 
-        pauseMagmaCoreProfitTracker();
-    }
-});
-buttonsDisplay.addLine(pauseTrackerDisplayLine);
-
-let resetTrackerDisplayLine = new DisplayLine(`${RED}[Click to reset]`).setShadow(true);
-resetTrackerDisplayLine.registerClicked((x, y, mouseButton, buttonState) => {
-    if (mouseButton === 0 && buttonState === false) { // When left mouse button is UP. 0 is left mouse button, false is UP, true is DOWN. 
-        resetMagmaCoreProfitTracker(false);
-    }
-});
-buttonsDisplay.addLine(resetTrackerDisplayLine);
+const buttonsDisplay = createButtonsDisplay(true, () => resetMagmaCoreProfitTracker(false), true, () => pauseMagmaCoreProfitTracker());
 
 export function resetMagmaCoreProfitTracker(isConfirmed) {
     try {
@@ -235,14 +219,5 @@ function renderMagmaCoreTrackerOverlay() {
         .setScale(overlayCoordsData.magmaCoreProfitTrackerOverlay.scale);
     overlay.draw();
 
-    const shouldShowButtons = isInChatOrInventoryGui();
-    if (shouldShowButtons) {
-        resetTrackerDisplayLine.setScale(overlayCoordsData.magmaCoreProfitTrackerOverlay.scale - 0.2);
-        pauseTrackerDisplayLine.setScale(overlayCoordsData.magmaCoreProfitTrackerOverlay.scale - 0.2);
-        buttonsDisplay
-            .setRenderX(overlayCoordsData.magmaCoreProfitTrackerOverlay.x)
-            .setRenderY(overlayCoordsData.magmaCoreProfitTrackerOverlay.y + overlay.getHeight() + 2).show();
-    } else {
-        buttonsDisplay.hide();
-    }
+    toggleButtonsDisplay(buttonsDisplay, overlay, overlayCoordsData.magmaCoreProfitTrackerOverlay);
 }

--- a/features/overlays/rareCatchesTracker.js
+++ b/features/overlays/rareCatchesTracker.js
@@ -3,11 +3,12 @@ import * as triggers from '../../constants/triggers';
 import * as seaCreatures from '../../constants/seaCreatures';
 import { persistentData } from "../../data/data";
 import { overlayCoordsData } from "../../data/overlayCoords";
-import { formatNumberWithSpaces, fromUppercaseToCapitalizedFirstLetters, isDoubleHook, isInChatOrInventoryGui, pluralize } from '../../utils/common';
-import { WHITE, GOLD, BOLD, YELLOW, GRAY, RED, UNDERLINE } from "../../constants/formatting";
+import { formatNumberWithSpaces, fromUppercaseToCapitalizedFirstLetters, isDoubleHook, pluralize } from '../../utils/common';
+import { WHITE, GOLD, BOLD, YELLOW, GRAY, RED } from "../../constants/formatting";
 import { RARE_CATCH_TRIGGERS } from "../../constants/triggers";
 import { getWorldName, hasFishingRodInHotbar, isInSkyblock } from "../../utils/playerState";
 import { KUUDRA } from "../../constants/areas";
+import { createButtonsDisplay, toggleButtonsDisplay } from "../../utils/overlays";
 
 triggers.RARE_CATCH_TRIGGERS.forEach(entry => {
     register("Chat", (event) => {
@@ -24,17 +25,7 @@ register("gameUnload", () => {
     }
 });
 
-// DisplayLine is initialized once in order to avoid multiple method calls on click.
-let resetTrackerDisplay = new Display().hide();
-let resetTrackerDisplayLine = new DisplayLine(`${RED}[Click to reset]`).setShadow(true);
-resetTrackerDisplayLine.registerClicked((x, y, mouseButton, buttonState) => {
-    if (mouseButton === 0 && buttonState === false) { // When left mouse button is UP. 0 is left mouse button, false is UP, true is DOWN. 
-        resetRareCatchesTracker(false);
-    }
-});
-resetTrackerDisplayLine.registerHovered(() => resetTrackerDisplayLine.setText(`${RED}${UNDERLINE}[Click to reset]`).setShadow(true));
-resetTrackerDisplayLine.registerMouseLeave(() => resetTrackerDisplayLine.setText(`${RED}[Click to reset]`).setShadow(true));
-resetTrackerDisplay.addLine(resetTrackerDisplayLine);
+const buttonsDisplay = createButtonsDisplay(true, () => resetRareCatchesTracker(false), false, null);
 
 export function resetRareCatchesTracker(isConfirmed) {
     try {
@@ -118,7 +109,7 @@ function renderRareCatchTrackerOverlay() {
         !hasFishingRodInHotbar() ||
         allOverlaysGui.isOpen()
     ) {
-        resetTrackerDisplay.hide();
+        buttonsDisplay.hide();
         return;
     }
 
@@ -143,13 +134,5 @@ function renderRareCatchTrackerOverlay() {
         .setScale(overlayCoordsData.rareCatchesTrackerOverlay.scale);
     overlay.draw();
 
-    const shouldShowReset = isInChatOrInventoryGui();
-    if (shouldShowReset) {
-        resetTrackerDisplayLine.setScale(overlayCoordsData.rareCatchesTrackerOverlay.scale - 0.2);
-        resetTrackerDisplay
-            .setRenderX(overlayCoordsData.rareCatchesTrackerOverlay.x)
-            .setRenderY(overlayCoordsData.rareCatchesTrackerOverlay.y + overlay.getHeight() + 2).show(); 
-    } else {
-        resetTrackerDisplay.hide();
-    }
+    toggleButtonsDisplay(buttonsDisplay, overlay, overlayCoordsData.rareCatchesTrackerOverlay);
 }

--- a/features/overlays/seaCreaturesCountAndTimeTracker.js
+++ b/features/overlays/seaCreaturesCountAndTimeTracker.js
@@ -6,7 +6,7 @@ import { EntityArmorStand } from "../../constants/javaTypes";
 import { overlayCoordsData } from "../../data/overlayCoords";
 import { getWorldName, hasFishingRodInHotbar, isInHunterArmor, isInSkyblock } from "../../utils/playerState";
 import { CRIMSON_ISLE, CRYSTAL_HOLLOWS, HUB, KUUDRA } from "../../constants/areas";
-import { isInChatOrInventoryGui } from "../../utils/common";
+import { createButtonsDisplay, toggleButtonsDisplay } from "../../utils/overlays";
 
 const TIMER_THRESHOLD_IN_MINUTES = 5;
 
@@ -25,17 +25,7 @@ register("worldUnload", () => {
     resetTimer();
 });
 
-// DisplayLine is initialized once in order to avoid multiple method calls on click.
-let resetTrackerDisplay = new Display().hide();
-let resetTrackerDisplayLine = new DisplayLine(`${RED}[Click to reset]`).setShadow(true);
-resetTrackerDisplayLine.registerClicked((x, y, mouseButton, buttonState) => {
-    if (mouseButton === 0 && buttonState === false) { // When left mouse button is UP. 0 is left mouse button, false is UP, true is DOWN. 
-        resetTimer();
-    }
-});
-resetTrackerDisplayLine.registerHovered(() => resetTrackerDisplayLine.setText(`${RED}${UNDERLINE}[Click to reset]`).setShadow(true));
-resetTrackerDisplayLine.registerMouseLeave(() => resetTrackerDisplayLine.setText(`${RED}[Click to reset]`).setShadow(true));
-resetTrackerDisplay.addLine(resetTrackerDisplayLine);
+const buttonsDisplay = createButtonsDisplay(true, () => resetTimer(), false, null);
 
 function resetTimer() {
     startTime = null;
@@ -137,7 +127,7 @@ function renderCountOverlay() {
         !hasFishingRodInHotbar() ||
         allOverlaysGui.isOpen()
     ) {
-        resetTrackerDisplay.hide();
+        buttonsDisplay.hide();
         return;
     }
 
@@ -161,15 +151,7 @@ function renderCountOverlay() {
         .setScale(overlayCoordsData.seaCreaturesCountOverlay.scale);
     overlay.draw();
 
-    const shouldShowReset = isInChatOrInventoryGui();
-    if (shouldShowReset) {
-        resetTrackerDisplayLine.setScale(overlayCoordsData.seaCreaturesCountOverlay.scale - 0.2);
-        resetTrackerDisplay
-            .setRenderX(overlayCoordsData.seaCreaturesCountOverlay.x + overlay.getWidth() + 2)
-            .setRenderY(overlayCoordsData.seaCreaturesCountOverlay.y + 1).show();
-    } else {
-        resetTrackerDisplay.hide();
-    }
+    toggleButtonsDisplay(buttonsDisplay, overlay, overlayCoordsData.seaCreaturesCountOverlay);
 }
 
 function getSeaCreaturesCountThreshold() {

--- a/features/overlays/wormMembraneProfitTracker.js
+++ b/features/overlays/wormMembraneProfitTracker.js
@@ -1,12 +1,13 @@
 import settings, { allOverlaysGui } from "../../settings";
 import { AQUA, BOLD, DARK_PURPLE, GOLD, GRAY, GREEN, RED, WHITE, YELLOW } from "../../constants/formatting";
 import { getBazaarItemPrices } from "../../utils/bazaarPrices";
-import { formatElapsedTime, formatNumberWithSpaces, getItemsAddedToSacks, isDoubleHook, isInChatOrInventoryGui, isInSacksGui, toShortNumber } from "../../utils/common";
+import { formatElapsedTime, formatNumberWithSpaces, getItemsAddedToSacks, isDoubleHook, isInSacksGui, toShortNumber } from "../../utils/common";
 import * as triggers from '../../constants/triggers';
 import { getLastGuisClosed, getWorldName, hasFishingRodInHotbar, isInSkyblock } from "../../utils/playerState";
 import { CRYSTAL_HOLLOWS } from "../../constants/areas";
 import { overlayCoordsData } from "../../data/overlayCoords";
 import { getAuctionItemPrices } from "../../utils/auctionPrices";
+import { createButtonsDisplay, toggleButtonsDisplay } from "../../utils/overlays";
 
 var totalMembranesCount = 0;
 var totalChambersCount = 0;
@@ -50,25 +51,7 @@ register("worldUnload", () => {
     isSessionActive = false;
 });
 
-
-// DisplayLine is initialized once in order to avoid multiple method calls on click.
-let buttonsDisplay = new Display().hide();
-
-let pauseTrackerDisplayLine = new DisplayLine(`${YELLOW}[Click to pause]`).setShadow(true);
-pauseTrackerDisplayLine.registerClicked((x, y, mouseButton, buttonState) => {
-    if (mouseButton === 0 && buttonState === false) { // When left mouse button is UP. 0 is left mouse button, false is UP, true is DOWN. 
-        pauseWormMembraneProfitTracker();
-    }
-});
-buttonsDisplay.addLine(pauseTrackerDisplayLine);
-
-let resetTrackerDisplayLine = new DisplayLine(`${RED}[Click to reset]`).setShadow(true);
-resetTrackerDisplayLine.registerClicked((x, y, mouseButton, buttonState) => {
-    if (mouseButton === 0 && buttonState === false) { // When left mouse button is UP. 0 is left mouse button, false is UP, true is DOWN. 
-        resetWormMembraneProfitTracker(false);
-    }
-});
-buttonsDisplay.addLine(resetTrackerDisplayLine);
+const buttonsDisplay = createButtonsDisplay(true, () => resetWormMembraneProfitTracker(false), true, () => pauseWormMembraneProfitTracker());
 
 export function resetWormMembraneProfitTracker(isConfirmed) {
     try {
@@ -356,16 +339,7 @@ function renderWormMembraneProfitTrackerOverlay() {
         .setScale(overlayCoordsData.wormProfitTrackerOverlay.scale);
     overlay.draw();
 
-    const shouldShowButtons = isInChatOrInventoryGui();
-    if (shouldShowButtons) {
-        resetTrackerDisplayLine.setScale(overlayCoordsData.wormProfitTrackerOverlay.scale - 0.2);
-        pauseTrackerDisplayLine.setScale(overlayCoordsData.wormProfitTrackerOverlay.scale - 0.2);
-        buttonsDisplay
-            .setRenderX(overlayCoordsData.wormProfitTrackerOverlay.x)
-            .setRenderY(overlayCoordsData.wormProfitTrackerOverlay.y + overlay.getHeight() + 2).show();
-    } else {
-        buttonsDisplay.hide();
-    }
+    toggleButtonsDisplay(buttonsDisplay, overlay, overlayCoordsData.wormProfitTrackerOverlay);
 }
 
 // Returns array of inventory slots, each array item is membranes count in this slot.

--- a/metadata.json
+++ b/metadata.json
@@ -3,7 +3,7 @@
     "entry": "index.js",
     "author": "MoonTheSadFisher",
     "description": "Hypixel Skyblock fishing utilities for parties.",
-    "version": "1.34.0",
+    "version": "1.35.0",
     "requires": [
         "Amaterasu",
         "PogData",

--- a/settings.js
+++ b/settings.js
@@ -1432,6 +1432,15 @@ ${RED}Hidden if you have no fishing rod in your hotbar!`,
     placeHolder: "",
     subcategory: "Attributes"
 })
+.addTextInput({
+    category: "Items and storages",
+    configName: "showAttributesIgnoredItems",
+    title: "Ignored items",
+    description: "Do not render attributes on items from this list. Specify base item name, and comma as a separator to specify multiple.\nExample: Staff of the Volcano,Blade of the Volcano,Fire Fury Staff,Fire Veil Wand,Ragnarock Axe",
+    value: "",
+    placeHolder: "",
+    subcategory: "Attributes"
+})
 
 .addSwitch({
     category: "Items and storages",

--- a/settings.js
+++ b/settings.js
@@ -917,6 +917,15 @@ const config = new DefaultConfig("FeeshNotifier", "config/settings.json")
     value: true
 })
 
+.addDropDown({
+    category: "Overlays",
+    configName: "buttonsPosition",
+    title: "Buttons position",
+    description: "Where to place Reset / Pause buttons relatively to an overlay.",
+    options: ["Bottom","Top"],
+    value: 0,
+    subcategory: "General"
+})
 .addSwitch({
     category: "Overlays",
     configName: "totemRemainingTimeOverlay",

--- a/utils/bazaarPrices.js
+++ b/utils/bazaarPrices.js
@@ -26,10 +26,10 @@ function trackBazaarPrices() {
             Object.keys(response.products).forEach(itemId => {
                 const itemSellSummary = response.products[itemId].sell_summary || [];
                 const itemBuySummary = response.products[itemId].buy_summary || [];
-                const itemQuickStatus = response.products[itemId].quick_status;
+                const itemQuickStatus = response.products[itemId].quick_status || null;
                 bazaarPrices[itemId] = {
-                    instaSell: itemSellSummary.length ? itemSellSummary[0].pricePerUnit : itemQuickStatus.sellPrice,
-                    sellOffer: itemBuySummary.length ? itemBuySummary[0].pricePerUnit : itemQuickStatus.buyPrice
+                    instaSell: itemSellSummary.length ? itemSellSummary[0].pricePerUnit : (itemQuickStatus?.sellPrice || 0),
+                    sellOffer: itemBuySummary.length ? itemBuySummary[0].pricePerUnit : (itemQuickStatus?.buyPrice || 0)
                 };
             });
         })

--- a/utils/overlays.js
+++ b/utils/overlays.js
@@ -1,0 +1,75 @@
+import settings from "../settings";
+import { RED, YELLOW } from "../constants/formatting";
+import { isInChatOrInventoryGui } from "./common";
+
+/**
+ * Create Display with specified buttons and actions on button click.
+ * @param {boolean} isResetable
+ * @param {Function} resetFn - Callback function executed when Reset button pressed
+ * @param {boolean} isPausable
+ * @param {Function} pauseFn - Callback function executed when Pause button pressed
+ * @returns {Display}
+ */
+export function createButtonsDisplay(isResetable, resetFn, isPausable, pauseFn) {
+    let buttonsDisplay = new Display().hide();
+
+    if (isPausable && pauseFn) {
+        let pauseTrackerDisplayLine = new DisplayLine(`${YELLOW}[Click to pause]`).setShadow(true);
+        pauseTrackerDisplayLine.registerClicked((x, y, mouseButton, buttonState) => {
+            if (mouseButton === 0 && buttonState === false) { // When left mouse button is UP. 0 is left mouse button, false is UP, true is DOWN. 
+                pauseFn();
+            }
+        });
+        buttonsDisplay.addLine(pauseTrackerDisplayLine);  
+    }
+
+    if (isResetable && resetFn) {
+        let resetTrackerDisplayLine = new DisplayLine(`${RED}[Click to reset]`).setShadow(true);
+        resetTrackerDisplayLine.registerClicked((x, y, mouseButton, buttonState) => {
+            if (mouseButton === 0 && buttonState === false) { // When left mouse button is UP. 0 is left mouse button, false is UP, true is DOWN. 
+                resetFn();
+            }
+        });    
+        buttonsDisplay.addLine(resetTrackerDisplayLine);
+    }
+
+    return buttonsDisplay;
+}
+
+/**
+ * Show or hide buttons display for the specified overlay, depending on buttons position from the settings (bottom, top). It's shown when user is in chat or inventory GUI.
+ * @param {Display} buttonsDisplay
+ * @param {Display|Text} overlay
+ * @param {object} overlayCoords - object containing x, y, scale
+ */
+export function toggleButtonsDisplay(buttonsDisplay, overlay, overlayCoords) {
+    const shouldShowButtons = isInChatOrInventoryGui();
+    if (shouldShowButtons) {
+        buttonsDisplay.getLines().forEach(line => { line.setScale(overlayCoords.scale - 0.2); });
+        buttonsDisplay
+            .setRenderX(overlayCoords.x)
+            .setRenderY(getButtonsDisplayRenderY(buttonsDisplay, overlay, overlayCoords)).show();
+    } else {
+        buttonsDisplay.hide();
+    }
+}
+
+/**
+ * Calculate render Y for the buttons display, depending on buttons position from the settings (bottom, top) and overlay coords.
+ * @param {Display} buttonsDisplay
+ * @param {Display|Text} overlay
+ * @param {object} overlayCoords - object containing x, y, scale
+ * @returns {string} Y coordinate
+ */
+export function getButtonsDisplayRenderY(buttonsDisplay, overlay, overlayCoords) {
+	if (!overlay || !overlayCoords) return;
+
+	if (settings.buttonsPosition === 0) { // At the bottom of overlay
+		return overlayCoords.y + overlay.getHeight() + 2;
+	}
+
+    if (settings.buttonsPosition === 1) { // At the top of overlay
+		const height = buttonsDisplay.getHeight();
+		return overlayCoords.y - height - 2;
+	}
+}


### PR DESCRIPTION
## Features
- Added setting to ignore rendering of attributes for specific items. Search for "Ignored items" in Attributes section, and fill in item names to not see attributes on them.
- Added setting to display overlay buttons (Reset / Pause) on top of the overlay. Search for "Buttons position" setting in Overlays section.

## Bugfixes
- Fixed Frozen Steve catch message not being compacted.
- Fixed total profit in Fishing Profit Tracker being 0 after leveling up a soulbound pet.
- Fixed error when new item is added to bazaar by SB and has not full details exposed from the Hypixel API.

## Other
- Removed calculation of Orb of Energy profits as Pulse Rings (justification - it was added when Orb of Energy was soulbound, but now it can be sold on bazaar, so removed recalculation for consistency).