### PR TITLE
fix: Fixed crash because of ConcurrentModificationException on pausing Fishing Profit Tracker

### DIFF
--- a/features/overlays/fishingProfitTracker.js
+++ b/features/overlays/fishingProfitTracker.js
@@ -12,7 +12,6 @@ import { getLastFishingHookSeenAt, getLastGuisClosed, getLastKatUpgrade, getWorl
 import { playRareDropSound } from '../../utils/sound';
 import { createButtonsDisplay, getButtonsDisplayRenderY } from '../../utils/overlays';
 import { registerIf } from '../../utils/registers';
-import { Keybind } from "../../../KeybindFix"
 
 let isVisible = false;
 let areActionsVisible = false;
@@ -127,15 +126,16 @@ export function resetFishingProfitTracker(isConfirmed) {
 	}
 }
 
-export function pauseFishingProfitTracker() {
+export function pauseFishingProfitTracker(forceRefreshDisplay) {
     try {
         if (!isVisible || !isSessionActive) {
             return;
         }
 
         pause();
-        refreshTrackerDisplayData();
-        ChatLib.chat(`${GOLD}[FeeshNotifier] ${WHITE}Fishing profit tracker is paused. Continue fishing to resume it.`);       
+        ChatLib.chat(`${GOLD}[FeeshNotifier] ${WHITE}Fishing profit tracker is paused. Continue fishing to resume it.`);
+        
+        if (forceRefreshDisplay) refreshTrackerDisplayData();
     } catch (e) {
         console.error(e);
 		console.log(`[FeeshNotifier] [ProfitTracker] Failed to pause Fishing profit tracker.`);

--- a/keybinds.js
+++ b/keybinds.js
@@ -7,7 +7,7 @@ import { pauseWormMembraneProfitTracker } from "./features/overlays/wormMembrane
 
 const pauseKeyBind = new Keybind("Pause active overlays", Keyboard.KEY_PAUSE, "FeeshNotifier");
 pauseKeyBind.registerKeyRelease(() => {
-    pauseFishingProfitTracker();
+    pauseFishingProfitTracker(true);
     pauseSeaCreaturesPerHourTracker();
     pauseAbandonedQuarryTracker();
     pauseMagmaCoreProfitTracker();


### PR DESCRIPTION
There was a crash clicking [Click to pause] widget line because of extra display refresh needed to display paused state