### PR TITLE
refactor: Applied registerif to various alerts

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -12,8 +12,8 @@ Bugfixes:
 - Fixed Totem of Corruption expiration alert triggering on other player's totem sometimes.
 
 Other:
-- Refactored different trackers to not execute any checks when setting is disabled / when being in a wrong world:
-  - Legion & Bobbing Time
+- Refactored different functionality to not execute any checks when setting is disabled / when being in a wrong world:
+  - Legion & Bobbing Time tracker
     - Also made it work only in "fishing" worlds.
   - Rare catches tracker
   - Abandoned Quarry tracker
@@ -22,6 +22,11 @@ Other:
   - Magma Core profit tracker
   - Totem of Corruption tracker
   - Flare tracker
+  - Alert of Hotspot gone
+  - Message on Hotspot found
+  - Message on Revenant spawned
+  - Alert on non-fishing armor
+  - Alert on Worm the Fish caught
 
 ## v1.36.0
 

--- a/features/alerts/alertOnHotspotGone.js
+++ b/features/alerts/alertOnHotspotGone.js
@@ -5,10 +5,15 @@ import { HOTSPOT_WORLDS } from "../../constants/areas";
 import { GOLD, LIGHT_PURPLE, RED, RESET, WHITE } from "../../constants/formatting";
 import { getPlayerFishingHook, isFishingHookActive } from "../../utils/common";
 import { findClosestHotspotInRange, findHotspotsInRange } from "../../utils/entityDetection";
+import { registerIf } from "../../utils/registers";
 
 let lastClosestHotspot = null;
 
-register("step", (event) => playAlertOnHotspotGone()).setDelay(1);
+registerIf(
+    register("step", (event) => playAlertOnHotspotGone()).setDelay(1),
+    () => settings.alertOnHotspotGone && isInSkyblock() && HOTSPOT_WORLDS.includes(getWorldName())
+);
+
 register("worldUnload", () => {
     lastClosestHotspot = null;
 });

--- a/features/alerts/alertOnNonFishingArmor.js
+++ b/features/alerts/alertOnNonFishingArmor.js
@@ -2,9 +2,9 @@ import settings from "../../settings";
 import { RED } from "../../constants/formatting";
 import { getWorldName, hasFishingRodInHotbar, isInSkyblock } from "../../utils/playerState";
 import { OFF_SOUND_MODE } from "../../constants/sounds";
-import { DUNGEONS, KUUDRA } from "../../constants/areas";
 import { EntityFishHook } from "../../constants/javaTypes";
-import { getLore, isFishingHookActive } from "../../utils/common";
+import { getLore, isFishingHookActive, isInFishingWorld } from "../../utils/common";
+import { registerIf } from "../../utils/registers";
 
 let lastHookDetectedAt = null;
 
@@ -12,11 +12,14 @@ register("worldUnload", () => {
     lastHookDetectedAt = null; 
 });
 
-register(net.minecraftforge.event.entity.EntityJoinWorldEvent, (event) => alertOnNonFishingArmor(event));
+registerIf(
+    register(net.minecraftforge.event.entity.EntityJoinWorldEvent, (event) => alertOnNonFishingArmor(event)),
+    () => settings.alertOnNonFishingArmor && isInSkyblock() && isInFishingWorld(getWorldName())
+);
 
 function alertOnNonFishingArmor(event) {
     try {
-        if (!settings.alertOnNonFishingArmor || !isInSkyblock() || !hasFishingRodInHotbar() || getWorldName() === KUUDRA || getWorldName() === DUNGEONS || !(event.entity instanceof EntityFishHook)) {
+        if (!settings.alertOnNonFishingArmor || !isInSkyblock() || !isInFishingWorld(getWorldName()) || !hasFishingRodInHotbar() || !(event.entity instanceof EntityFishHook)) {
             return;
         }
     

--- a/features/alerts/alertOnWormTheFish.js
+++ b/features/alerts/alertOnWormTheFish.js
@@ -1,16 +1,22 @@
 import settings from "../../settings";
 import { RED, WHITE } from "../../constants/formatting";
 import { EntityItem } from "../../constants/javaTypes";
-import { hasDirtRodInHand, isInSkyblock } from "../../utils/playerState";
+import { getWorldName, hasDirtRodInHand, isInSkyblock } from "../../utils/playerState";
 import { OFF_SOUND_MODE } from "../../constants/sounds";
+import { registerIf } from "../../utils/registers";
+import { isInFishingWorld } from "../../utils/common";
 
 let wormTheFishCount = 0;
 
-register("step", () => alertOnWormTheFishCatch()).setFps(2);
+registerIf(
+    register("step", () => alertOnWormTheFishCatch()).setFps(2),
+    () => settings.alertOnWormTheFishCaught && isInSkyblock() && isInFishingWorld(getWorldName())
+);
 
 function alertOnWormTheFishCatch() {
     if (!settings.alertOnWormTheFishCaught ||
         !isInSkyblock() ||
+        !isInFishingWorld(getWorldName()) ||
         !hasDirtRodInHand()
     ) {
         return;

--- a/features/chat/messageOnHotspotFound.js
+++ b/features/chat/messageOnHotspotFound.js
@@ -5,11 +5,16 @@ import { BLUE, BOLD, GOLD, GRAY, LIGHT_PURPLE, RESET, WHITE, YELLOW } from "../.
 import { getMessageId, getZoneName } from "../../utils/common";
 import { OFF_SOUND_MODE } from "../../constants/sounds";
 import { findClosestHotspotInRange } from "../../utils/entityDetection";
+import { registerIf } from "../../utils/registers";
 
 let lastClosestHotspot = null;
 let lastFoundHotspotIds = []; // Remember 2 last found hotspots, to avoid announcing the same hotspots placed close to each other, when user is moving between them
 
-register("step", (event) => sendMessageOnHotspotFound()).setDelay(1);
+registerIf(
+    register("step", (event) => sendMessageOnHotspotFound()).setDelay(1),
+    () => settings.messageOnHotspotFound && isInSkyblock() && HOTSPOT_WORLDS.includes(getWorldName())
+);
+
 register("worldUnload", () => {
     lastClosestHotspot = null;
     lastFoundHotspotIds = [];

--- a/features/chat/messageOnRevenant.js
+++ b/features/chat/messageOnRevenant.js
@@ -1,17 +1,22 @@
 import settings from '../../settings';
-import { DUNGEONS, KUUDRA } from '../../constants/areas';
+import { DUNGEON_HUB, DUNGEONS, GARDEN, GLACITE_MINESHAFTS, KUUDRA, RIFT, THE_END } from '../../constants/areas';
 import { EntityArmorStand } from '../../constants/javaTypes';
 import { getWorldName, isInSkyblock } from '../../utils/playerState';
+import { registerIf } from '../../utils/registers';
 
-const chatCommand = 'pc';
+const CHAT_COMMAND = 'pc';
+const EXCLUDED_WORLDS = [RIFT, GARDEN, KUUDRA, DUNGEON_HUB, DUNGEONS, THE_END, GLACITE_MINESHAFTS];
 
 let slayerUUID = null;
 
-register('step', () => sendMessageOnRevenantSpawn()).setFps(3);
+registerIf(
+    register('step', () => sendMessageOnRevenantSpawn()).setFps(3),
+    () => settings.messageOnRevenantHorrorSpawn && isInSkyblock() && !EXCLUDED_WORLDS.includes(getWorldName())
+);
 
 function sendMessageOnRevenantSpawn() {
 	try {
-		if (!settings.messageOnRevenantHorrorSpawn || !isInSkyblock() || getWorldName() === KUUDRA || getWorldName() === DUNGEONS) {
+		if (!settings.messageOnRevenantHorrorSpawn || !isInSkyblock() || EXCLUDED_WORLDS.includes(getWorldName())) {
 			return;
 		}
 	
@@ -49,7 +54,7 @@ function sendMessageOnRevenantSpawn() {
 
         const location = `x: ${Math.round(slayer.getX())}, y: ${Math.round(slayer.getY())}, z: ${Math.round(slayer.getZ())}`;
 		const message = `${location} | Revenant Horror`;
-		ChatLib.command(chatCommand + ' ' + message);
+		ChatLib.command(CHAT_COMMAND + ' ' + message);
 	} catch (e) {
 		console.error(e);
 		console.log(`[FeeshNotifier] Failed to send the message on Revenant spawn.`);


### PR DESCRIPTION
Refactored functionalities to not execute any checks when setting is disabled / when being in a wrong world:
  - Message on Hotspot found
  - Message on Revenant spawned
  - Alert on non-fishing armor
  - Alert on Worm the Fish caught