### PR TITLE
fix: Fixed issue with DisplayLine being clickable for disabled & invisible widgets

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -25,7 +25,7 @@ Features:
     - Sea creatures per hour tracker
 
 Bugfixes:
--
+- Fixed issue with DisplayLine being clickable for disabled&invisible widgets, for some users.
 
 Other:
 - Refactored different functionality to not execute any checks when setting is disabled / when being in a wrong world:

--- a/utils/overlays.js
+++ b/utils/overlays.js
@@ -18,7 +18,7 @@ export function createButtonsDisplay(isResetable, resetFn, isPausable, pauseFn, 
     if (hasViewModes && changeViewModeFn) {
         let viewModeDisplayLine = new DisplayLine(`${GREEN}[Click to change view mode]`).setShadow(true);
         viewModeDisplayLine.registerClicked((x, y, mouseButton, buttonState) => {
-            if (isLeftMouseButtonUp(mouseButton, buttonState)) {
+            if (buttonsDisplay.getShouldRender() && isLeftMouseButtonUp(mouseButton, buttonState)) {
                 changeViewModeFn();
             }
         });    
@@ -28,7 +28,7 @@ export function createButtonsDisplay(isResetable, resetFn, isPausable, pauseFn, 
     if (isPausable && pauseFn) {
         let pauseTrackerDisplayLine = new DisplayLine(`${YELLOW}[Click to pause]`).setShadow(true);
         pauseTrackerDisplayLine.registerClicked((x, y, mouseButton, buttonState) => {
-            if (isLeftMouseButtonUp(mouseButton, buttonState)) {
+            if (buttonsDisplay.getShouldRender() && isLeftMouseButtonUp(mouseButton, buttonState)) {
                 pauseFn();
             }
         });
@@ -38,7 +38,7 @@ export function createButtonsDisplay(isResetable, resetFn, isPausable, pauseFn, 
     if (isResetable && resetFn) {
         let resetTrackerDisplayLine = new DisplayLine(`${RED}[Click to reset]`).setShadow(true);
         resetTrackerDisplayLine.registerClicked((x, y, mouseButton, buttonState) => {
-            if (isLeftMouseButtonUp(mouseButton, buttonState)) {
+            if (buttonsDisplay.getShouldRender() && isLeftMouseButtonUp(mouseButton, buttonState)) {
                 resetFn();
             }
         });    


### PR DESCRIPTION
One user reported he has [Click to reset] confirmation chat message randomly for different widgets which are disabled in settings.