### PR TITLE
Release 1.40.0

### DIFF
--- a/constants/fishingProfitItems.js
+++ b/constants/fishingProfitItems.js
@@ -814,6 +814,7 @@ export const FISHING_PROFIT_ITEMS = [
         itemAlternateNames: [ 'Enchanted Book (Caster 6)' ],
         itemDisplayName: `${RARE}Caster VI ${WHITE}Book`,
         npcPrice: 0,
+        shouldAnnounceRareDrop: true,
     },
     {
         itemId: 'ENCHANTMENT_BLESSING_6',

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -5,6 +5,7 @@
 Released: ???
 
 Features:
+- Added option to auto-share found hotspots to the selected chat [disabled by default].
 - Announce RARE DROP! on Caster VI book dropped.
 
 Bugfixes:

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -7,9 +7,28 @@ Released: ???
 Features:
 - Added option to auto-share found hotspots to the selected chat [disabled by default].
 - Announce RARE DROP! on Caster VI book dropped.
+- Do not show Abandoned Quarry tracker when in Trophy Hunter armor (as it's often used to just catch treasure).
+- Show Sea creature HP overlay and render boxes even if no fishing rod in hotbar.
+- Changed different overlays to hide them when player is not fishing.
+  - Before this change, overlays were visible if player had a fishing rod in hotbar (which is a case for many other activities other than fishing).
+  - Now the overlays appear after player starts fishing in water/lava, and are hidden after 10 minutes of inactivity or after swapping server.
+  - Also, overlays with timers are not paused now when taking off a rod from hotbar.
+  - The following overlays affected:
+    - Fishing Profit tracker
+    - Rare Catches tracker
+    - Crimson Isle tracker
+    - Jerry Workshop tracker
+    - Magma Core profit tracker
+    - Worm membrane profit tracker
+    - Sea creatures per hour tracker
 
 Bugfixes:
 -
+
+Other:
+- Refactored different functionality to not execute any checks when setting is disabled / when being in a wrong world:
+  - Sea creatures count overlay & alert
+  - Worm membrane profit tracker
 
 ## v1.39.0
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -25,7 +25,7 @@ Features:
     - Sea creatures per hour tracker
 
 Bugfixes:
--
+- Fixed issue with DisplayLine being clickable for disabled&invisible widgets, for some users.
 
 Other:
 - Refactored different functionality to not execute any checks when setting is disabled / when being in a wrong world:

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,8 +1,18 @@
 # Releases
 
-## v1.39.0
+## v1.40.0
 
 Released: ???
+
+Features:
+-
+
+Bugfixes:
+-
+
+## v1.39.0
+
+Released: 2025-04-23
 
 Features:
 - Added Archfiend Dice profit tracker with Session and Total view modes.

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -5,13 +5,15 @@
 Released: ???
 
 Features:
+- Added option to set a keybind in Minecraft's Controls menu to pause all active overlays on button pressed. Default button is PAUSE.
+  - The effect is the same as pressing [Click to pause] line on each active overlay.
 - Added option to auto-share found hotspots to the selected chat [disabled by default].
 - Announce RARE DROP! on Caster VI book dropped.
 - Do not show Abandoned Quarry tracker when in Trophy Hunter armor (as it's often used to just catch treasure).
 - Show Sea creature HP overlay and render boxes even if no fishing rod in hotbar.
 - Changed different overlays to hide them when player is not fishing.
   - Before this change, overlays were visible if player had a fishing rod in hotbar (which is a case for many other activities other than fishing).
-  - Now the overlays appear after player starts fishing in water/lava, and are hidden after 10 minutes of inactivity or after swapping server.
+  - Now the overlays appear after player starts fishing in water/lava, and hide after 10 minutes of inactivity / after swapping server.
   - Also, overlays with timers are not paused now when taking off a rod from hotbar.
   - The following overlays affected:
     - Fishing Profit tracker
@@ -27,6 +29,7 @@ Bugfixes:
 
 Other:
 - Refactored different functionality to not execute any checks when setting is disabled / when being in a wrong world:
+  - Fishing profit tracker
   - Sea creatures count overlay & alert
   - Worm membrane profit tracker
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -5,7 +5,7 @@
 Released: ???
 
 Features:
--
+- Announce RARE DROP! on Caster VI book dropped.
 
 Bugfixes:
 -

--- a/docs/Future ideas & requests.md
+++ b/docs/Future ideas & requests.md
@@ -1,14 +1,13 @@
 - Track catches for Ragnarok in crimson isle tracker (when in hotspot).
 - Hotspot search
-- Auto announce hotspots
-- Hide elapsed time in Fishing Profit Tracker
+- Decrease elapsed time in Fishing Profit Tracker (when user forgot to stop tracker being afk)
 - Offer supercrafting or BZ sell when items like raw fish goes to inventory (sacks are full).
 - Track scavenged coins in Fishing Profit Tracker
 - Track Ice Essence drop from mobs in Fishing Profit Tracker
+- [Bug] Reset confirmation messages appear for disabled overlays for no reason, for one person.
 - [Bug] Some items are tracked by Fishing Profit Tracker when dropped, but drop was prevented by SB settings (basically it drops and picks up again).
 - [Bug] Fishing Profit Tracker recalculates profits/h too often when in "display buttons" mode.
 - [Bug] Trading with other players adds items to the profit trackers.
-- [Bug] Magma Core Profit Tracker does not stop timer if move out rod and then return it back.
 - Calculate pet price in Fishing Profit Tracker as difference between lvl 1 and lvl 100
   - Also, there are requests to track pet level progress in coins
 - Remove double hook reindrake logic because DH is not possible now

--- a/docs/Future ideas & requests.md
+++ b/docs/Future ideas & requests.md
@@ -1,5 +1,7 @@
 - Track catches for Ragnarok in crimson isle tracker (when in hotspot).
 - Hotspot search
+- Auto announce hotspots
+- Hide elapsed time in Fishing Profit Tracker
 - Offer supercrafting or BZ sell when items like raw fish goes to inventory (sacks are full).
 - Track scavenged coins in Fishing Profit Tracker
 - Track Ice Essence drop from mobs in Fishing Profit Tracker

--- a/features/chat/messageOnHotspotFound.js
+++ b/features/chat/messageOnHotspotFound.js
@@ -12,7 +12,7 @@ let lastFoundHotspotIds = []; // Remember 2 last found hotspots, to avoid announ
 
 registerIf(
     register("step", (event) => sendMessageOnHotspotFound()).setDelay(1),
-    () => settings.messageOnHotspotFound && isInSkyblock() && HOTSPOT_WORLDS.includes(getWorldName())
+    () => (settings.messageOnHotspotFound || settings.autoMessageOnHotspotFound) && isInSkyblock() && HOTSPOT_WORLDS.includes(getWorldName())
 );
 
 register("worldUnload", () => {
@@ -22,7 +22,7 @@ register("worldUnload", () => {
 
 function sendMessageOnHotspotFound() {
 	try {
-		if (!settings.messageOnHotspotFound ||
+		if ((!settings.messageOnHotspotFound && !settings.autoMessageOnHotspotFound) ||
             !HOTSPOT_WORLDS.includes(getWorldName()) ||
             !isInSkyblock()
         ) {
@@ -61,19 +61,27 @@ function sendChatMessage(position, perk) {
     }
 
     const message = getMessage(position, perk);
-    new Message(
-        `${GOLD}[FeeshNotifier] ${WHITE}You found ${perk} ${RESET}${LIGHT_PURPLE}Hotspot${WHITE}.\n`,
-        new TextComponent(`${WHITE}${BOLD}[Share to ${BLUE}${BOLD}PARTY ${WHITE}${BOLD}chat]`)
-            .setClickAction('run_command')
-            .setClickValue('/pc ' + message),
-        ` ${GRAY}or `,
-        new TextComponent(`${WHITE}${BOLD}[Share to ${YELLOW}${BOLD}ALL ${WHITE}${BOLD}chat]`)
-            .setClickAction('run_command')
-            .setClickValue('/ac ' + message),
-    ).chat();
 
-    if (settings.soundMode !== OFF_SOUND_MODE) {
-        World.playSound('random.orb', 1, 1);
+    if (settings.messageOnHotspotFound) {
+        new Message(
+            `${GOLD}[FeeshNotifier] ${WHITE}You found ${perk} ${RESET}${LIGHT_PURPLE}Hotspot${WHITE}.\n`,
+            new TextComponent(`${WHITE}${BOLD}[Share to ${BLUE}${BOLD}PARTY ${WHITE}${BOLD}chat]`)
+                .setClickAction('run_command')
+                .setClickValue('/pc ' + message),
+            ` ${GRAY}or `,
+            new TextComponent(`${WHITE}${BOLD}[Share to ${YELLOW}${BOLD}ALL ${WHITE}${BOLD}chat]`)
+                .setClickAction('run_command')
+                .setClickValue('/ac ' + message),
+        ).chat();
+    
+        if (settings.soundMode !== OFF_SOUND_MODE) {
+            World.playSound('random.orb', 1, 1);
+        }
+    }
+
+    if (settings.autoMessageOnHotspotFound) {
+        const command = settings.autoMessageOnHotspotFoundSource === 0 ? 'pc' : 'ac';
+        ChatLib.command(command + ' ' + message);
     }
 }
 

--- a/features/overlays/abandonedQuarryTracker.js
+++ b/features/overlays/abandonedQuarryTracker.js
@@ -4,7 +4,7 @@ import { ABANDONED_QUARRY, DWARVEN_MINES } from "../../constants/areas";
 import { AQUA, BOLD, GOLD, GRAY, GREEN, RED, WHITE, YELLOW } from "../../constants/formatting";
 import { ANY_MITHRIL_GRUBBER_MESSAGE } from "../../constants/triggers";
 import { formatElapsedTime, formatNumberWithSpaces, isDoubleHook, isFishingHookActive } from "../../utils/common";
-import { getLastGuisClosed, getWorldName, getZoneName, hasFishingRodInHotbar, isInSkyblock } from "../../utils/playerState";
+import { getLastFishingHookSeenAt, getLastGuisClosed, getWorldName, getZoneName, isInHunterArmor, isInSkyblock } from "../../utils/playerState";
 import { BLOATED_MITHRIL_GRUBBER, LARGE_MITHRIL_GRUBBER, MEDIUM_MITHRIL_GRUBBER, SMALL_MITHRIL_GRUBBER } from "../../constants/seaCreatures";
 import { createButtonsDisplay, toggleButtonsDisplay } from "../../utils/overlays";
 import { registerIf } from "../../utils/registers";
@@ -58,6 +58,11 @@ registerIf(
     () => settings.abandonedQuarryTrackerOverlay && isInSkyblock() && getWorldName() === DWARVEN_MINES
 );
 
+register("worldUnload", () => {
+    pauseSession();
+    buttonsDisplay.hide();
+});
+
 export function resetAbandonedQuarryTracker(isConfirmed) {
     try {
         if (!isConfirmed) {
@@ -98,7 +103,7 @@ export function resetAbandonedQuarryTracker(isConfirmed) {
 
 function pauseAbandonedQuarryTracker() {
     try {
-        if (!isSessionActive || !settings.abandonedQuarryTrackerOverlay || !isInSkyblock() || !hasFishingRodInHotbar() || getZoneName() !== ABANDONED_QUARRY) {
+        if (!isSessionActive || !settings.abandonedQuarryTrackerOverlay || !isInSkyblock() || getZoneName() !== ABANDONED_QUARRY) {
             return;
         }
     
@@ -117,7 +122,7 @@ function pauseSession() {
 
 function activateSessionOnPlayersFishingHook() {
     try {
-        if (!settings.abandonedQuarryTrackerOverlay || !isInSkyblock() || !hasFishingRodInHotbar() || getZoneName() !== ABANDONED_QUARRY) {
+        if (!settings.abandonedQuarryTrackerOverlay || !isInSkyblock() || getZoneName() !== ABANDONED_QUARRY || isInHunterArmor()) {
             return;
         }
     
@@ -146,7 +151,7 @@ function activateSessionOnPlayersFishingHook() {
 
 function refreshElapsedTime() {
     try {
-        if (!isSessionActive || !settings.abandonedQuarryTrackerOverlay || !isInSkyblock() || !hasFishingRodInHotbar() || getZoneName() !== ABANDONED_QUARRY) {
+        if (!isSessionActive || !settings.abandonedQuarryTrackerOverlay || !isInSkyblock() || getZoneName() !== ABANDONED_QUARRY || isInHunterArmor()) {
             pauseSession();
             return;
         }
@@ -168,7 +173,7 @@ function refreshElapsedTime() {
 
 function trackMithrilGrubberCatch(seaCreature, isDoubleHook) {
     try {
-        if (!seaCreature || !settings.abandonedQuarryTrackerOverlay || !isInSkyblock() || !hasFishingRodInHotbar() || getZoneName() !== ABANDONED_QUARRY) {
+        if (!seaCreature || !settings.abandonedQuarryTrackerOverlay || !isInSkyblock() || getZoneName() !== ABANDONED_QUARRY) {
             return;
         }
   
@@ -207,7 +212,7 @@ function getMithrilPowder() {
 
 function detectMithrilPowderChanges() {
     try {
-        if (!isSessionActive || !settings.abandonedQuarryTrackerOverlay || !isInSkyblock() || !hasFishingRodInHotbar() || getZoneName() !== ABANDONED_QUARRY) {
+        if (!isSessionActive || !settings.abandonedQuarryTrackerOverlay || !isInSkyblock() || getZoneName() !== ABANDONED_QUARRY) {
             return;
         }
 
@@ -242,7 +247,7 @@ function detectMithrilPowderChanges() {
 
 function refreshTrackerData() {
     try {
-        if (!isSessionActive || !settings.abandonedQuarryTrackerOverlay || !isInSkyblock() || !hasFishingRodInHotbar() || getZoneName() !== ABANDONED_QUARRY) {
+        if (!isSessionActive || !settings.abandonedQuarryTrackerOverlay || !isInSkyblock() || getZoneName() !== ABANDONED_QUARRY) {
             return;
         }
 
@@ -265,10 +270,11 @@ function refreshTrackerData() {
 function renderMithrilGrubberPowderTrackerOverlay() {
     if (!settings.abandonedQuarryTrackerOverlay ||
         !isInSkyblock() ||
-        !hasFishingRodInHotbar() ||
         getZoneName() !== ABANDONED_QUARRY ||
+        isInHunterArmor() ||
         !trackerData ||
         !trackerData.elapsedSeconds ||
+        (new Date() - getLastFishingHookSeenAt() > 10 * 60 * 1000) ||
         allOverlaysGui.isOpen()
     ) {
         buttonsDisplay.hide();
@@ -276,7 +282,7 @@ function renderMithrilGrubberPowderTrackerOverlay() {
     }
 
     const lastPowderGainText = trackerData.lastPowderGain ? ` ${GRAY}[+${formatNumberWithSpaces(trackerData.lastPowderGain)} last added]` : '';
-    const pausedText = isSessionActive ? '' : ` ${YELLOW}[Paused]`;
+    const pausedText = isSessionActive ? '' : ` ${GRAY}[Paused]`;
     let text = `${YELLOW}${BOLD}Abandoned Quarry tracker\n`;
     text += `${GREEN}Total Mithril Grubbers caught: ${WHITE}${formatNumberWithSpaces(trackerData.totalCatches)} ${GRAY}(${WHITE}${formatNumberWithSpaces(trackerData.catches[SMALL_MITHRIL_GRUBBER_KEY])} ${formatNumberWithSpaces(trackerData.catches[MEDIUM_MITHRIL_GRUBBER_KEY])} ${formatNumberWithSpaces(trackerData.catches[LARGE_MITHRIL_GRUBBER_KEY])} ${formatNumberWithSpaces(trackerData.catches[BLOATED_MITHRIL_GRUBBER_KEY])}${GRAY})\n`;
     text += `${GREEN}Total Mithril Powder: ${WHITE}${formatNumberWithSpaces(trackerData.totalPowder)}${lastPowderGainText}\n`;

--- a/features/overlays/abandonedQuarryTracker.js
+++ b/features/overlays/abandonedQuarryTracker.js
@@ -101,7 +101,7 @@ export function resetAbandonedQuarryTracker(isConfirmed) {
     }
 }
 
-function pauseAbandonedQuarryTracker() {
+export function pauseAbandonedQuarryTracker() {
     try {
         if (!isSessionActive || !settings.abandonedQuarryTrackerOverlay || !isInSkyblock() || getZoneName() !== ABANDONED_QUARRY) {
             return;

--- a/features/overlays/crimsonIsleTracker.js
+++ b/features/overlays/crimsonIsleTracker.js
@@ -4,7 +4,7 @@ import * as seaCreatures from '../../constants/seaCreatures';
 import { persistentData } from "../../data/data";
 import { overlayCoordsData } from "../../data/overlayCoords";
 import { BOLD, GOLD, LIGHT_PURPLE, RED, WHITE, GRAY, DARK_RED, DARK_GRAY, RESET } from "../../constants/formatting";
-import { getWorldName, hasFishingRodInHotbar, isInSkyblock } from "../../utils/playerState";
+import { getLastFishingHookSeenAt, getWorldName, isInSkyblock } from "../../utils/playerState";
 import { formatDate, formatNumberWithSpaces, formatTimeElapsedBetweenDates, isDoubleHook } from "../../utils/common";
 import { CRIMSON_ISLE } from "../../constants/areas";
 import { MEME_SOUND_MODE, NORMAL_SOUND_MODE, SAD_TROMBONE_SOUND_SOURCE } from "../../constants/sounds";
@@ -269,7 +269,7 @@ function renderCrimsonIsleTrackerOverlay() {
         ) ||
         !isInSkyblock() ||
         getWorldName() !== CRIMSON_ISLE ||
-        !hasFishingRodInHotbar() ||
+        (new Date() - getLastFishingHookSeenAt() > 10 * 60 * 1000) ||
         allOverlaysGui.isOpen()
     ) {
         buttonsDisplay.hide();

--- a/features/overlays/fishingProfitTracker.js
+++ b/features/overlays/fishingProfitTracker.js
@@ -12,7 +12,6 @@ import { getLastFishingHookSeenAt, getLastGuisClosed, getLastKatUpgrade, getWorl
 import { playRareDropSound } from '../../utils/sound';
 import { createButtonsDisplay, getButtonsDisplayRenderY } from '../../utils/overlays';
 import { registerIf } from '../../utils/registers';
-import { Keybind } from "../../../KeybindFix"
 
 let isVisible = false;
 let areActionsVisible = false;
@@ -127,15 +126,16 @@ export function resetFishingProfitTracker(isConfirmed) {
 	}
 }
 
-export function pauseFishingProfitTracker() {
+export function pauseFishingProfitTracker(forceRefreshDisplay) {
     try {
         if (!isVisible || !isSessionActive) {
             return;
         }
 
         pause();
-        refreshTrackerDisplayData();
-        ChatLib.chat(`${GOLD}[FeeshNotifier] ${WHITE}Fishing profit tracker is paused. Continue fishing to resume it.`);       
+        ChatLib.chat(`${GOLD}[FeeshNotifier] ${WHITE}Fishing profit tracker is paused. Continue fishing to resume it.`);
+        
+        if (forceRefreshDisplay) refreshTrackerDisplayData();
     } catch (e) {
         console.error(e);
 		console.log(`[FeeshNotifier] [ProfitTracker] Failed to pause Fishing profit tracker.`);

--- a/features/overlays/fishingProfitTracker.js
+++ b/features/overlays/fishingProfitTracker.js
@@ -2,42 +2,73 @@ import * as triggers from '../../constants/triggers';
 import settings, { allOverlaysGui, fishingProfitTrackerOverlayGui } from "../../settings";
 import { persistentData } from "../../data/data";
 import { overlayCoordsData } from "../../data/overlayCoords";
-import { CRIMSON_ISLE, JERRY_WORKSHOP, KUUDRA } from "../../constants/areas";
+import { CRIMSON_ISLE, JERRY_WORKSHOP } from "../../constants/areas";
 import { FISHING_PROFIT_ITEMS } from "../../constants/fishingProfitItems";
-import { AQUA, BOLD, GOLD, GRAY, RESET, WHITE, RED, GREEN, BLUE } from "../../constants/formatting";
+import { AQUA, BOLD, GOLD, GRAY, RESET, WHITE, RED } from "../../constants/formatting";
 import { getAuctionItemPrices, getPetRarityCode } from "../../utils/auctionPrices";
 import { getBazaarItemPrices } from "../../utils/bazaarPrices";
-import { formatElapsedTime, getCleanItemName, getItemsAddedToSacks, getLore, isFishingHookActive, isInChatOrInventoryGui, isInSacksGui, isInSupercraftGui, splitArray, toShortNumber } from "../../utils/common";
-import { getLastGuisClosed, getLastKatUpgrade, getWorldName, hasFishingRodInHotbar, isInSkyblock } from "../../utils/playerState";
+import { formatElapsedTime, getCleanItemName, getItemsAddedToSacks, getLore, isFishingHookActive, isInChatOrInventoryGui, isInFishingWorld, isInSacksGui, isInSupercraftGui, splitArray, toShortNumber } from "../../utils/common";
+import { getLastFishingHookSeenAt, getLastGuisClosed, getLastKatUpgrade, getWorldName, isInSkyblock } from "../../utils/playerState";
 import { playRareDropSound } from '../../utils/sound';
 import { createButtonsDisplay, getButtonsDisplayRenderY } from '../../utils/overlays';
+import { registerIf } from '../../utils/registers';
 
 let isVisible = false;
 let areActionsVisible = false;
 let previousInventory = [];
 let isSessionActive = false;
-let lastHookSeenAt = null;
 
-register("Chat", (event) => onAddedToSacks(event)).setCriteria('&6[Sacks] &r&a+').setStart(); // Items added to the sacks
-register('step', () => detectInventoryChanges()).setFps(4); // Items added to the inventory
+registerIf(
+    register("Chat", (event) => onAddedToSacks(event)).setCriteria('&6[Sacks] &r&a+').setStart(), // Items added to the sacks
+    () => settings.fishingProfitTrackerOverlay && isInSkyblock() && isInFishingWorld(getWorldName())
+);
 
-triggers.COINS_FISHED_TRIGGERS.forEach(trigger => { register("Chat", (coins, event) => onCoinsFished(coins)).setCriteria(trigger.trigger); });
-triggers.ICE_ESSENCE_FISHED_TRIGGERS.forEach(trigger => { register("Chat", (count, event) => onIceEssenceFished(count)).setCriteria(trigger.trigger); });
+registerIf(
+    register('step', () => detectInventoryChanges()).setFps(4), // Items added to the inventory
+    () => settings.fishingProfitTrackerOverlay && isInSkyblock() && isInFishingWorld(getWorldName())
+);
 
-// &r&aYour &r&5Ender Dragon &r&aleveled up to level &r&981&r&a!&r
-// &r&aYour &r&6Mammoth &r&aleveled up to level &r&92&r&a!&r
-register("Chat", (petDisplayName, level, event) => onPetReachedMaxLevel(+level, petDisplayName))
-    .setCriteria(`${RESET}${GREEN}Your ${RESET}` + "${petDisplayName}" + ` ${RESET}${GREEN}leveled up to level ${RESET}${BLUE}` + "${level}" + `${RESET}${GREEN}!${RESET}`)
-    .setContains();
+triggers.COINS_FISHED_TRIGGERS.forEach(trigger => {
+    registerIf(
+        register("Chat", (coins, event) => onCoinsFished(coins)).setCriteria(trigger.trigger),
+        () => settings.fishingProfitTrackerOverlay && isInSkyblock() && isInFishingWorld(getWorldName())
+    );
+});
+
+triggers.ICE_ESSENCE_FISHED_TRIGGERS.forEach(trigger => {
+    registerIf(
+        register("Chat", (count, event) => onIceEssenceFished(count)).setCriteria(trigger.trigger),
+        () => settings.fishingProfitTrackerOverlay && isInSkyblock() && getWorldName() === JERRY_WORKSHOP
+    );
+});
+
+registerIf(
+    register("Chat", (petDisplayName, level, event) => onPetReachedMaxLevel(+level, petDisplayName))
+        .setCriteria(triggers.PET_LEVEL_UP_MESSAGE)
+        .setContains(),
+    () => settings.fishingProfitTrackerOverlay && isInSkyblock() && getWorldName() === CRIMSON_ISLE
+);
 
 register('step', () => {
     activateSessionOnPlayersFishingHook();
     refreshIsVisible();
     refreshAreActionsVisible();
 }).setFps(2);
-register('step', () => refreshElapsedTime()).setFps(1);
-register('step', () => refreshPrices()).setDelay(30);
-register('step', () => { if (fishingProfitTrackerOverlayGui.isOpen()) refreshTrackerDisplayData(); }).setFps(4); // Handle move/resize
+
+registerIf(
+    register('step', () => refreshElapsedTime()).setFps(1),    
+    () => settings.fishingProfitTrackerOverlay && isInSkyblock() && isInFishingWorld(getWorldName())
+);
+
+registerIf(
+    register('step', () => refreshPrices()).setDelay(30),
+    () => settings.fishingProfitTrackerOverlay && isInSkyblock() && isInFishingWorld(getWorldName())
+);
+
+registerIf(
+    register('step', () => { if (fishingProfitTrackerOverlayGui.isOpen()) refreshTrackerDisplayData(); }).setFps(4), // Handle move/resize
+    () => settings.fishingProfitTrackerOverlay && isInSkyblock() && isInFishingWorld(getWorldName())
+);
 
 let isWorldLoaded = false;
 // World.isLoaded() doesn't give the same result for some reason
@@ -111,7 +142,6 @@ function pauseFishingProfitTracker() {
 
 function pause() {
     previousInventory = [];
-    lastHookSeenAt = null;
     isSessionActive = false;
 }
 
@@ -122,8 +152,8 @@ function refreshIsVisible() {
         !persistentData || !persistentData.fishingProfit ||
         (!persistentData.fishingProfit.totalProfit && !Object.keys(persistentData.fishingProfit.profitTrackerItems).length && !persistentData.fishingProfit.elapsedSeconds) ||
         !isInSkyblock() ||
-        getWorldName() === KUUDRA ||
-        !hasFishingRodInHotbar() ||
+        !isInFishingWorld(getWorldName()) ||
+        (new Date() - getLastFishingHookSeenAt() > 10 * 60 * 1000) ||
         allOverlaysGui.isOpen()
     ) {
         isVisible = false;
@@ -186,12 +216,11 @@ function changeItemAmount(itemId, isDelete, difference) {
 
 function activateSessionOnPlayersFishingHook() {
     try {
-        if (!settings.fishingProfitTrackerOverlay || !isWorldLoaded || !isInSkyblock() || !hasFishingRodInHotbar() || getWorldName() === KUUDRA) {
+        if (!settings.fishingProfitTrackerOverlay || !isWorldLoaded || !isInSkyblock() || !isInFishingWorld(getWorldName())) {
             return;
         }
     
         const isHookActive = isFishingHookActive();
-
         if (isHookActive) {
             activateTimer();
         }
@@ -201,7 +230,6 @@ function activateSessionOnPlayersFishingHook() {
 	}
 
     function activateTimer() {
-        lastHookSeenAt = new Date();
         isSessionActive = true;
 
         if (!persistentData.fishingProfit.elapsedSeconds) {
@@ -218,6 +246,7 @@ function refreshElapsedTime() {
         }
 
         const maxSecondsElapsedSinceLastAction = 60 * 6; // Time to kill any mob before despawn, e.g. Jawbus
+        const lastHookSeenAt = getLastFishingHookSeenAt();
         const elapsedSecondsSinceLastAction = (new Date() - lastHookSeenAt) / 1000;
 
         if (lastHookSeenAt && elapsedSecondsSinceLastAction < maxSecondsElapsedSinceLastAction) {
@@ -633,7 +662,8 @@ function getFishingProfitItemByName(itemName) {
 }
 
 function getElapsedTimeLineText(elapsedTime) {
-    return `\n${AQUA}Elapsed time: ${WHITE}${formatElapsedTime(elapsedTime)}`
+    const pausedText = isSessionActive ? '' : ` ${GRAY}[Paused]`;
+    return `\n${AQUA}Elapsed time: ${WHITE}${formatElapsedTime(elapsedTime)}${pausedText}`
 }
 
 function refreshTrackerDisplayData() {

--- a/features/overlays/fishingProfitTracker.js
+++ b/features/overlays/fishingProfitTracker.js
@@ -12,6 +12,7 @@ import { getLastFishingHookSeenAt, getLastGuisClosed, getLastKatUpgrade, getWorl
 import { playRareDropSound } from '../../utils/sound';
 import { createButtonsDisplay, getButtonsDisplayRenderY } from '../../utils/overlays';
 import { registerIf } from '../../utils/registers';
+import { Keybind } from "../../../KeybindFix"
 
 let isVisible = false;
 let areActionsVisible = false;
@@ -126,13 +127,14 @@ export function resetFishingProfitTracker(isConfirmed) {
 	}
 }
 
-function pauseFishingProfitTracker() {
+export function pauseFishingProfitTracker() {
     try {
         if (!isVisible || !isSessionActive) {
             return;
         }
 
         pause();
+        refreshTrackerDisplayData();
         ChatLib.chat(`${GOLD}[FeeshNotifier] ${WHITE}Fishing profit tracker is paused. Continue fishing to resume it.`);       
     } catch (e) {
         console.error(e);

--- a/features/overlays/jerryWorkshopTracker.js
+++ b/features/overlays/jerryWorkshopTracker.js
@@ -4,7 +4,7 @@ import * as seaCreatures from '../../constants/seaCreatures';
 import { persistentData } from "../../data/data";
 import { overlayCoordsData } from "../../data/overlayCoords";
 import { BOLD, GOLD, RED, WHITE, DARK_PURPLE, GRAY, AQUA, DARK_GRAY, LIGHT_PURPLE } from "../../constants/formatting";
-import { getWorldName, hasFishingRodInHotbar, isInSkyblock } from "../../utils/playerState";
+import { getLastFishingHookSeenAt, getWorldName, isInSkyblock } from "../../utils/playerState";
 import { formatDate, formatNumberWithSpaces, formatTimeElapsedBetweenDates } from "../../utils/common";
 import { JERRY_WORKSHOP } from "../../constants/areas";
 import { createButtonsDisplay, toggleButtonsDisplay } from "../../utils/overlays";
@@ -248,7 +248,7 @@ function renderJerryWorkshopOverlay() {
         ) ||
         !isInSkyblock() ||
         getWorldName() !== JERRY_WORKSHOP ||
-        !hasFishingRodInHotbar() ||
+        (new Date() - getLastFishingHookSeenAt() > 10 * 60 * 1000) ||
         allOverlaysGui.isOpen()
     ) {
         buttonsDisplay.hide();

--- a/features/overlays/magmaCoreProfitTracker.js
+++ b/features/overlays/magmaCoreProfitTracker.js
@@ -97,7 +97,7 @@ export function resetMagmaCoreProfitTracker(isConfirmed) {
 	}
 }
 
-function pauseMagmaCoreProfitTracker() {
+export function pauseMagmaCoreProfitTracker() {
     try {
         if (!settings.magmaCoreProfitTrackerOverlay || !isInSkyblock() || getWorldName() !== CRYSTAL_HOLLOWS || !isSessionActive) {
             return;

--- a/features/overlays/magmaCoreProfitTracker.js
+++ b/features/overlays/magmaCoreProfitTracker.js
@@ -2,7 +2,7 @@ import settings, { allOverlaysGui } from "../../settings";
 import * as triggers from '../../constants/triggers';
 import { overlayCoordsData } from "../../data/overlayCoords";
 import { BOLD, GOLD, RED, WHITE, BLUE, YELLOW, GREEN, AQUA, GRAY } from "../../constants/formatting";
-import { getWorldName, hasFishingRodInHotbar, isInSkyblock } from "../../utils/playerState";
+import { getLastFishingHookSeenAt, getWorldName, isInSkyblock } from "../../utils/playerState";
 import {  formatElapsedTime, formatNumberWithSpaces, isDoubleHook, toShortNumber } from "../../utils/common";
 import { CRYSTAL_HOLLOWS } from "../../constants/areas";
 import { getBazaarItemPrices } from "../../utils/bazaarPrices";
@@ -99,7 +99,7 @@ export function resetMagmaCoreProfitTracker(isConfirmed) {
 
 function pauseMagmaCoreProfitTracker() {
     try {
-        if (!settings.magmaCoreProfitTrackerOverlay || !isInSkyblock() || !hasFishingRodInHotbar() || getWorldName() !== CRYSTAL_HOLLOWS || !isSessionActive) {
+        if (!settings.magmaCoreProfitTrackerOverlay || !isInSkyblock() || getWorldName() !== CRYSTAL_HOLLOWS || !isSessionActive) {
             return;
         }
     
@@ -113,7 +113,8 @@ function pauseMagmaCoreProfitTracker() {
 
 function refreshElapsedTime() {
     try {
-        if (!isSessionActive || !settings.magmaCoreProfitTrackerOverlay || !isInSkyblock() || !hasFishingRodInHotbar() || getWorldName() !== CRYSTAL_HOLLOWS) {
+        if (!isSessionActive || !settings.magmaCoreProfitTrackerOverlay || !isInSkyblock() || getWorldName() !== CRYSTAL_HOLLOWS) {
+            isSessionActive = false;
             return;
         }
 
@@ -134,7 +135,7 @@ function refreshElapsedTime() {
 
 function refreshTrackerData() {
     try {
-        if (!settings.magmaCoreProfitTrackerOverlay || !isInSkyblock() || !hasFishingRodInHotbar() || getWorldName() !== CRYSTAL_HOLLOWS) {
+        if (!settings.magmaCoreProfitTrackerOverlay || !isInSkyblock() || getWorldName() !== CRYSTAL_HOLLOWS) {
             return;
         }
 
@@ -165,7 +166,7 @@ function refreshTrackerData() {
 
 function trackSeaCreatureCatch(isDoubleHooked) {
     try {
-        if (!settings.magmaCoreProfitTrackerOverlay || !isInSkyblock() || !hasFishingRodInHotbar() || getWorldName() !== CRYSTAL_HOLLOWS) {
+        if (!settings.magmaCoreProfitTrackerOverlay || !isInSkyblock() || getWorldName() !== CRYSTAL_HOLLOWS) {
             return;
         }
 
@@ -191,7 +192,7 @@ function trackMagmaCoreDrop() {
         totalMagmaCoresCount += 1;
 
         const now = new Date();
-        if (now - lastMagmaCoreDroppedAt < 10 * 1000) { // If players kill a cap slowly, the membranes are added a few times nearly at the same time
+        if (now - lastMagmaCoreDroppedAt < 10 * 1000) { // If players kill a cap slowly, the cores are added a few times nearly at the same time
             lastAddedMagmaCoresCount += 1;
         } else {
             lastAddedMagmaCoresCount = 1;
@@ -208,16 +209,16 @@ function trackMagmaCoreDrop() {
 function renderMagmaCoreTrackerOverlay() {
     if (!settings.magmaCoreProfitTrackerOverlay ||
         !isInSkyblock() ||
-        !hasFishingRodInHotbar() ||
         getWorldName() !== CRYSTAL_HOLLOWS ||
         (!totalMagmaCoresCount && !totalSeaCreaturesCaughtCount) ||
+        (new Date() - getLastFishingHookSeenAt() > 10 * 60 * 1000) ||
         allOverlaysGui.isOpen()
     ) {
         buttonsDisplay.hide();
         return;
     }
 
-    const pausedText = isSessionActive ? '' : ` ${YELLOW}[Paused]`;
+    const pausedText = isSessionActive ? '' : ` ${GRAY}[Paused]`;
     let text = `${YELLOW}${BOLD}Magma Core profit tracker\n`;
     text += `${GREEN}Total sea creatures caught: ${WHITE}${formatNumberWithSpaces(totalSeaCreaturesCaughtCount)}\n`;
     text += `${BLUE}Total magma cores: ${WHITE}${formatNumberWithSpaces(totalMagmaCoresCount)} ${GRAY}[+${formatNumberWithSpaces(lastAddedMagmaCoresCount)} last added]\n`;

--- a/features/overlays/rareCatchesTracker.js
+++ b/features/overlays/rareCatchesTracker.js
@@ -6,7 +6,7 @@ import { overlayCoordsData } from "../../data/overlayCoords";
 import { formatNumberWithSpaces, fromUppercaseToCapitalizedFirstLetters, isDoubleHook, isInFishingWorld, pluralize } from '../../utils/common';
 import { WHITE, GOLD, BOLD, YELLOW, GRAY, RED } from "../../constants/formatting";
 import { RARE_CATCH_TRIGGERS } from "../../constants/triggers";
-import { getWorldName, hasFishingRodInHotbar, isInSkyblock } from "../../utils/playerState";
+import { getLastFishingHookSeenAt, getWorldName, isInSkyblock } from "../../utils/playerState";
 import { createButtonsDisplay, toggleButtonsDisplay } from "../../utils/overlays";
 import { registerIf } from "../../utils/registers";
 
@@ -37,7 +37,7 @@ export function resetRareCatchesTracker(isConfirmed) {
     try {
         if (!isConfirmed) {
             new Message(
-                new TextComponent(`${GOLD}[FeeshNotifier] ${WHITE}Do you want to reset rare catches tracker? ${RED}${BOLD}[Click to confirm]`)
+                new TextComponent(`${GOLD}[FeeshNotifier] ${WHITE}Do you want to reset Rare catches tracker? ${RED}${BOLD}[Click to confirm]`)
                     .setClickAction('run_command')
                     .setClickValue('/feeshResetRareCatches noconfirm')
             ).chat();
@@ -77,7 +77,7 @@ function trackCatch(options) {
             return;
         }
     
-        if (options.seaCreature === seaCreatures.VANQUISHER && !hasFishingRodInHotbar()) {
+        if (options.seaCreature === seaCreatures.VANQUISHER && (new Date() - getLastFishingHookSeenAt() > 6 * 60 * 1000)) {
             return;
         }
 
@@ -118,7 +118,7 @@ function renderRareCatchTrackerOverlay() {
         !Object.entries(persistentData.rareCatches).length ||
         !isInSkyblock() ||
         !isInFishingWorld(getWorldName()) ||
-        !hasFishingRodInHotbar() ||
+        (new Date() - getLastFishingHookSeenAt() > 10 * 60 * 1000) ||
         allOverlaysGui.isOpen()
     ) {
         buttonsDisplay.hide();

--- a/features/overlays/rareCatchesTracker.js
+++ b/features/overlays/rareCatchesTracker.js
@@ -4,7 +4,7 @@ import * as seaCreatures from '../../constants/seaCreatures';
 import { persistentData } from "../../data/data";
 import { overlayCoordsData } from "../../data/overlayCoords";
 import { formatNumberWithSpaces, fromUppercaseToCapitalizedFirstLetters, isDoubleHook, isInFishingWorld, pluralize } from '../../utils/common';
-import { WHITE, GOLD, BOLD, YELLOW, GRAY, RED } from "../../constants/formatting";
+import { WHITE, GOLD, BOLD, GRAY, RED, AQUA } from "../../constants/formatting";
 import { RARE_CATCH_TRIGGERS } from "../../constants/triggers";
 import { getLastFishingHookSeenAt, getWorldName, isInSkyblock } from "../../utils/playerState";
 import { createButtonsDisplay, toggleButtonsDisplay } from "../../utils/overlays";
@@ -125,7 +125,7 @@ function renderRareCatchTrackerOverlay() {
         return;
     }
 
-    let overlayText = `${YELLOW}${BOLD}Rare catches tracker\n`;
+    let overlayText = `${AQUA}${BOLD}Rare catches tracker\n`;
 
     const entries = Object.entries(persistentData.rareCatches)
         .map(([key, value]) => {
@@ -142,7 +142,7 @@ function renderRareCatchTrackerOverlay() {
         overlayText += `${GRAY}- ${rarityColorCode}${fromUppercaseToCapitalizedFirstLetters(entry.seaCreature)}${GRAY}: ${WHITE}${formatNumberWithSpaces(entry.amount)}${doubleHookInfo}\n`;
     });
 
-    overlayText += `${YELLOW}Total: ${WHITE}${persistentData.totalRareCatches}`;
+    overlayText += `${GRAY}Total: ${WHITE}${persistentData.totalRareCatches}`;
 
     const overlay = new Text(overlayText, overlayCoordsData.rareCatchesTrackerOverlay.x, overlayCoordsData.rareCatchesTrackerOverlay.y)
         .setShadow(true)

--- a/features/overlays/seaCreaturesHpTracker.js
+++ b/features/overlays/seaCreaturesHpTracker.js
@@ -2,7 +2,7 @@ import settings, { allOverlaysGui } from "../../settings";
 import { BOLD, YELLOW } from "../../constants/formatting";
 import { EntityArmorStand } from "../../constants/javaTypes";
 import { overlayCoordsData } from "../../data/overlayCoords";
-import { getWorldName, hasFishingRodInHotbar, isInSkyblock } from "../../utils/playerState";
+import { getWorldName, isInSkyblock } from "../../utils/playerState";
 import { BACKWATER_BAYOU, CRIMSON_ISLE, JERRY_WORKSHOP, WATER_HOTSPOT_WORLDS } from "../../constants/areas";
 import { OFF_SOUND_MODE } from "../../constants/sounds";
 import { registerIf } from "../../utils/registers";
@@ -82,8 +82,8 @@ function trackSeaCreaturesHp() {
 
         if (!settings.seaCreaturesHpOverlay ||
             !isInSkyblock() ||
-            !TRACKED_WORLD_NAMES.includes(getWorldName()) ||
-            !hasFishingRodInHotbar()) {
+            !TRACKED_WORLD_NAMES.includes(getWorldName())
+        ) {
             return;
         }
     
@@ -121,7 +121,6 @@ function renderHpOverlay() {
         !mobs.length ||
         !isInSkyblock() ||
         !TRACKED_WORLD_NAMES.includes(getWorldName()) ||
-        !hasFishingRodInHotbar() ||
         allOverlaysGui.isOpen()
     ) {
         return;

--- a/features/overlays/seaCreaturesPerHourTracker.js
+++ b/features/overlays/seaCreaturesPerHourTracker.js
@@ -3,7 +3,7 @@ import * as triggers from "../../constants/triggers";
 import { AQUA, BOLD, GOLD, GRAY, RED, WHITE, YELLOW } from "../../constants/formatting";
 import { overlayCoordsData } from "../../data/overlayCoords";
 import { formatElapsedTime, formatNumberWithSpaces, isDoubleHook, isInFishingWorld } from "../../utils/common";
-import { getWorldName, hasFishingRodInHotbar, isInSkyblock } from '../../utils/playerState';
+import { getLastFishingHookSeenAt, getWorldName, isInSkyblock } from '../../utils/playerState';
 import { registerIf } from "../../utils/registers";
 import { createButtonsDisplay, toggleButtonsDisplay } from "../../utils/overlays";
 
@@ -62,7 +62,7 @@ export function resetSeaCreaturesPerHourTracker(isConfirmed) {
 
 function pauseSeaCreaturesPerHourTracker() {
     try {
-        if (!settings.seaCreaturesPerHourTrackerOverlay || !isInSkyblock() || !hasFishingRodInHotbar() || !isSessionActive) {
+        if (!settings.seaCreaturesPerHourTrackerOverlay || !isInSkyblock() || !isSessionActive) {
             return;
         }
     
@@ -76,7 +76,7 @@ function pauseSeaCreaturesPerHourTracker() {
 
 function refreshElapsedTime() {
     try {
-        if (!isSessionActive || !settings.seaCreaturesPerHourTrackerOverlay || !isInSkyblock() || !hasFishingRodInHotbar()) {
+        if (!isSessionActive || !settings.seaCreaturesPerHourTrackerOverlay || !isInSkyblock() || !isInFishingWorld(getWorldName())) {
             isSessionActive = false;
             return;
         }
@@ -99,7 +99,7 @@ function refreshElapsedTime() {
 
 function trackSeaCreatureCatch() {
     try {
-        if (!settings.seaCreaturesPerHourTrackerOverlay || !isInSkyblock() || !hasFishingRodInHotbar() || !isInFishingWorld(getWorldName())) {
+        if (!settings.seaCreaturesPerHourTrackerOverlay || !isInSkyblock() || !isInFishingWorld(getWorldName())) {
             return;
         }
 
@@ -120,7 +120,7 @@ function trackSeaCreatureCatch() {
 
 function refreshTrackerData() {
     try {
-        if (!settings.seaCreaturesPerHourTrackerOverlay || !isInSkyblock() || !hasFishingRodInHotbar()) {
+        if (!settings.seaCreaturesPerHourTrackerOverlay || !isInSkyblock()) {
             return;
         }
 
@@ -138,15 +138,15 @@ function renderTrackerOverlay() {
     if (!settings.seaCreaturesPerHourTrackerOverlay ||
         !isInSkyblock() ||
         !isInFishingWorld(getWorldName()) ||
-        !hasFishingRodInHotbar() ||
         (!totalSeaCreaturesCaughtCount && !seaCreaturesPerHour) ||
+        (new Date() - getLastFishingHookSeenAt() > 10 * 60 * 1000) ||
         allOverlaysGui.isOpen()
     ) {
         buttonsDisplay.hide();
         return;
     }
 
-    const pausedText = isSessionActive ? '' : ` ${YELLOW}[Paused]`;
+    const pausedText = isSessionActive ? '' : ` ${GRAY}[Paused]`;
     let text = `${YELLOW}${BOLD}Sea creatures per hour`;
     text += `\n${WHITE}${formatNumberWithSpaces(seaCreaturesPerHour)} ${GRAY}per hour (${WHITE}${formatNumberWithSpaces(totalSeaCreaturesCaughtCount)} ${GRAY}total)`;
     text += `\n`;

--- a/features/overlays/seaCreaturesPerHourTracker.js
+++ b/features/overlays/seaCreaturesPerHourTracker.js
@@ -60,7 +60,7 @@ export function resetSeaCreaturesPerHourTracker(isConfirmed) {
     }
 }
 
-function pauseSeaCreaturesPerHourTracker() {
+export function pauseSeaCreaturesPerHourTracker() {
     try {
         if (!settings.seaCreaturesPerHourTrackerOverlay || !isInSkyblock() || !isSessionActive) {
             return;

--- a/features/overlays/wormMembraneProfitTracker.js
+++ b/features/overlays/wormMembraneProfitTracker.js
@@ -217,7 +217,7 @@ function detectInventoryChanges() {
     }
 }
 
-function pauseWormMembraneProfitTracker() {
+export function pauseWormMembraneProfitTracker() {
     try {
         if (!settings.wormProfitTrackerOverlay || !isInSkyblock() || getWorldName() !== CRYSTAL_HOLLOWS || !isSessionActive) {
             return;

--- a/features/rendering/boxEntities.js
+++ b/features/rendering/boxEntities.js
@@ -1,7 +1,7 @@
 import settings from "../../settings";
 import RenderLibV2 from "../../../RenderLibV2";
 import { BACKWATER_BAYOU, CRIMSON_ISLE, WATER_HOTSPOT_WORLDS } from "../../constants/areas";
-import { getWorldName, hasFishingRodInHotbar, isInSkyblock } from "../../utils/playerState";
+import { getWorldName, isInSkyblock } from "../../utils/playerState";
 import { registerIf } from "../../utils/registers";
 import { EntityArmorStand } from "../../constants/javaTypes";
 
@@ -38,7 +38,7 @@ function isRegisterEnabled() {
 
 function trackEntitiesToBox() {
     try {
-        if (!isRegisterEnabled() || !hasFishingRodInHotbar()) {
+        if (!isRegisterEnabled()) {
             return;
         }
     
@@ -105,7 +105,7 @@ function getBoxColor(plainName) {
 }
 
 function boxEntities() {
-    if (!boxedEntities.length || !isRegisterEnabled() || !hasFishingRodInHotbar()) {
+    if (!boxedEntities.length || !isRegisterEnabled()) {
         return;
     }
 

--- a/index.js
+++ b/index.js
@@ -1,6 +1,7 @@
 import "./commands";
 import "./moveOverlay";
 import "./moveAllOverlays";
+import "./keybinds";
 import "./utils/playerState";
 import "./utils/registers";
 import "./utils/bazaarPrices";

--- a/keybinds.js
+++ b/keybinds.js
@@ -7,7 +7,7 @@ import { pauseWormMembraneProfitTracker } from "./features/overlays/wormMembrane
 
 const pauseKeyBind = new Keybind("Pause active overlays", Keyboard.KEY_PAUSE, "FeeshNotifier");
 pauseKeyBind.registerKeyRelease(() => {
-    pauseFishingProfitTracker();
+    pauseFishingProfitTracker(true);
     pauseSeaCreaturesPerHourTracker();
     pauseAbandonedQuarryTracker();
     pauseMagmaCoreProfitTracker();

--- a/keybinds.js
+++ b/keybinds.js
@@ -1,0 +1,15 @@
+import { Keybind } from "../KeybindFix";
+import { pauseAbandonedQuarryTracker } from "./features/overlays/abandonedQuarryTracker";
+import { pauseFishingProfitTracker } from "./features/overlays/fishingProfitTracker";
+import { pauseMagmaCoreProfitTracker } from "./features/overlays/magmaCoreProfitTracker";
+import { pauseSeaCreaturesPerHourTracker } from "./features/overlays/seaCreaturesPerHourTracker";
+import { pauseWormMembraneProfitTracker } from "./features/overlays/wormMembraneProfitTracker";
+
+const pauseKeyBind = new Keybind("Pause active overlays", Keyboard.KEY_PAUSE, "FeeshNotifier");
+pauseKeyBind.registerKeyRelease(() => {
+    pauseFishingProfitTracker();
+    pauseSeaCreaturesPerHourTracker();
+    pauseAbandonedQuarryTracker();
+    pauseMagmaCoreProfitTracker();
+    pauseWormMembraneProfitTracker();
+});

--- a/metadata.json
+++ b/metadata.json
@@ -8,6 +8,7 @@
         "Amaterasu",
         "PogData",
         "requestV2",
-        "RenderLibV2"
+        "RenderLibV2",
+        "KeybindFix"
     ]
 }

--- a/metadata.json
+++ b/metadata.json
@@ -3,7 +3,7 @@
     "entry": "index.js",
     "author": "MoonTheSadFisher",
     "description": "Hypixel Skyblock fishing utilities for parties.",
-    "version": "1.39.0",
+    "version": "1.40.0",
     "requires": [
         "Amaterasu",
         "PogData",

--- a/moveAllOverlays.js
+++ b/moveAllOverlays.js
@@ -34,11 +34,12 @@ const SAMPLE_GUIS = [
         toggleSettingKey: 'rareCatchesTrackerOverlay',
         guiSettings: overlayCoordsData.rareCatchesTrackerOverlay,
         sampleText: 
-`${YELLOW}${BOLD}Rare catches tracker
+`${AQUA}${BOLD}Rare catches tracker
 ${GRAY}- ${LIGHT_PURPLE}Thunder${GRAY}: ${WHITE}10 ${GRAY}| DH: ${WHITE}2 ${GRAY}(25%)
 ${GRAY}- ${DARK_PURPLE}Vanquisher${GRAY}: ${WHITE}8
 ${GRAY}- ${LIGHT_PURPLE}Lord Jawbus${GRAY}: ${WHITE}2 ${GRAY}| DH: ${WHITE}1 ${GRAY}(100%)
-${GRAY}- ${LIGHT_PURPLE}Ragnarok${GRAY}: ${WHITE}1 ${GRAY}| DH: ${WHITE}0 ${GRAY}(0%)`,
+${GRAY}- ${LIGHT_PURPLE}Ragnarok${GRAY}: ${WHITE}1 ${GRAY}| DH: ${WHITE}0 ${GRAY}(0%)
+${GRAY}Total: ${WHITE}21`,
         isActive: false,
         width: 0,
         height: 0

--- a/settings.js
+++ b/settings.js
@@ -977,6 +977,14 @@ const config = new DefaultConfig("FeeshNotifier", "config/settings.json")
     value: 0,
     subcategory: "General"
 })
+.addTextParagraph({
+    category: "Overlays",
+    configName: "pauseButtonKeybindInformationText",
+    title: "Pause button",
+    description: "Set a keybind in Minecraft's Controls menu to pause all active overlays on button pressed. Default button is PAUSE.",
+    subcategory: "General"
+})
+
 .addSwitch({
     category: "Overlays",
     configName: "totemRemainingTimeOverlay",

--- a/settings.js
+++ b/settings.js
@@ -68,13 +68,31 @@ const config = new DefaultConfig("FeeshNotifier", "config/settings.json")
     subcategory: "Player's death",
     value: true
 })
+
 .addSwitch({
     category: "Chat",
     configName: "messageOnHotspotFound",
-    title: "Offer sharing the found hotspots",
+    title: "Offer sharing the found hotspots on click",
     description: "Shows clickable chat message that offers sharing Hotspot location and its perk to ALL chat or PARTY chat. You need to be close to the hotspot in order to trigger it.",
     subcategory: "Hotspot",
     value: true
+})
+.addSwitch({
+    category: "Chat",
+    configName: "autoMessageOnHotspotFound",
+    title: "Autoshare the found hotspots",
+    description: "Sends a chat message with Hotspot location and its perk to the selected chat. You need to be close to the hotspot in order to trigger it.",
+    subcategory: "Hotspot"
+})
+.addDropDown({
+    category: "Chat",
+    configName: "autoMessageOnHotspotFoundSource",
+    title: "Autoshare to",
+    description: "Source chat type to autoshare the found hotspots (if autosharing enabled).",
+    options: ["Party chat", "All chat"],
+    value: 0,
+    shouldShow: data => data.autoMessageOnHotspotFound,
+    subcategory: "Hotspot"
 })
 
 .addSwitch({

--- a/settings.js
+++ b/settings.js
@@ -1,6 +1,6 @@
 import Settings from "../Amaterasu/core/Settings";
 import DefaultConfig from "../Amaterasu/core/DefaultConfig";
-import { AQUA, GOLD, GRAY, RED, WHITE, BLUE, DARK_GRAY, RESET, BOLD, LIGHT_PURPLE } from "./constants/formatting";
+import { AQUA, GOLD, GRAY, RED, WHITE, BLUE, DARK_GRAY, RESET, BOLD, LIGHT_PURPLE, YELLOW } from "./constants/formatting";
 
 export const allOverlaysGui = new Gui(); // Sample overlays GUI to move/resize them all at once
 
@@ -95,6 +95,14 @@ const config = new DefaultConfig("FeeshNotifier", "config/settings.json")
     subcategory: "Hotspot"
 })
 
+.addTextParagraph({
+    category: "Chat",
+    configName: "messageOnCatchInformationText",
+    title: "Information",
+    description: `You need to enable ${YELLOW}Skyblock Settings -> Personal -> Fishing Settings -> Sea Creature Chat ${RESET}for this functionality to work!`,
+    centered: false,
+    subcategory: "Rare Catches"
+})
 .addSwitch({
     category: "Chat",
     configName: "messageOnYetiCatch",
@@ -632,6 +640,13 @@ const config = new DefaultConfig("FeeshNotifier", "config/settings.json")
     value: true
 })
 
+.addTextParagraph({
+    category: "Alerts",
+    configName: "alertOnCatchInformationText",
+    title: "Information",
+    description: `You need to enable ${YELLOW}Skyblock Settings -> Personal -> Fishing Settings -> Sea Creature Chat ${RESET}for this functionality to work!`,    centered: false,
+    subcategory: "Rare Catches"
+})
 .addSwitch({
     category: "Alerts",
     configName: "alertOnYetiCatch",
@@ -957,7 +972,7 @@ const config = new DefaultConfig("FeeshNotifier", "config/settings.json")
     category: "Overlays",
     configName: "buttonsPosition",
     title: "Buttons position",
-    description: "Where to place Reset / Pause buttons relatively to an overlay.",
+    description: "Where to place Reset / Pause / other buttons relatively to an overlay.",
     options: ["Bottom","Top"],
     value: 0,
     subcategory: "General"
@@ -1004,7 +1019,7 @@ const config = new DefaultConfig("FeeshNotifier", "config/settings.json")
     category: "Overlays",
     configName: "rareCatchesTrackerOverlay",
     title: "Rare catches tracker",
-    description: `Shows an overlay with the statistics of rare sea creatures caught, and frequency of double hooking them.\nDo ${AQUA}/feeshResetRareCatches${GRAY} to reset.\n${RED}Hidden if you have no fishing rod in your hotbar!`,
+    description: `Shows an overlay with the statistics of rare sea creatures caught, and frequency of double hooking them.\nDo ${AQUA}/feeshResetRareCatches${GRAY} to reset.`,
     subcategory: "Rare catches",
     value: true
 })
@@ -1040,7 +1055,7 @@ const config = new DefaultConfig("FeeshNotifier", "config/settings.json")
     category: "Overlays",
     configName: "seaCreaturesHpOverlay",
     title: "Sea creatures HP",
-    description: `Shows an overlay with the HP of nearby sea creatures when they're in lootshare range. Tracked creatures: Fiery Scuttler, Thunder, Lord Jawbus, Plhlegblast, Ragnarok, Reindrake, Yeti, Alligator, Blue Ringed Octopus, Wiki Tiki, Titanoboa.\n${RED}Hidden if you have no fishing rod in your hotbar!`,
+    description: `Shows an overlay with the HP of nearby sea creatures when they're in lootshare range. Tracked creatures: Fiery Scuttler, Thunder, Lord Jawbus, Plhlegblast, Ragnarok, Reindrake, Yeti, Alligator, Blue Ringed Octopus, Wiki Tiki, Titanoboa.`,
     subcategory: "Sea creatures HP",
     value: true
 })
@@ -1078,7 +1093,7 @@ const config = new DefaultConfig("FeeshNotifier", "config/settings.json")
     category: "Overlays",
     configName: "seaCreaturesPerHourTrackerOverlay",
     title: "Sea creatures per hour tracker",
-    description: `Shows an overlay with the sea creatures per hour, and total sea creatures caught per session. Not persistent - resets on MC restart.\n${RED}Hidden if you have no fishing rod in your hotbar!`,
+    description: `Shows an overlay with the sea creatures per hour, and total sea creatures caught per session. Not persistent - resets on MC restart.`,
     subcategory: "Sea creatures per hour tracker"
 })
 .addButton({
@@ -1124,7 +1139,7 @@ const config = new DefaultConfig("FeeshNotifier", "config/settings.json")
     category: "Overlays",
     configName: "jerryWorkshopTrackerOverlay",
     title: "Jerry Workshop tracker",
-    description: `Shows an overlay with Yeti / Reindrake catch statistics and Baby Yeti pet drops statistics while in the Jerry Workshop.\nDo ${AQUA}/feeshResetJerryWorkshop${GRAY} to reset.\n${RED}Hidden if you have no fishing rod in your hotbar!`,
+    description: `Shows an overlay with Yeti / Reindrake catch statistics and Baby Yeti pet drops statistics while in the Jerry Workshop.\nDo ${AQUA}/feeshResetJerryWorkshop${GRAY} to reset.`,
     subcategory: "Jerry Workshop tracker",
     value: true
 })
@@ -1162,8 +1177,7 @@ const config = new DefaultConfig("FeeshNotifier", "config/settings.json")
     title: "Crimson Isle tracker",
     description: `
 Shows an overlay with Thunder / Lord Jawbus catch statistics and Radioactive Vial drop statistics while in the Crimson Isle.
-Do ${AQUA}/feeshResetCrimsonIsle${GRAY} to reset.
-${RED}Hidden if you have no fishing rod in your hotbar!`,
+Do ${AQUA}/feeshResetCrimsonIsle${GRAY} to reset.`,
     subcategory: "Crimson Isle tracker",
     value: true
 })
@@ -1216,7 +1230,7 @@ Example: ${AQUA}/feeshSetRadioactiveVials 5 2024-03-18T14:05:00Z`);
     category: "Overlays",
     configName: "wormProfitTrackerOverlay",
     title: "Worm profit tracker",
-    description: `Shows an overlay with the worm fishing statistics - total and per hour, when in Crystal Hollows. Not persistent - resets on MC restart.\nDo ${AQUA}/feeshResetWormProfit${GRAY} to reset.\n${RED}Hidden if you have no fishing rod in your hotbar!`,
+    description: `Shows an overlay with the worm fishing statistics - total and per hour, when in Crystal Hollows. Not persistent - resets on MC restart.\nDo ${AQUA}/feeshResetWormProfit${GRAY} to reset.`,
     subcategory: "Worm profit tracker",
     value: true
 })
@@ -1254,7 +1268,7 @@ Example: ${AQUA}/feeshSetRadioactiveVials 5 2024-03-18T14:05:00Z`);
     category: "Overlays",
     configName: "magmaCoreProfitTrackerOverlay",
     title: "Magma Core profit tracker",
-    description: `Shows an overlay with the Magma Core fishing statistics - total and per hour, when in Crystal Hollows. Not persistent - resets on MC restart. \nDo ${AQUA}/feeshResetMagmaCoreProfit${GRAY} to reset.\n${RED}Hidden if you have no fishing rod in your hotbar!`,
+    description: `Shows an overlay with the Magma Core fishing statistics - total and per hour, when in Crystal Hollows. Not persistent - resets on MC restart. \nDo ${AQUA}/feeshResetMagmaCoreProfit${GRAY} to reset.`,
     subcategory: "Magma Core profit tracker",
     value: true
 })
@@ -1283,7 +1297,7 @@ Example: ${AQUA}/feeshSetRadioactiveVials 5 2024-03-18T14:05:00Z`);
     category: "Overlays",
     configName: "abandonedQuarryTrackerOverlay",
     title: "Abandoned Quarry tracker",
-    description: `Shows an overlay with the Mithril Grubber and Mithril Powder statistics, when in Abandoned Quarry. Not persistent - resets on MC restart.\n${DARK_GRAY}This requires Powder Widget to be enabled in /tablist.\nDo ${AQUA}/feeshResetAbandonedQuarry${GRAY} to reset.\n${RED}Hidden if you have no fishing rod in your hotbar!`,
+    description: `Shows an overlay with the Mithril Grubber and Mithril Powder statistics, when in Abandoned Quarry. Not persistent - resets on MC restart.\nThis requires ${YELLOW}Powder Widget ${RESET}to be enabled in /tablist.\nDo ${AQUA}/feeshResetAbandonedQuarry${GRAY} to reset.`,
     subcategory: "Abandoned Quarry tracker",
     value: true
 })
@@ -1353,9 +1367,8 @@ Example: ${AQUA}/feeshSetRadioactiveVials 5 2024-03-18T14:05:00Z`);
     title: "Fishing profit tracker",
     description: `
 Shows an overlay with your profits per fishing session.
-${DARK_GRAY}For this to work, make sure to enable Settings - Personal -> Chat Feedback -> Sack Notifications in Skyblock.
-${GRAY}Do ${AQUA}/feeshResetProfitTracker${GRAY} to reset.
-${RED}Hidden if you have no fishing rod in your hotbar!`,
+Make sure to enable ${YELLOW}Skyblock Settings -> Personal -> Chat Feedback -> Sack Notifications${RESET} to count items added to your sacks.
+${GRAY}Do ${AQUA}/feeshResetProfitTracker${GRAY} to reset.`,
     subcategory: "Fishing profit tracker",
     value: true
 })
@@ -1573,7 +1586,7 @@ ${RED}Hidden if you have no fishing rod in your hotbar!`,
     category: "Rendering",
     configName: "renderingBoxingText",
     title: "Boxing",
-    description: `This section allows to draw boxes around some entities. ${BOLD}Boxes are not visible through walls!\n${RED}Hidden if you have no fishing rod in your hotbar!`,
+    description: `This section allows to draw boxes around some entities. ${BOLD}Boxes are not visible through walls!`,
     centered: false,
     subcategory: "Boxing"
 })

--- a/utils/overlays.js
+++ b/utils/overlays.js
@@ -18,7 +18,7 @@ export function createButtonsDisplay(isResetable, resetFn, isPausable, pauseFn, 
     if (hasViewModes && changeViewModeFn) {
         let viewModeDisplayLine = new DisplayLine(`${GREEN}[Click to change view mode]`).setShadow(true);
         viewModeDisplayLine.registerClicked((x, y, mouseButton, buttonState) => {
-            if (isLeftMouseButtonUp(mouseButton, buttonState)) {
+            if (buttonsDisplay.getShouldRender() && isLeftMouseButtonUp(mouseButton, buttonState)) {
                 changeViewModeFn();
             }
         });    
@@ -28,7 +28,7 @@ export function createButtonsDisplay(isResetable, resetFn, isPausable, pauseFn, 
     if (isPausable && pauseFn) {
         let pauseTrackerDisplayLine = new DisplayLine(`${YELLOW}[Click to pause]`).setShadow(true);
         pauseTrackerDisplayLine.registerClicked((x, y, mouseButton, buttonState) => {
-            if (isLeftMouseButtonUp(mouseButton, buttonState)) {
+            if (buttonsDisplay.getShouldRender() && isLeftMouseButtonUp(mouseButton, buttonState)) {
                 pauseFn();
             }
         });
@@ -38,7 +38,7 @@ export function createButtonsDisplay(isResetable, resetFn, isPausable, pauseFn, 
     if (isResetable && resetFn) {
         let resetTrackerDisplayLine = new DisplayLine(`${RED}[Click to reset]`).setShadow(true);
         resetTrackerDisplayLine.registerClicked((x, y, mouseButton, buttonState) => {
-            if (isLeftMouseButtonUp(mouseButton, buttonState)) {
+            if (buttonsDisplay.getShouldRender() && isLeftMouseButtonUp(mouseButton, buttonState)) {
                 resetFn();
             }
         });    

--- a/utils/playerState.js
+++ b/utils/playerState.js
@@ -1,4 +1,4 @@
-import { isFishingRod } from "./common";
+import { isFishingHookActive, isFishingRod } from "./common";
 import { updateRegisters } from "./registers";
 
 var inSkyblock = false;
@@ -8,6 +8,7 @@ var zoneName = null;
 var hasFishingRodInHotbar = false;
 var hasDirtRodInHand = false;
 var isInHunterArmor = false;
+var lastFishingHookSeenAt = null;
 
 var lastKatUpgrade = {
 	lastPetClaimedAt: null,
@@ -38,9 +39,11 @@ function trackPlayerState() {
 
 		if (prevInSkyblock !== inSkyblock || prevWorldName !== worldName) {
 			updateRegisters();
+			lastFishingHookSeenAt = null;
 		}
 
 		setHasFishingRodInHotbar();
+		setLastFishingHookSeenAt();
 		setHasDirtRodInHand();
 		setIsInHunterArmor();	
 	} catch (e) {
@@ -112,6 +115,10 @@ export function hasDirtRodInHand() {
 
 export function isInHunterArmor() {
 	return isInHunterArmor;
+}
+
+export function getLastFishingHookSeenAt() {
+	return lastFishingHookSeenAt;
 }
 
 export function getLastGuisClosed() {
@@ -210,4 +217,15 @@ function setIsInHunterArmor() {
 	} else {
 		isInHunterArmor = false;
 	}
+}
+
+function setLastFishingHookSeenAt() {
+	if (!inSkyblock) {
+		return;
+	}
+
+	const isHookActive = isFishingHookActive();
+    if (isHookActive) {
+        lastFishingHookSeenAt = new Date();
+    }
 }


### PR DESCRIPTION
## Features
- Added option to set a keybind in Minecraft's Controls menu to pause all active overlays on button pressed. Default button is PAUSE.
  - The effect is the same as pressing [Click to pause] line on each active overlay.
- Added option to auto-share found hotspots to the selected chat [disabled by default].
- Announce RARE DROP! on Caster VI book dropped.
- Do not show Abandoned Quarry tracker when in Trophy Hunter armor (as it's often used to just catch treasure).
- Show Sea creature HP overlay and render boxes even if no fishing rod in hotbar.
- Changed different overlays to hide them when player is not fishing.
  - Before this change, overlays were visible if player had a fishing rod in hotbar (which is a case for many other activities other than fishing).
  - Now the overlays appear after player starts fishing in water/lava, and hide after 10 minutes of inactivity / after swapping server.
  - Also, overlays with timers are not paused now when taking off a rod from hotbar.
  - The following overlays affected:
    - Fishing Profit tracker
    - Rare Catches tracker
    - Crimson Isle tracker
    - Jerry Workshop tracker
    - Magma Core profit tracker
    - Worm membrane profit tracker
    - Sea creatures per hour tracker

## Bugfixes
- Fixed issue with DisplayLine being clickable for disabled&invisible widgets, for some users.

## Other
- Refactored different functionality to not execute any checks when setting is disabled / when being in a wrong world:
  - Fishing profit tracker
  - Sea creatures count overlay & alert
  - Worm membrane profit tracker