### PR TITLE
feat: Sea creatures HP tracker rework

### DIFF
--- a/constants/areas.js
+++ b/constants/areas.js
@@ -7,6 +7,8 @@ export const ABANDONED_QUARRY = 'Abandoned Quarry';
 export const BACKWATER_BAYOU = 'Backwater Bayou';
 export const JERRY_WORKSHOP = 'Jerry\'s Workshop';
 export const SPIDERS_DEN = 'Spider\'s Den';
+export const PARK = 'The Park';
+export const FARMING_ISLANDS = 'The Farming Islands';
 export const KUUDRA = 'Kuudra';
 export const DUNGEONS = 'Catacombs';
 export const GARDEN = 'Garden';
@@ -36,4 +38,15 @@ export const NO_FISHING_WORLDS = [
     DUNGEON_HUB,
     THE_END,
     GLACITE_MINESHAFTS
+];
+
+export const WATER_FISHING_WORLDS = [
+    BACKWATER_BAYOU,
+    SPIDERS_DEN,
+    HUB,
+    CRYSTAL_HOLLOWS,
+    DWARVEN_MINES,
+    JERRY_WORKSHOP,
+    PARK,
+    FARMING_ISLANDS
 ];

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -5,7 +5,9 @@
 Released: ???
 
 Features:
--
+- Added all Legendary and Mythic mobs to Sea creature HP tracker.
+- Added setting for maximum count of sea creatures to display in Sea creature HP tracker.
+- Made Sea creature HP tracker moveable even when no sea creatures displayed.
 
 Bugfixes:
 -

--- a/features/overlays/seaCreaturesHpTracker.js
+++ b/features/overlays/seaCreaturesHpTracker.js
@@ -1,5 +1,5 @@
 import settings, { allOverlaysGui, seaCreaturesHpOverlayGui } from "../../settings";
-import { BOLD, YELLOW } from "../../constants/formatting";
+import { AQUA, BOLD } from "../../constants/formatting";
 import { EntityArmorStand } from "../../constants/javaTypes";
 import { overlayCoordsData } from "../../data/overlayCoords";
 import { getWorldName, isInSkyblock } from "../../utils/playerState";
@@ -152,13 +152,13 @@ function renderHpOverlay() {
     }
 
     if (!mobs.length && seaCreaturesHpOverlayGui.isOpen()) {
-        const overlayText = `${YELLOW}${BOLD}Sea creatures HP`;
+        const overlayText = `${AQUA}${BOLD}Sea creatures HP`;
         drawText(overlayText);
         return;
     }
     
     if (mobs.length) {
-        let overlayText = `${YELLOW}${BOLD}Sea creatures HP\n`;
+        let overlayText = `${AQUA}${BOLD}Sea creatures HP\n`;
         mobs.forEach((mob) => {
             overlayText += `${mob}\n`;
         });

--- a/moveAllOverlays.js
+++ b/moveAllOverlays.js
@@ -47,7 +47,7 @@ ${GRAY}Total: ${WHITE}21`,
     {
         toggleSettingKey: 'seaCreaturesHpOverlay',
         guiSettings: overlayCoordsData.seaCreaturesHpOverlay,
-        sampleText: `${YELLOW}${BOLD}Sea creatures HP\n${RED}${BOLD}Lord Jawbus ${RESET}${GREEN}76m${WHITE}/${GREEN}100m${RED}❤`,
+        sampleText: `${AQUA}${BOLD}Sea creatures HP\n${RED}${BOLD}Lord Jawbus ${RESET}${GREEN}76m${WHITE}/${GREEN}100m${RED}❤`,
         isActive: false,
         width: 0,
         height: 0

--- a/settings.js
+++ b/settings.js
@@ -1067,6 +1067,15 @@ const config = new DefaultConfig("FeeshNotifier", "config/settings.json")
     subcategory: "Sea creatures HP",
     value: true
 })
+.addSlider({
+    category: "Overlays",
+    configName: "seaCreaturesHpOverlay_maxCount",
+    title: "Maximum sea creatures count to display",
+    description: "Show top N sea creatures nearby.",
+    options: [1, 15],
+    value: 5,
+    subcategory: "Sea creatures HP"
+})
 .addButton({
     category: "Overlays",
     configName: "moveSeaCreaturesHpOverlay",

--- a/settings.js
+++ b/settings.js
@@ -1070,9 +1070,9 @@ const config = new DefaultConfig("FeeshNotifier", "config/settings.json")
 .addSlider({
     category: "Overlays",
     configName: "seaCreaturesHpOverlay_maxCount",
-    title: "Maximum sea creatures count to display",
-    description: "Show top N sea creatures nearby.",
-    options: [1, 15],
+    title: "Maximum sea creatures HP count",
+    description: "Show maximum N sea creatures nearby (to limit overlay size).",
+    options: [1, 20],
     value: 5,
     subcategory: "Sea creatures HP"
 })

--- a/settings.js
+++ b/settings.js
@@ -1063,7 +1063,7 @@ const config = new DefaultConfig("FeeshNotifier", "config/settings.json")
     category: "Overlays",
     configName: "seaCreaturesHpOverlay",
     title: "Sea creatures HP",
-    description: `Shows an overlay with the HP of nearby sea creatures when they're in lootshare range. Tracked creatures: Fiery Scuttler, Thunder, Lord Jawbus, Plhlegblast, Ragnarok, Reindrake, Yeti, Alligator, Blue Ringed Octopus, Wiki Tiki, Titanoboa.`,
+    description: `Shows an overlay with the HP of nearby Legendary/Mythic sea creatures when they're in lootshare range.`,
     subcategory: "Sea creatures HP",
     value: true
 })


### PR DESCRIPTION
- Added all Legendary and Mythic mobs to Sea creature HP tracker.
- Added setting for maximum count of sea creatures to display in Sea creature HP tracker.
- Made Sea creature HP tracker moveable even when no sea creatures displayed.