### PR TITLE
refactor: Applied registerif to Totem of Corruption tracker

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -8,7 +8,8 @@ Features:
 - 
 
 Bugfixes:
-- 
+- Fixed Totem of Corruption expiration alert triggering twice sometimes.
+- Fixed Totem of Corruption expiration alert triggering on other player's totem sometimes.
 
 Other:
 - Refactored Rare catches tracker to not execute any checks when setting is disabled / when being in a wrong world.

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -14,6 +14,7 @@ Other:
 - Refactored Rare catches tracker to not execute any checks when setting is disabled / when being in a wrong world.
 - Refactored Abandoned Quarry tracker to not execute any checks when setting is disabled / when being in a wrong world.
 - Refactored Jerry Workshop tracker to not execute any checks when setting is disabled / when being in a wrong world.
+- Refactored Totem tracker to not execute any checks when setting is disabled / when being in a wrong world.
 
 ## v1.36.0
 

--- a/features/overlays/totemTracker.js
+++ b/features/overlays/totemTracker.js
@@ -5,9 +5,11 @@ import { TIMER_SOUND_SOURCE, OFF_SOUND_MODE } from "../../constants/sounds";
 import { WHITE, RED, DARK_PURPLE, GOLD } from "../../constants/formatting";
 import { isInSkyblock } from "../../utils/playerState";
 import { registerIf } from "../../utils/registers";
+import { getMcEntityById, getMcEntityId } from "../../utils/common";
 
 let remainingTotemTime; // Format examples: 01m 02s, 50s, 09s
-let playerTotemPosition;
+let lastAlertAt = null; // Prevent alerting 2 times when register rarely triggers twice per second
+
 const currentPlayer = Player.getName();
 const secondsBeforeExpiration = 10;
 
@@ -26,43 +28,64 @@ register("worldUnload", () => {
 });
 
 function trackTotemStatus() {
-    if ((!settings.alertOnTotemExpiresSoon && !settings.totemRemainingTimeOverlay) || !isInSkyblock()) {
-        return;
-    }
-
-    const entities = World.getAllEntitiesOfType(EntityArmorStand);
-    const hasPlayersTotem = entities.some(entity => {
-        const name = entity?.getName()?.removeFormatting();
-        return name.includes('Owner:') && name.includes(currentPlayer);
-    });
-    if (playerTotemPosition && !hasPlayersTotem) {
-        resetTotem();
-    }
-
-	entities.forEach(entity => {
-        const name = entity?.getName()?.removeFormatting();
-
-        if (name.includes('Owner:') && name.includes(currentPlayer)) {
-            playerTotemPosition = entity.getPos();
+    try {
+        if ((!settings.alertOnTotemExpiresSoon && !settings.totemRemainingTimeOverlay) || !isInSkyblock()) {
+            return;
         }
 
-        if (playerTotemPosition && name.includes('Remaining: ')) {
-            const position = entity.getPos();
-            if (position.x === playerTotemPosition.x && position.z === playerTotemPosition.z) {
-                remainingTotemTime = name.split('Remaining: ').pop();
+        const entities = World.getAllEntitiesOfType(EntityArmorStand);
+        const ownerArmorStand = entities.find(entity => {
+            const name = entity?.getName()?.removeFormatting();
+            return name.includes('Owner:') && name.includes(currentPlayer);
+        });
+        if (!ownerArmorStand) {
+            resetTotem();
+            return;
+        }
+    
+        const ownerArmorStandId = getMcEntityId(ownerArmorStand);
+        const totemArmorStand = getMcEntityById(ownerArmorStandId - 2);
+        if (!totemArmorStand || !(totemArmorStand instanceof net.minecraft.entity.item.EntityArmorStand)) return;
+    
+        const totemArmorStandName = totemArmorStand.func_95999_t()?.removeFormatting(); // func_95999_t -> getCustomNameTag()
+        if (totemArmorStandName !== 'Totem of Corruption') {
+            resetTotem();
+            return;
+        }
+    
+        const remainingArmorStand = getMcEntityById(ownerArmorStandId - 1);
+        if (!remainingArmorStand || !(remainingArmorStand instanceof net.minecraft.entity.item.EntityArmorStand)) return;
+    
+        const remainingArmorStandName = remainingArmorStand.func_95999_t()?.removeFormatting(); // func_95999_t -> getCustomNameTag()
+        if (!remainingArmorStandName?.includes('Remaining: ')) {
+            resetTotem();
+            return;
+        }
+    
+        remainingTotemTime = remainingArmorStandName.split('Remaining: ').pop();
 
-                if (settings.alertOnTotemExpiresSoon && remainingTotemTime && remainingTotemTime === `${secondsBeforeExpiration}s`) {
-                    Client.showTitle(`${DARK_PURPLE}Totem ${RED}expires soon`, '', 1, 30, 1);
-                    ChatLib.chat(`${GOLD}[FeeshNotifier] ${WHITE}Your ${DARK_PURPLE}Totem of Corruption ${WHITE}expires soon.`);
+        playAlertOnExpiration();
+    } catch (e) {
+		console.error(e);
+		console.log(`[FeeshNotifier] Failed to track Totem status.`);
+	}
 
-                    if (settings.soundMode !== OFF_SOUND_MODE)
-                    {
-                        new Sound(TIMER_SOUND_SOURCE).play();
-                    }
-                }
-            }
-        } 
-    })	
+    function playAlertOnExpiration() {
+        if (!settings.alertOnTotemExpiresSoon ||
+            remainingTotemTime !== `${secondsBeforeExpiration}s` ||
+            (lastAlertAt && new Date() - lastAlertAt < 1000)) {
+            return;
+        }
+
+        Client.showTitle(`${DARK_PURPLE}Totem ${RED}expires soon`, '', 1, 30, 1);
+        ChatLib.chat(`${GOLD}[FeeshNotifier] ${WHITE}Your ${DARK_PURPLE}Totem of Corruption ${WHITE}expires soon.`);
+        lastAlertAt = new Date();
+
+        if (settings.soundMode !== OFF_SOUND_MODE)
+        {
+            new Sound(TIMER_SOUND_SOURCE).play();
+        }
+    }
 }
 
 function renderTotemOverlay() {
@@ -79,6 +102,6 @@ function renderTotemOverlay() {
 }
 
 function resetTotem() {
-    playerTotemPosition = null;
     remainingTotemTime = null;
+    lastAlertAt = null;
 }

--- a/features/overlays/totemTracker.js
+++ b/features/overlays/totemTracker.js
@@ -4,14 +4,23 @@ import { EntityArmorStand } from "../../constants/javaTypes";
 import { TIMER_SOUND_SOURCE, OFF_SOUND_MODE } from "../../constants/sounds";
 import { WHITE, RED, DARK_PURPLE, GOLD } from "../../constants/formatting";
 import { isInSkyblock } from "../../utils/playerState";
+import { registerIf } from "../../utils/registers";
 
 let remainingTotemTime; // Format examples: 01m 02s, 50s, 09s
 let playerTotemPosition;
 const currentPlayer = Player.getName();
 const secondsBeforeExpiration = 10;
 
-register('step', () => trackTotemStatus()).setFps(1);
-register('renderOverlay', () => renderTotemOverlay());
+registerIf(
+    register('step', () => trackTotemStatus()).setFps(1),
+    () => (settings.alertOnTotemExpiresSoon || settings.totemRemainingTimeOverlay) && isInSkyblock()
+);
+
+registerIf(
+    register('renderOverlay', () => renderTotemOverlay()),
+    () => settings.totemRemainingTimeOverlay && isInSkyblock()
+);
+
 register("worldUnload", () => {
     resetTotem();
 });

--- a/utils/common.js
+++ b/utils/common.js
@@ -452,6 +452,26 @@ export function isInFishingWorld(worldName) {
 	return !NO_FISHING_WORLDS.includes(worldName);
 }
 
+/**
+ * Get MC entity ID.
+ * @param {Entity} entity
+ * @returns {number} ID
+ */
+export function getMcEntityId(entity) {
+    if (!entity || !entity.entity) return;
+    return entity.entity.func_145782_y(); // func_145782_y() -> getEntityId()
+}
+
+/**
+ * Get MC entity ID.
+ * @param {number} id MC entity ID
+ * @returns {object} MC entity
+ */
+export function getMcEntityById(id) {
+    if (!id) return;
+    return World.getWorld()?.func_73045_a(id); // func_73045_a() -> getEntityByID()
+}
+
 function getCurrentGuiChestName() {
 	if (Client.isInGui() && Client.currentGui?.getClassName() === 'GuiChest') {
 		const chestName = Client.currentGui?.get()?.field_147002_h?.func_85151_d()?.func_145748_c_()?.text;


### PR DESCRIPTION
- Fixed Totem of Corruption expiration alert triggering twice sometimes.
- Fixed Totem of Corruption expiration alert triggering on other player's totem sometimes.
- Refactored Totem of Corruption tracker to not execute any checks when setting is disabled / when being in a wrong world.
