### PR TITLE
feat: Command to set drops count in trackers

### DIFF
--- a/commands.js
+++ b/commands.js
@@ -14,7 +14,7 @@ import { resetAbandonedQuarryTracker } from "./features/overlays/abandonedQuarry
 import { resetSeaCreaturesPerHourTracker } from "./features/overlays/seaCreaturesPerHourTracker";
 import { resetArchfiendDiceProfitTracker } from "./features/overlays/archfiendDiceProfitTracker";
 import { SESSION_VIEW_MODE, TOTAL_VIEW_MODE } from "./constants/viewModes";
-import { resetWaterHotspotsAndBayouTracker } from "./features/overlays/waterHotspotsAndBayouTracker";
+import { resetWaterHotspotsAndBayouTracker, setTikiMasks, setTitanoboaSheds } from "./features/overlays/waterHotspotsAndBayouTracker";
 
 register("command", (...args) => {
     settings.getConfig().openGui();
@@ -78,11 +78,21 @@ register("command", (...args) => {
     }
 }).setName("feeshResetProfitTracker");
 
-register("command", (...args) => {
-    const count = args[0];
-    const lastOn = args[1];
-    setRadioactiveVials(+count, lastOn);
-}).setName("feeshSetRadioactiveVials");
+register("command", (dropId, count, ...dateParts) => {
+    const lastOn = dateParts.join(' ');
+
+    switch (dropId) {
+        case 'RADIOACTIVE_VIAL':
+            setRadioactiveVials(+count, lastOn);
+            break;
+        case 'TITANOBOA_SHED':
+            setTitanoboaSheds(+count, lastOn);
+            break;
+        case 'TIKI_MASK':
+            setTikiMasks(+count, lastOn);
+            break;
+    }
+}).setName("feeshSetTrackerDrops");
 
 register("command", (...args) => {
     calculateFishingPetPrices();

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -11,11 +11,11 @@ Features:
     - /feeshSetTrackerDrops TIKI_MASK <COUNT> <LAST_ON_DATE>
     - <COUNT> is a mandatory number of times you've dropped it.
     - <LAST_ON_DATE> is optional and, if provided, should be in YYYY-MM-DD hh:mm:ss format. Can not be in future!
-    - Example 1: ${AQUA}/feeshSetTrackerDrops TITANOBOA_SHED 5 2025-05-30 23:59:00
-    - Example 2: ${AQUA}/feeshSetTrackerDrops TIKI_MASK 5 2025-05-30 23:59:00
+    - Example 1: /feeshSetTrackerDrops TITANOBOA_SHED 5 2025-05-30 23:59:00
+    - Example 2: /feeshSetTrackerDrops TIKI_MASK 5 2025-05-30 23:59:00
+- Added Fiery Scuttler & Ragnarok (when fishing in hotspot), Plhlegblast (when in Plhlegblast Pool) tracking to Crimson Isle tracker.
 - Changed command to initialize Radioactive Vials in the Crimson Isle Tracker, to have the same pattern everywhere:
   - /feeshSetTrackerDrops RADIOACTIVE_VIAL <COUNT> <LAST_ON_DATE>
-- Added Fiery Scuttler & Ragnarok (when fishing in hotspot), Plhlegblast (when in Plhlegblast Pool) tracking to Crimson Isle tracker.
 
 Bugfixes:
 - Do not display DH for Reindrakes in Rare Catches tracker.

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -6,7 +6,15 @@ Released: ???
 
 Features:
 - Added Water hotspots & Bayou tracker. It shows an overlay with Titanoboa (when fishing in hotspot) and Wiki Tiki (when in Backwater Bayou) catch statistics. Also has Titanoboa Shed and Tiki Mask drop statistics.
-  - TODO: Set drops command
+  - You can initialize Titanoboa Sheds and Tiki Masks using the command:
+    - /feeshSetTrackerDrops TITANOBOA_SHED <COUNT> <LAST_ON_DATE>
+    - /feeshSetTrackerDrops TIKI_MASK <COUNT> <LAST_ON_DATE>
+    - <COUNT> is a mandatory number of times you've dropped it.
+    - <LAST_ON_DATE> is optional and, if provided, should be in YYYY-MM-DD hh:mm:ss format. Can not be in future!
+    - Example 1: ${AQUA}/feeshSetTrackerDrops TITANOBOA_SHED 5 2025-05-30 23:59:00
+    - Example 2: ${AQUA}/feeshSetTrackerDrops TIKI_MASK 5 2025-05-30 23:59:00
+- Changed command to initialize Radioactive Vials in the Crimson Isle Tracker, to have the same pattern everywhere:
+  - /feeshSetTrackerDrops RADIOACTIVE_VIAL <COUNT> <LAST_ON_DATE>
 - Added Fiery Scuttler & Ragnarok (when fishing in hotspot), Plhlegblast (when in Plhlegblast Pool) tracking to Crimson Isle tracker.
 
 Bugfixes:

--- a/docs/Future ideas & requests.md
+++ b/docs/Future ideas & requests.md
@@ -58,6 +58,10 @@
 - Offer supercrafting or BZ sell when items like raw fish goes to inventory (sacks are full).
 - Refactor all existing features so they consume less FPS
 
+## Fishing Hook
+
+- [Bug] Sometimes default Hypixel fishing hook is rendered (when in water)
+
 ## Baits
 
 - Bait changed alert

--- a/features/overlays/crimsonIsleTracker.js
+++ b/features/overlays/crimsonIsleTracker.js
@@ -8,7 +8,7 @@ import { getLastFishingHookInHotspotSeenAt, getLastFishingHookSeenAt, getWorldNa
 import { getCatchesCounterChatMessage, getDropCatchesCounterChatMessage } from "../../utils/common";
 import { CRIMSON_ISLE, PLHLEGBLAST_POOL } from "../../constants/areas";
 import { MEME_SOUND_MODE, NORMAL_SOUND_MODE, SAD_TROMBONE_SOUND_SOURCE } from "../../constants/sounds";
-import { createButtonsDisplay, toggleButtonsDisplay, setSeaCreatureStatisticsOnCatch, getSeaCreatureStatisticsOverlayText, getDropStatisticsOverlayText, setDropStatisticsOnCatch, setDropStatisticsOnDrop } from "../../utils/overlays";
+import { createButtonsDisplay, toggleButtonsDisplay, setSeaCreatureStatisticsOnCatch, getSeaCreatureStatisticsOverlayText, getDropStatisticsOverlayText, setDropStatisticsOnCatch, setDropStatisticsOnDrop, initDropCountOnOverlay } from "../../utils/overlays";
 import { registerIf } from "../../utils/registers";
 
 const TRACKED_SEA_CREATURES = [
@@ -102,41 +102,17 @@ export function setRadioactiveVials(count, lastOn) {
             return;
         }
         
-        if (typeof count !== 'number' || count < 0 || !Number.isInteger(count)) {
-            ChatLib.chat(`${GOLD}[FeeshNotifier] ${RED}Please specify correct Radioactive Vials count.`);
+        const errorMessage = initDropCountOnOverlay(persistentData.crimsonIsle.radioactiveVials, count, lastOn);
+        if (errorMessage) {
+            ChatLib.chat(errorMessage);
             return;
-        }
-        persistentData.crimsonIsle.radioactiveVials.count = count;
-
-        if (lastOn) {
-            if (!isIsoDate(lastOn)) {
-                ChatLib.chat(`${GOLD}[FeeshNotifier] ${RED}Please specify correct Last On UTC date in format YYYY-MM-DDThh:mm:ssZ, e.g. 2024-03-18T14:05:00Z`);
-                return;
-            }
-
-            const dropsHistory = (persistentData.crimsonIsle.radioactiveVials.dropsHistory || []);
-            const dateIso = new Date(lastOn);
-            if (dropsHistory.length) {
-                dropsHistory[0].time = dateIso;
-            } else {
-                dropsHistory.unshift({
-                    time: dateIso,
-                });
-            }
         }
 
         persistentData.save();
-
-        ChatLib.chat(`${GOLD}[FeeshNotifier] ${GRAY}Successfully changed Radioactive Vials count to ${count} for the Crimson Isle tracker.`);   
+        ChatLib.chat(`${GOLD}[FeeshNotifier] ${GRAY}Successfully changed Radioactive Vials count to ${count} for the Crimson Isle tracker.`);
     } catch (e) {
         console.error(e);
 		console.log(`[FeeshNotifier] Failed to set Radioactive Vials.`);
-    }
-
-    function isIsoDate(dateString) {
-        if (!/\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z/.test(dateString)) return false;
-        const d = new Date(dateString); 
-        return d instanceof Date && !isNaN(d.getTime());
     }
 }
 

--- a/features/overlays/waterHotspotsAndBayouTracker.js
+++ b/features/overlays/waterHotspotsAndBayouTracker.js
@@ -7,7 +7,7 @@ import { BOLD, GOLD, LIGHT_PURPLE, RED, WHITE, GRAY, AQUA } from "../../constant
 import { getLastFishingHookInHotspotSeenAt, getLastFishingHookSeenAt, getWorldName, isInSkyblock } from "../../utils/playerState";
 import { getCatchesCounterChatMessage, getDropCatchesCounterChatMessage } from "../../utils/common";
 import { BACKWATER_BAYOU, WATER_HOTSPOT_WORLDS } from "../../constants/areas";
-import { createButtonsDisplay, toggleButtonsDisplay, setSeaCreatureStatisticsOnCatch, setDropStatisticsOnCatch, setDropStatisticsOnDrop, getSeaCreatureStatisticsOverlayText, getDropStatisticsOverlayText } from "../../utils/overlays";
+import { createButtonsDisplay, toggleButtonsDisplay, setSeaCreatureStatisticsOnCatch, setDropStatisticsOnCatch, setDropStatisticsOnDrop, getSeaCreatureStatisticsOverlayText, getDropStatisticsOverlayText, initDropCountOnOverlay } from "../../utils/overlays";
 import { registerIf } from "../../utils/registers";
 
 const TRACKED_SEA_CREATURES = [
@@ -85,6 +85,46 @@ export function resetWaterHotspotsAndBayouTracker(isConfirmed) {
 		console.error(e);
 		console.log(`[FeeshNotifier] [WaterHotspotsAndBayouTracker] Failed to reset Water Hotspots & Bayou tracker.`);
 	}
+}
+
+export function setTitanoboaSheds(count, lastOn) {
+    try {
+        if (!isInSkyblock()) {
+            return;
+        }
+        
+        const errorMessage = initDropCountOnOverlay(persistentData.waterHotspotsAndBayou.titanoboaSheds, count, lastOn);
+        if (errorMessage) {
+            ChatLib.chat(errorMessage);
+            return;
+        }
+
+        persistentData.save();
+        ChatLib.chat(`${GOLD}[FeeshNotifier] ${GRAY}Successfully changed Titanoboa Sheds count to ${count} for the Water Hotspots & Bayou tracker.`);   
+    } catch (e) {
+        console.error(e);
+		console.log(`[FeeshNotifier] Failed to set Titanoboa Sheds.`);
+    }
+}
+
+export function setTikiMasks(count, lastOn) {
+    try {
+        if (!isInSkyblock()) {
+            return;
+        }
+        
+        const errorMessage = initDropCountOnOverlay(persistentData.waterHotspotsAndBayou.tikiMasks, count, lastOn);
+        if (errorMessage) {
+            ChatLib.chat(errorMessage);
+            return;
+        }
+
+        persistentData.save();
+        ChatLib.chat(`${GOLD}[FeeshNotifier] ${GRAY}Successfully changed Tiki Masks count to ${count} for the Water Hotspots & Bayou tracker.`);   
+    } catch (e) {
+        console.error(e);
+		console.log(`[FeeshNotifier] Failed to set Tiki Masks.`);
+    }
 }
 
 function getDefaultSeaCreatureSectionObject() {

--- a/settings.js
+++ b/settings.js
@@ -1209,17 +1209,17 @@ Do ${AQUA}/feeshResetCrimsonIsle${GRAY} to reset.`,
     category: "Overlays",
     configName: "getRadioactiveVialsSetupHelp",
     title: "Set Radioactive Vials count",
-    description: "Explains how to setup Radioactive Vials count and last drop date.",
+    description: "Explains in your chat how to setup Radioactive Vials count and last drop date.",
     subcategory: "Crimson Isle tracker",
     onClick() {
         ChatLib.chat(`
 ${LIGHT_PURPLE}${BOLD}Radioactive Vials setup
 
-Do ${AQUA}/feeshSetRadioactiveVials <COUNT> <LAST_ON_UTC_DATE>${RESET} to initialize your vials history:
+Do ${AQUA}/feeshSetTrackerDrops RADIOACTIVE_VIAL <COUNT> <LAST_ON_DATE>${RESET} to initialize your drops history:
   - <COUNT> is a mandatory number of vials.
-  - <LAST_ON_UTC_DATE> is optional and, if provided, should be in YYYY-MM-DDThh:mm:ssZ format (UTC).
+  - <LAST_ON_DATE> is optional and, if provided, should be in YYYY-MM-DD hh:mm:ss format. Can not be in future!
 
-Example: ${AQUA}/feeshSetRadioactiveVials 5 2024-03-18T14:05:00Z`);
+Example: ${AQUA}/feeshSetTrackerDrops RADIOACTIVE_VIAL 5 2025-05-30 23:59:00`);
     }
 })
 .addSwitch({
@@ -1259,6 +1259,24 @@ Shows an overlay with Titanoboa (when fishing in hotspot) and Wiki Tiki (when in
 Do ${AQUA}/feeshResetWaterHotspotsAndBayou${GRAY} to reset.`,
     subcategory: "Water hotspots & Bayou tracker",
     value: true
+})
+.addButton({
+    category: "Overlays",
+    configName: "getTitanoboaShedAndTikiMaskSetupHelp",
+    title: "Set Titanoboa Sheds / Tiki Masks count",
+    description: "Explains in your chat how to setup Titanoboa Sheds / Tiki Masks count and last drop date.",
+    subcategory: "Water hotspots & Bayou tracker",
+    onClick() {
+        ChatLib.chat(`
+${LIGHT_PURPLE}${BOLD}Titanoboa Sheds / Tiki Masks setup
+
+Do ${AQUA}/feeshSetTrackerDrops TITANOBOA_SHED|TIKI_MASK <COUNT> <LAST_ON_DATE>${RESET} to initialize your drops history:
+  - <COUNT> is a mandatory number of drops.
+  - <LAST_ON_DATE> is optional and, if provided, should be in YYYY-MM-DD hh:mm:ss format. Can not be in future!
+
+Example 1: ${AQUA}/feeshSetTrackerDrops TITANOBOA_SHED 5 2025-05-30 23:59:00
+Example 2: ${AQUA}/feeshSetTrackerDrops TIKI_MASK 5 2025-05-30 23:59:00`);
+    }
 })
 .addSwitch({
     category: "Overlays",

--- a/settings.js
+++ b/settings.js
@@ -1215,8 +1215,9 @@ Do ${AQUA}/feeshResetCrimsonIsle${GRAY} to reset.`,
         ChatLib.chat(`
 ${LIGHT_PURPLE}${BOLD}Radioactive Vials setup
 
-Do ${AQUA}/feeshSetTrackerDrops RADIOACTIVE_VIAL <COUNT> <LAST_ON_DATE>${RESET} to initialize your drops history:
-  - <COUNT> is a mandatory number of vials.
+Do ${AQUA}/feeshSetTrackerDrops <ITEM_ID> <COUNT> <LAST_ON_DATE>${RESET} to initialize your drops history:
+  - <ITEM_ID> is a mandatory item ID - RADIOACTIVE_VIAL.
+  - <COUNT> is a mandatory number of times you've dropped it.
   - <LAST_ON_DATE> is optional and, if provided, should be in YYYY-MM-DD hh:mm:ss format. Can not be in future!
 
 Example: ${AQUA}/feeshSetTrackerDrops RADIOACTIVE_VIAL 5 2025-05-30 23:59:00`);
@@ -1270,8 +1271,9 @@ Do ${AQUA}/feeshResetWaterHotspotsAndBayou${GRAY} to reset.`,
         ChatLib.chat(`
 ${LIGHT_PURPLE}${BOLD}Titanoboa Sheds / Tiki Masks setup
 
-Do ${AQUA}/feeshSetTrackerDrops TITANOBOA_SHED|TIKI_MASK <COUNT> <LAST_ON_DATE>${RESET} to initialize your drops history:
-  - <COUNT> is a mandatory number of drops.
+Do ${AQUA}/feeshSetTrackerDrops <ITEM_ID> <COUNT> <LAST_ON_DATE>${RESET} to initialize your drops history:
+  - <ITEM_ID> is a mandatory item ID - TITANOBOA_SHED or TIKI_MASK.
+  - <COUNT> is a mandatory number of times you've dropped it.
   - <LAST_ON_DATE> is optional and, if provided, should be in YYYY-MM-DD hh:mm:ss format. Can not be in future!
 
 Example 1: ${AQUA}/feeshSetTrackerDrops TITANOBOA_SHED 5 2025-05-30 23:59:00


### PR DESCRIPTION
Added reusable command /feeshSetTrackerDrops
- It's used to initialize Titanoboa Sheds and Tiki Masks.
- Also, now it's used to initialize Radioactive Vials in the Crimson Isle Tracker, to have the same pattern everywhere.