### PR TITLE
refactor: Applied registerif to various alerts

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -10,6 +10,18 @@ Features:
 Bugfixes:
 -
 
+Other:
+- Refactored different functionality to not execute any checks when setting is disabled / when being in a wrong world:
+  - Announce mob spawn to ALL chat
+  - Compact catch messages
+  - Message / alert on player's death
+  - Alert on thunder bottle charged
+  - Alert on chum bucket autopickup
+  - Alert on reindrake in lobby
+  - Alert on golden fish
+  - Alert on spirit mask used
+  - Alert on fishing with bag disabled
+
 ## v1.38.0
 
 Released: 2025-04-13

--- a/features/alerts/alertOnChumBucketAutopickup.js
+++ b/features/alerts/alertOnChumBucketAutopickup.js
@@ -4,14 +4,15 @@ import settings from "../../settings";
 import * as triggers from '../../constants/triggers';
 import { OFF_SOUND_MODE } from "../../constants/sounds";
 import { YELLOW } from "../../constants/formatting";
-import { isInSkyblock } from "../../utils/playerState";
+import { getWorldName, isInSkyblock } from "../../utils/playerState";
 import { registerIf } from "../../utils/registers";
+import { isInFishingWorld } from "../../utils/common";
 
 let worldChangedAt = null;
 
 registerIf(
 	register("Chat", (event) => setTimeout(playAlertOnBucketAutoPickup, 500)).setCriteria(triggers.CHUM_BUCKET_AUTO_PICKED_UP_MESSAGE),
-	() => settings.alertOnChumBucketAutoPickedUp && isInSkyblock()
+	() => settings.alertOnChumBucketAutoPickedUp && isInSkyblock() && isInFishingWorld(getWorldName())
 );
 
 register("worldUnload", () => {
@@ -20,7 +21,7 @@ register("worldUnload", () => {
 
 export function playAlertOnBucketAutoPickup() {
 	try {
-		if (!settings.alertOnChumBucketAutoPickedUp || !isInSkyblock() || !World.isLoaded) {
+		if (!settings.alertOnChumBucketAutoPickedUp || !isInSkyblock() || !isInFishingWorld(getWorldName()) || !World.isLoaded) {
 			return;
 		}
 

--- a/features/alerts/alertOnChumBucketAutopickup.js
+++ b/features/alerts/alertOnChumBucketAutopickup.js
@@ -5,10 +5,14 @@ import * as triggers from '../../constants/triggers';
 import { OFF_SOUND_MODE } from "../../constants/sounds";
 import { YELLOW } from "../../constants/formatting";
 import { isInSkyblock } from "../../utils/playerState";
+import { registerIf } from "../../utils/registers";
 
 let worldChangedAt = null;
 
-register("Chat", (event) => setTimeout(playAlertOnBucketAutoPickup, 500)).setCriteria(triggers.CHUM_BUCKET_AUTO_PICKED_UP_MESSAGE);
+registerIf(
+	register("Chat", (event) => setTimeout(playAlertOnBucketAutoPickup, 500)).setCriteria(triggers.CHUM_BUCKET_AUTO_PICKED_UP_MESSAGE),
+	() => settings.alertOnChumBucketAutoPickedUp && isInSkyblock()
+);
 
 register("worldUnload", () => {
     worldChangedAt = new Date();

--- a/features/alerts/alertOnGoldenFish.js
+++ b/features/alerts/alertOnGoldenFish.js
@@ -2,13 +2,18 @@ import settings from "../../settings";
 import * as triggers from '../../constants/triggers';
 import { OFF_SOUND_MODE } from "../../constants/sounds";
 import { GOLD, WHITE } from "../../constants/formatting";
-import { isInSkyblock } from "../../utils/playerState";
+import { getWorldName, isInSkyblock } from "../../utils/playerState";
+import { registerIf } from "../../utils/registers";
+import { CRIMSON_ISLE } from "../../constants/areas";
 
-register("Chat", (event) => playAlertOnGoldenFish()).setCriteria(triggers.GOLDEN_FISH_MESSAGE);
+registerIf(
+	register("Chat", (event) => playAlertOnGoldenFish()).setCriteria(triggers.GOLDEN_FISH_MESSAGE),
+	() => settings.alertOnGoldenFishSpawned && isInSkyblock() && getWorldName() === CRIMSON_ISLE
+);
 
 function playAlertOnGoldenFish() {
 	try {
-		if (!settings.alertOnGoldenFishSpawned || !isInSkyblock()) {
+		if (!settings.alertOnGoldenFishSpawned || !isInSkyblock() || getWorldName() !== CRIMSON_ISLE) {
 			return;
 		}
 		

--- a/features/alerts/alertOnPlayerDeath.js
+++ b/features/alerts/alertOnPlayerDeath.js
@@ -4,30 +4,31 @@ import { OFF_SOUND_MODE } from "../../constants/sounds";
 import { RED } from "../../constants/formatting";
 import { isInSkyblock } from "../../utils/playerState";
 import { getColoredPlayerNameFromPartyChat, getPartyChatMessage, getPlayerDeathMessage } from "../../utils/common";
+import { registerIf } from "../../utils/registers";
 
 triggers.KILLED_BY_TRIGGERS.forEach(entry => {
-    register(
-        "Chat",
-        (rankAndPlayer, event) => playAlertOnPlayerDeath({
-            isEnabled: settings.alertOnPartyMemberDeath,
-            player: getColoredPlayerNameFromPartyChat(rankAndPlayer)
-        })
-    ).setCriteria(getPartyChatMessage(getPlayerDeathMessage()));
+	registerIf(
+		register(
+			"Chat",
+			(rankAndPlayer, event) => playAlertOnPlayerDeath(getColoredPlayerNameFromPartyChat(rankAndPlayer))
+		).setCriteria(getPartyChatMessage(getPlayerDeathMessage())),
+		() => settings.alertOnPartyMemberDeath && isInSkyblock()
+	);
 });
 
 // Shows a title and plays a sound on automated player death message sent by this module.
-function playAlertOnPlayerDeath(options) {
+function playAlertOnPlayerDeath(player) {
 	try {
-		if (!options.isEnabled || !isInSkyblock()) {
+		if (!settings.alertOnPartyMemberDeath || !isInSkyblock()) {
 			return;
 		}
 		
 		// If the party message is sent by current player, no need to show alert.
-		if (options.player && options.player.includes(Player.getName())) {
+		if (player && player.includes(Player.getName())) {
 			return;
 		}
 	
-		const title = `${options.player || 'Party member'} ${RED}killed ☠`;
+		const title = `${player || 'Party member'} ${RED}killed ☠`;
 		Client.showTitle(title, 'Wait for them to come back', 1, 30, 1);
 	
 		if (settings.soundMode !== OFF_SOUND_MODE) {

--- a/features/alerts/alertOnReindrake.js
+++ b/features/alerts/alertOnReindrake.js
@@ -2,19 +2,24 @@ import settings from "../../settings";
 import * as triggers from '../../constants/triggers';
 import * as seaCreatures from '../../constants/seaCreatures';
 import { NOTIFICATION_SOUND_SOURCE, OFF_SOUND_MODE } from "../../constants/sounds";
-import { isInSkyblock } from "../../utils/playerState";
+import { getWorldName, isInSkyblock } from "../../utils/playerState";
 import { getCatchTitle } from "../../utils/common";
+import { registerIf } from "../../utils/registers";
+import { JERRY_WORKSHOP } from "../../constants/areas";
 
 // Alert on any reindrake spawned in a lobby
 
-register("Chat", (event) => playAlertOnReindrake()).setCriteria(triggers.REINDRAKE_SPAWNED_BY_ANYONE_MESSAGE).setContains();
+registerIf(
+	register("Chat", (event) => playAlertOnReindrake()).setCriteria(triggers.REINDRAKE_SPAWNED_BY_ANYONE_MESSAGE).setContains(),
+	() => settings.alertOnAnyReindrakeCatch && isInSkyblock() && getWorldName() === JERRY_WORKSHOP
+);
 
 const reindrakeTrigger = triggers.RARE_CATCH_TRIGGERS.find(t => t.seaCreature == seaCreatures.REINDRAKE);
 const title = getCatchTitle(reindrakeTrigger.seaCreature, reindrakeTrigger.rarityColorCode);
 
 function playAlertOnReindrake() {
 	try {
-		if (!settings.alertOnAnyReindrakeCatch || !isInSkyblock()) {
+		if (!settings.alertOnAnyReindrakeCatch || !isInSkyblock() || getWorldName() !== JERRY_WORKSHOP) {
 			return;
 		}
 		

--- a/features/alerts/alertOnSpiritMaskUsed.js
+++ b/features/alerts/alertOnSpiritMaskUsed.js
@@ -3,11 +3,12 @@ import * as triggers from '../../constants/triggers';
 import { OFF_SOUND_MODE } from "../../constants/sounds";
 import { DARK_PURPLE, GOLD, GREEN, WHITE, YELLOW } from "../../constants/formatting";
 import { isInSkyblock } from "../../utils/playerState";
+import { registerIf } from "../../utils/registers";
 
-register(
-	"Chat",
-	(event) => playAlertOnSpiritMaskUsed()
-).setCriteria(triggers.SPIRIT_MASK_USED_MESSAGE);
+registerIf(
+	register("Chat", (event) => playAlertOnSpiritMaskUsed()).setCriteria(triggers.SPIRIT_MASK_USED_MESSAGE),
+	() => settings.alertOnSpiritMaskUsed && isInSkyblock()
+);
 
 function playAlertOnSpiritMaskUsed() {
 	try {

--- a/features/alerts/alertOnThunderBottleCharged.js
+++ b/features/alerts/alertOnThunderBottleCharged.js
@@ -3,12 +3,16 @@ import * as triggers from '../../constants/triggers';
 import { OFF_SOUND_MODE } from "../../constants/sounds";
 import { AQUA } from "../../constants/formatting";
 import { isInSkyblock } from "../../utils/playerState";
+import { registerIf } from "../../utils/registers";
 
 triggers.BOTTLE_CHARGED_TRIGGERS.forEach(entry => {
-    register(
-        "Chat",
-        (event) => setTimeout(() => playAlertOnBottleCharged(entry.bottleName), 1000) // Delay because the alert is often overriden by the Thunder spawn alert
-    ).setCriteria(entry.trigger).setContains();
+	registerIf(
+		register(
+			"Chat",
+			(event) => setTimeout(() => playAlertOnBottleCharged(entry.bottleName), 1000) // Delay because the alert is often overriden by the Thunder spawn alert
+		).setCriteria(entry.trigger).setContains(),
+		() => settings.alertOnThunderBottleCharged && isInSkyblock()
+	);
 });
 
 function playAlertOnBottleCharged(bottleName) {

--- a/features/chat/announceMobSpawnToAllChat.js
+++ b/features/chat/announceMobSpawnToAllChat.js
@@ -2,7 +2,9 @@ import settings from '../../settings';
 import * as triggers from '../../constants/triggers';
 import * as seaCreatures from '../../constants/seaCreatures';
 import { getMessageId, getZoneName, isDoubleHook } from '../../utils/common';
-import { isInSkyblock } from '../../utils/playerState';
+import { getWorldName, isInSkyblock } from '../../utils/playerState';
+import { registerIf } from '../../utils/registers';
+import { CRIMSON_ISLE } from '../../constants/areas';
 
 const chatCommand = 'ac';
 
@@ -15,12 +17,12 @@ const mobTriggers = triggers.RARE_CATCH_TRIGGERS.filter(t =>
 );
 
 mobTriggers.forEach(entry => {
-    register(
-        "Chat",
-        (event) => {
-            announceMobSpawnToAllChat(entry.seaCreature, entry.isAnnounceToAllChatEnabledSettingKey);
-        }
-    ).setCriteria(entry.trigger).setContains();
+    registerIf(
+        register("Chat", (event) => announceMobSpawnToAllChat(entry.seaCreature, entry.isAnnounceToAllChatEnabledSettingKey))
+            .setCriteria(entry.trigger)
+            .setContains(),
+        () => isInSkyblock() && getWorldName() === CRIMSON_ISLE
+    );
 });
 
 function announceMobSpawnToAllChat(seaCreature, isAnnounceToAllChatEnabledSettingKey) {

--- a/features/chat/compactCatchMessages.js
+++ b/features/chat/compactCatchMessages.js
@@ -1,20 +1,27 @@
 import settings from "../../settings";
 import { AQUA, BOLD, GRAY, RESET } from "../../constants/formatting";
 import * as triggers from "../../constants/triggers";
-import { getArticle, isDoubleHook } from "../../utils/common";
-import { isInSkyblock } from '../../utils/playerState';
+import { getArticle, isDoubleHook, isInFishingWorld } from "../../utils/common";
+import { getWorldName, isInSkyblock } from '../../utils/playerState';
+import { registerIf } from "../../utils/registers";
 
 triggers.DOUBLE_HOOK_MESSAGES.forEach(entry => {
-    register("Chat", (event) => compactDoubleHookChatMessage(event)).setCriteria(entry);
+    registerIf(
+        register("Chat", (event) => compactDoubleHookChatMessage(event)).setCriteria(entry),
+        () => settings.compactCatchMessages && isInSkyblock() && isInFishingWorld(getWorldName())
+    );
 });
 
 triggers.ALL_CATCHES_TRIGGERS.forEach(entry => {
-    register("Chat", (event) => compactSeaCreatureCatchChatMessage(entry, event)).setCriteria(entry.trigger).setContains();
+    registerIf(
+        register("Chat", (event) => compactSeaCreatureCatchChatMessage(entry, event)).setCriteria(entry.trigger).setContains(),
+        () => settings.compactCatchMessages && isInSkyblock() && isInFishingWorld(getWorldName())
+    );
 });
 
 function compactDoubleHookChatMessage(event) {
     try {
-        if (!settings.compactCatchMessages || !isInSkyblock()) {
+        if (!settings.compactCatchMessages || !isInSkyblock() || !isInFishingWorld(getWorldName())) {
             return;
         }
 
@@ -27,7 +34,7 @@ function compactDoubleHookChatMessage(event) {
 
 function compactSeaCreatureCatchChatMessage(entry, event) {
     try {
-        if (!settings.compactCatchMessages || !isInSkyblock()) {
+        if (!settings.compactCatchMessages || !isInSkyblock() || !isInFishingWorld(getWorldName())) {
             return;
         }
 

--- a/features/chat/messageOnPlayerDeath.js
+++ b/features/chat/messageOnPlayerDeath.js
@@ -1,24 +1,22 @@
 import settings from "../../settings";
 import * as triggers from '../../constants/triggers';
 import { getPlayerDeathMessage } from '../../utils/common';
-import { isInSkyblock } from '../../utils/playerState';
+import { getWorldName, isInSkyblock } from '../../utils/playerState';
+import { registerIf } from "../../utils/registers";
+import { CRIMSON_ISLE } from "../../constants/areas";
 
 const chatCommand = 'pc';
 
 triggers.KILLED_BY_TRIGGERS.forEach(entry => {
-    register(
-        "Chat",
-        (event) => {
-            sendMessageOnPlayerDeath({
-                isEnabled: settings.messageOnDeath
-            });
-        }
-    ).setCriteria(entry.trigger).setContains();
+	registerIf(
+		register("Chat", (event) => sendMessageOnPlayerDeath()).setCriteria(entry.trigger).setContains(),
+		() => settings.messageOnDeath && isInSkyblock() && getWorldName() === CRIMSON_ISLE
+	);
 });
 
-function sendMessageOnPlayerDeath(options) {
+function sendMessageOnPlayerDeath() {
 	try {
-		if (!options.isEnabled || !isInSkyblock()) {
+		if (!settings.messageOnDeath || !isInSkyblock() || getWorldName() !== CRIMSON_ISLE) {
 			return;
 		}
 

--- a/settings.js
+++ b/settings.js
@@ -486,7 +486,7 @@ const config = new DefaultConfig("FeeshNotifier", "config/settings.json")
     category: "Alerts",
     configName: "alertOnFishingBagDisabled",
     title: "Alert when Fishing Bag is disabled",
-    description: "Shows a title and plays a sound when current player starts fishing with Fishing Bag disabled.",
+    description: `Shows a title and plays a sound when current player starts fishing with Fishing Bag disabled.\n${RED}After enabling the setting, please open your fishing bag once to initialize its state!`,
     subcategory: "Fishing bag",
     value: true
 })


### PR DESCRIPTION
Refactored different functionality to not execute any checks when setting is disabled / when being in a wrong world:
  - Announce mob spawn to ALL chat
  - Compact catch messages
  - Message / alert on player's death
  - Alert on thunder bottle charged
  - Alert on chum bucket autopickup
  - Alert on reindrake in lobby
  - Alert on golden fish
  - Alert on spirit mask used
  - Alert on fishing with bag disabled