### PR TITLE
refactor: Applied registerif to Magma Core Profit tracker

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -19,6 +19,7 @@ Other:
   - Abandoned Quarry tracker
   - Jerry Workshop tracker
   - Crimson Isle tracker
+  - Magma Core profit tracker
   - Totem of Corruption tracker
   - Flare tracker
 


### PR DESCRIPTION
Refactored Magma Core Profit tracker to not execute any checks when setting is disabled / when being in a wrong world