### PR TITLE
Release 1.44.0

### DIFF
--- a/commands.js
+++ b/commands.js
@@ -14,7 +14,7 @@ import { resetAbandonedQuarryTracker } from "./features/overlays/abandonedQuarry
 import { resetSeaCreaturesPerHourTracker } from "./features/overlays/seaCreaturesPerHourTracker";
 import { resetArchfiendDiceProfitTracker } from "./features/overlays/archfiendDiceProfitTracker";
 import { SESSION_VIEW_MODE, TOTAL_VIEW_MODE } from "./constants/viewModes";
-import { resetWaterHotspotsAndBayouTracker } from "./features/overlays/waterHotspotsAndBayouTracker";
+import { resetWaterHotspotsAndBayouTracker, setTikiMasks, setTitanoboaSheds } from "./features/overlays/waterHotspotsAndBayouTracker";
 
 register("command", (...args) => {
     settings.getConfig().openGui();
@@ -78,11 +78,21 @@ register("command", (...args) => {
     }
 }).setName("feeshResetProfitTracker");
 
-register("command", (...args) => {
-    const count = args[0];
-    const lastOn = args[1];
-    setRadioactiveVials(+count, lastOn);
-}).setName("feeshSetRadioactiveVials");
+register("command", (dropId, count, ...dateParts) => {
+    const lastOn = dateParts.join(' ');
+
+    switch (dropId) {
+        case 'RADIOACTIVE_VIAL':
+            setRadioactiveVials(+count, lastOn);
+            break;
+        case 'TITANOBOA_SHED':
+            setTitanoboaSheds(+count, lastOn);
+            break;
+        case 'TIKI_MASK':
+            setTikiMasks(+count, lastOn);
+            break;
+    }
+}).setName("feeshSetTrackerDrops");
 
 register("command", (...args) => {
     calculateFishingPetPrices();

--- a/commands.js
+++ b/commands.js
@@ -14,6 +14,7 @@ import { resetAbandonedQuarryTracker } from "./features/overlays/abandonedQuarry
 import { resetSeaCreaturesPerHourTracker } from "./features/overlays/seaCreaturesPerHourTracker";
 import { resetArchfiendDiceProfitTracker } from "./features/overlays/archfiendDiceProfitTracker";
 import { SESSION_VIEW_MODE, TOTAL_VIEW_MODE } from "./constants/viewModes";
+import { resetWaterHotspotsAndBayouTracker } from "./features/overlays/waterHotspotsAndBayouTracker";
 
 register("command", (...args) => {
     settings.getConfig().openGui();
@@ -38,6 +39,11 @@ register("command", (...args) => {
     const isConfirmed = args[0] && args[0] === "noconfirm";
     resetJerryWorkshopTracker(!!isConfirmed);
 }).setName("feeshResetJerryWorkshop");
+
+register("command", (...args) => {
+    const isConfirmed = args[0] && args[0] === "noconfirm";
+    resetWaterHotspotsAndBayouTracker(!!isConfirmed);
+}).setName("feeshResetWaterHotspotsAndBayou");
 
 register("command", (...args) => {
     const isConfirmed = args[0] && args[0] === "noconfirm";

--- a/constants/areas.js
+++ b/constants/areas.js
@@ -16,6 +16,7 @@ export const DUNGEON_HUB = 'Dungeon Hub';
 export const THE_END = 'The End';
 export const GLACITE_MINESHAFTS = 'Glacite Mineshafts';
 export const RIFT = 'Rift Dimension';
+export const PLHLEGBLAST_POOL = 'Plhlegblast Pool';
 
 export const WATER_HOTSPOT_WORLDS = [
     BACKWATER_BAYOU,

--- a/constants/triggers.js
+++ b/constants/triggers.js
@@ -948,7 +948,7 @@ export const KILLED_BY_TRIGGERS = [
     },
 ];
 
-// All mobs that can spawn on Crimson Isle except Thunder / Lord Jawbus
+// All sea creatures that can spawn on Crimson Isle except creatures tracked by Crimson Isle tracker
 export const REGULAR_CRIMSON_CATCH_TRIGGERS = [
     {
         trigger: MAGMA_SLUG_MESSAGE
@@ -972,19 +972,10 @@ export const REGULAR_CRIMSON_CATCH_TRIGGERS = [
         trigger: TAURUS_MESSAGE
     },
     {
-        trigger: PLHLEGBLAST_MESSAGE
-    },
-    {
-        trigger: RAGNAROK_MESSAGE
-    },
-    {
         trigger: FRIED_CHICKEN_MESSAGE
     },
     {
         trigger: FIREPROOF_WITCH_MESSAGE
-    },
-    {
-        trigger: FIERY_SCUTTLER_MESSAGE
     },
 ];
 

--- a/constants/triggers.js
+++ b/constants/triggers.js
@@ -1064,6 +1064,109 @@ export const REGULAR_JERRY_WORKSHOP_CATCH_TRIGGERS = [
     },
 ];
 
+// All sea creatures that can spawn in Water hotspot / Bayou except Wiki Tiki / Titanoboa
+export const REGULAR_WATER_HOTSPOT_AND_BAYOU_CATCH_TRIGGERS = [
+    {
+        trigger: SQUID_MESSAGE
+    },
+    {
+        trigger: SEA_WALKER_MESSAGE
+    },
+    {
+        trigger: SEA_GUARDIAN_MESSAGE
+    },
+    {
+        trigger: SEA_WITCH_MESSAGE
+    },
+    {
+        trigger: SEA_ARCHER_MESSAGE
+    },
+    {
+        trigger: RIDER_OF_THE_DEEP_MESSAGE
+    },
+    {
+        trigger: CATFISH_MESSAGE
+    },
+    {
+        trigger: SEA_LEECH_MESSAGE
+    },
+    {
+        trigger: GUARDIAN_DEFENDER_MESSAGE
+    },
+    {
+        trigger: DEEP_SEA_PROTECTOR_MESSAGE
+    },
+    {
+        trigger: WATER_HYDRA_MESSAGE
+    },
+    {
+        trigger: SEA_EMPEROR_MESSAGE
+    },
+    {
+        trigger: AGARIMOO_MESSAGE
+    },
+    {
+        trigger: CARROT_KING_MESSAGE
+    },
+    {
+        trigger: NURSE_SHARK_MESSAGE
+    },
+    {
+        trigger: BLUE_SHARK_MESSAGE
+    },
+    {
+        trigger: TIGER_SHARK_MESSAGE
+    },
+    {
+        trigger: GREAT_WHITE_SHARK_MESSAGE
+    },
+    {
+        trigger: WEREWOLF_MESSAGE
+    },
+    {
+        trigger: SCARECROW_MESSAGE
+    },
+    {
+        trigger: NIGHTMARE_MESSAGE
+    },
+    {
+        trigger: PHANTOM_FISHER_MESSAGE
+    },
+    {
+        trigger: GRIM_REAPER_MESSAGE
+    },
+    {
+        trigger: FROG_MAN_MESSAGE,
+    },
+    {
+        trigger: TRASH_GOBBLER_MESSAGE,
+    },
+    {
+        trigger: DUMPSTER_DIVER_MESSAGE,
+    },
+    {
+        trigger: BANSHEE_MESSAGE,
+    },
+    {
+        trigger: SNAPPING_TURTLE_MESSAGE,
+    },
+    {
+        trigger: BAYOU_SLUDGE_MESSAGE,
+    },
+    {
+        trigger: ALLIGATOR_MESSAGE,
+    },
+    {
+        trigger: BLUE_RINGED_OCTOPUS_MESSAGE,
+    },
+    {
+        trigger: WIKI_TIKI_MESSAGE,
+    },
+    {
+        trigger: TITANOBOA_MESSAGE,
+    },
+];
+
 export const WORM_CATCH_TRIGGERS = [
     {
         trigger: FLAMING_WORM_MESSAGE

--- a/constants/triggers.js
+++ b/constants/triggers.js
@@ -96,7 +96,7 @@ export const BAYOU_SLUDGE_MESSAGE = `${RESET}${GREEN}A swampy mass of slime emer
 export const ALLIGATOR_MESSAGE = `${RESET}${GREEN}A long snout breaks the surface of the water. It's an Alligator!${RESET}`;
 export const TITANOBOA_MESSAGE = `${RESET}${GREEN}${RESET}${RED}${BOLD}A massive Titanoboa surfaces. It's body stretches as far as the eye can see.${RESET}`; // &r&a&r&c&lA massive Titanoboa surfaces. It's body stretches as far as the eye can see.&r
 export const BLUE_RINGED_OCTOPUS_MESSAGE = `${RESET}${GREEN}A garish set of tentacles arise. It's a Blue Ringed Octopus!${RESET}`;
-export const WIKI_TIKI_MESSAGE = `${RESET}${RED}${RESET}${RED}${BOLD}The water bubbles and froths. A massive form emerges- you have disturbed the Wiki Tiki! You shall pay the price.${RESET}`;
+export const WIKI_TIKI_MESSAGE = `${RESET}${RED}${RESET}${RED}${BOLD}The water bubbles and froths. A massive form emerges- you have disturbed the Wiki Tiki! You shall pay the price.${RESET}`; // &r&c&r&c&lThe water bubbles and froths. A massive form emerges- you have disturbed the Wiki Tiki! You shall pay the price.&r
 
 // DROPS
 
@@ -1158,12 +1158,6 @@ export const REGULAR_WATER_HOTSPOT_AND_BAYOU_CATCH_TRIGGERS = [
     },
     {
         trigger: BLUE_RINGED_OCTOPUS_MESSAGE,
-    },
-    {
-        trigger: WIKI_TIKI_MESSAGE,
-    },
-    {
-        trigger: TITANOBOA_MESSAGE,
     },
 ];
 

--- a/data/data.js
+++ b/data/data.js
@@ -4,6 +4,24 @@ export const persistentData = new PogObject("FeeshNotifier", {
     "rareCatches": {},
     "totalRareCatches": 0,
     "crimsonIsle": {
+        "fieryScuttler": {
+            "catchesSinceLast": 0,
+            "lastCatchTime": null,
+            "catchesHistory": [],
+            "averageCatches": 0
+        },
+        "ragnarok": {
+            "catchesSinceLast": 0,
+            "lastCatchTime": null,
+            "catchesHistory": [],
+            "averageCatches": 0
+        },
+        "plhlegblast": {
+            "catchesSinceLast": 0,
+            "lastCatchTime": null,
+            "catchesHistory": [],
+            "averageCatches": 0
+        },
         "thunder": {
             "catchesSinceLast": 0,
             "lastCatchTime": null,

--- a/data/data.js
+++ b/data/data.js
@@ -62,6 +62,30 @@ export const persistentData = new PogObject("FeeshNotifier", {
             },
         }
     },
+    "waterHotspotsAndBayou": {
+        "titanoboa": {
+            "catchesSinceLast": 0,
+            "lastCatchTime": null,
+            "catchesHistory": [],
+            "averageCatches": 0
+        },
+        "titanoboaSheds": {
+            "count": 0,
+            "catchesSinceLast": 0,
+            "dropsHistory": []
+        },
+        "wikiTiki": {
+            "catchesSinceLast": 0,
+            "lastCatchTime": null,
+            "catchesHistory": [],
+            "averageCatches": 0
+        },
+        "tikiMasks": {
+            "count": 0,
+            "catchesSinceLast": 0,
+            "dropsHistory": []
+        },
+    },
     "fishingProfit": {
         "profitTrackerItems": {},
         "totalProfit": 0,

--- a/data/overlayCoords.js
+++ b/data/overlayCoords.js
@@ -10,6 +10,7 @@ export const overlayCoordsData = new PogObject("FeeshNotifier", {
     "legionAndBobbingTimeOverlay": { "x": 10, "y": 80, "scale": 1 },
     "crimsonIsleTrackerOverlay": { "x": 10, "y": 200, "scale": 1 },
     "jerryWorkshopTrackerOverlay": { "x": 10, "y": 200, "scale": 1 },
+    "waterHotspotsAndBayouTrackerOverlay": { "x": 10, "y": 200, "scale": 1 },
     "wormProfitTrackerOverlay": { "x": 10, "y": 200, "scale": 1 },
     "magmaCoreProfitTrackerOverlay": { "x": 10, "y": 200, "scale": 1 },
     "abandonedQuarryTrackerOverlay": { "x": 10, "y": 200, "scale": 1 },

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,8 +1,18 @@
 # Releases
 
-## v1.43.0
+## v1.44.0
 
 Released: ???
+
+Features:
+- 
+
+Bugfixes:
+-
+
+## v1.43.0
+
+Released: 2025-05-25
 
 Features:
 - Added custom Fishing Hook timer which extends functionality of default Hypixel's one. Explore /feesh -> Rendering -> Fishing Hook section to enable and customize.

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -5,6 +5,8 @@
 Released: ???
 
 Features:
+- Added Water hotspots & Bayou tracker. It shows an overlay with Titanoboa (when fishing in hotspot) and Wiki Tiki (when in Backwater Bayou) catch statistics. Also has Titanoboa Shed and Tiki Mask drop statistics.
+  - TODO: Set drops command
 - Added Fiery Scuttler & Ragnarok (when fishing in hotspot), Plhlegblast (when in Plhlegblast Pool) tracking to Crimson Isle tracker.
 
 Bugfixes:

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -10,7 +10,7 @@ Features:
 - Added Fiery Scuttler & Ragnarok (when fishing in hotspot), Plhlegblast (when in Plhlegblast Pool) tracking to Crimson Isle tracker.
 
 Bugfixes:
--
+- Do not display DH for Reindrakes in Rare Catches tracker.
 
 ## v1.43.0
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -6,8 +6,16 @@ Released: ???
 
 Features:
 - Added Water hotspots & Bayou tracker. It shows an overlay with Titanoboa (when fishing in hotspot) and Wiki Tiki (when in Backwater Bayou) catch statistics. Also has Titanoboa Shed and Tiki Mask drop statistics.
-  - TODO: Set drops command
+  - You can initialize Titanoboa Sheds and Tiki Masks using the command:
+    - /feeshSetTrackerDrops TITANOBOA_SHED <COUNT> <LAST_ON_DATE>
+    - /feeshSetTrackerDrops TIKI_MASK <COUNT> <LAST_ON_DATE>
+    - <COUNT> is a mandatory number of times you've dropped it.
+    - <LAST_ON_DATE> is optional and, if provided, should be in YYYY-MM-DD hh:mm:ss format. Can not be in future!
+    - Example 1: /feeshSetTrackerDrops TITANOBOA_SHED 5 2025-05-30 23:59:00
+    - Example 2: /feeshSetTrackerDrops TIKI_MASK 5 2025-05-30 23:59:00
 - Added Fiery Scuttler & Ragnarok (when fishing in hotspot), Plhlegblast (when in Plhlegblast Pool) tracking to Crimson Isle tracker.
+- Changed command to initialize Radioactive Vials in the Crimson Isle Tracker, to have the same pattern everywhere:
+  - /feeshSetTrackerDrops RADIOACTIVE_VIAL <COUNT> <LAST_ON_DATE>
 
 Bugfixes:
 - Do not display DH for Reindrakes in Rare Catches tracker.

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -5,7 +5,7 @@
 Released: ???
 
 Features:
-- 
+- Added Fiery Scuttler & Ragnarok (when fishing in hotspot), Plhlegblast (when in Plhlegblast Pool) tracking to Crimson Isle tracker.
 
 Bugfixes:
 -

--- a/docs/Future ideas & requests.md
+++ b/docs/Future ideas & requests.md
@@ -1,72 +1,87 @@
-- Track catches for Ragnarok and Scuttler in crimson isle tracker (when in hotspot).
-- Hotspot search
-- Fishing XP tracker
-- Decrease elapsed time in Fishing Profit Tracker (when user forgot to stop tracker being afk)
-- Offer supercrafting or BZ sell when items like raw fish goes to inventory (sacks are full).
+# Future ideas and player's requests
+
+## Fishing profit tracker
+
+- Option to decrease elapsed time in Fishing Profit Tracker (when user forgot to stop tracker being afk)
 - Track scavenged coins in Fishing Profit Tracker
 - Track Ice Essence drop from mobs in Fishing Profit Tracker
-- Option for Worm profit tracker that calculates the profit with [Gemstone Chamber - the price from Gemstone Mixtures]
-- PogData resets data file on PC crash - consider doing regular backups / research tska library as replacement for PogData
-- Kill time for fishing bosses
-- [Bug] Reset confirmation messages appear for disabled overlays for no reason, for one person.
-- [Bug] Some items are tracked by Fishing Profit Tracker when dropped, but drop was prevented by SB settings (basically it drops and picks up again).
-- [Bug] Fishing Profit Tracker recalculates profits/h too often when in "display buttons" mode.
-- [Bug] Trading with other players adds items to the profit trackers.
 - Calculate pet price in Fishing Profit Tracker as difference between lvl 1 and lvl 100
   - Also, there are requests to track pet level progress in coins
-- Remove double hook reindrake logic because DH is not possible now
-- Rain/Thunder widget
-- Find out price calculation for Kuudra Keys in Fishing Profit Tracker
-- Achievements (ScathaPro / SBO as reference)
-- Party chat commands
-  - something to explore profit tracker
-  - !feeshsincejawbus
-  - !feeshsincethunder
-  - !feeshsinceyeti
-  - !feeshsincereindrake
-  - !feeshsincevial
-  - !feeshvials
-  - !kdr - kills/deaths rate for thunder/jawbus [requires API key and custom backend]
-  - Commands cooldown so people do not spam
-  - /feeshkdr <player> - to check myself or someone privately without sending to the party chat [requires API key and custom backend]
-- Customized sounds
+- Find out price calculation for Kuudra Keys
+- Total and session tracker, or ability to load named session
+- Rewrite way to ignore compacted loot in profit tracker
+- Profit tracker causes lags after a while (memory consumption grows)
+- [Bug] Some items are tracked by Fishing Profit Tracker when dropped, but drop was prevented by SB settings (basically it drops and picks up again).
+- [Bug] Trading with other players adds items to the profit trackers.
+- [Bug] Fishing Profit Tracker recalculates profits/h too often when in "display buttons" mode.
+
+## Party commands
+
+- something to explore profit tracker and rare catches tracker
+- !feeshsincejawbus
+- !feeshsincethunder
+- !feeshsinceyeti
+- !feeshsincereindrake
+- !feeshsincevial
+- !feeshvials
+- !kdr - kills/deaths rate for thunder/jawbus [requires API key and custom backend]
+- Commands cooldown so people do not spam
+- /feeshkdr <player> - to check myself or someone privately without sending to the party chat [requires API key and custom backend]
+
+## Alerts & chat
+
+- Customized sounds for rare catches and rare drops
   - Sounds folder: assets
   - Ability to open folder from settings
   - Ability to test sound from settings
   - Toggle setting to enable customization
-- Render mob immunity flag
-- Highlight / box rare sea creatures (make this not visible through walls)
-- Total and session tracker, or ability to load named session
 - Multiple drops that happen at the same time lead to "You're sending messages too fast" error.
-- Personal cap alert (20 for CH, 5 for Crimson)
-- Expertise widget
-- Skill level tracking above fishing 60
+- Write smarter logic to detect personal cap alert (20 for CH, 5 for Crimson)
+- Do not include baby magma slugs when producing cap alert.
 - Attach Vials drop number to the pchat message
+
+## Worm profit tracker
+
+- Option for Worm profit tracker that calculates the profit with [Gemstone Chamber - the price from Gemstone Mixtures]
+
+## Hotspots
+
+- Hotspot location guesser
+
+## Fishing XP tracker
+
+- Fishing XP tracker
+- Skill level tracking above fishing 60
+
+## Inventory features
+
+- Offer supercrafting or BZ sell when items like raw fish goes to inventory (sacks are full).
+- Refactor all existing features so they consume less FPS
+
+## Baits
+
+- Bait changed alert
+- No bait used alert
+- Track baits cost in Fishing profit tracker
+- [Bug] Bait alert false triggered when opening /fb with fishing rod casted.
+
+## Other
+
+- Bigger custom nametag for fishing bosses
+- Glowing outline / highlight rare sea creatures (make this not visible through walls) - I want to get rid of SH for that, and replicate this feature in module.
+- PogData resets data file on PC crash - consider doing regular backups / research tska library as replacement for PogData
+- Kill time for fishing bosses
+- Remove double hook reindrake logic because DH is not possible now
+- Rain/Thunder widget
 - Track all mobs caught, not only rare
 - Golden fish timer
 "can you add a golden fish timer tracker into this? i only have golden fish diamond left and i like playing other games while just having my bobber in lava, and setting a 15min timer every time is p annoying lmao"
-- Bait changed / Bait missing alert
-"i think a feature that says im out of whale bait / fish bait / carrot bait would be cool to add because sometimes im just watching video and i realise im out of bait after like 30 mins."
-- "I was gonna say maybe add a feature that also keeps track of the cost of fish baits while fishing would be pretty cool"
-  - Probably same for buying rain
 - Thunder spark profit - Amount gained in bottle divided by lbin for the current item
   Hurricane: 400m
   Thunder sparkes gained in session: 1m 
   Profit for session: 80m
 
-Refactoring:
-
-- Do not run registers if feature is disabled.
-- Rewrite way to ignore compacted loot in profit tracker
-- [Faangorn] Profit tracker causes lags after a while (memory consumption grows)
-
-
-
-
-
-
-
-Achievements prototype:
+## Achievements
 
 Unlocked: X/Total (%)
 Sort by: rarity, locked/unlocked

--- a/docs/Future ideas & requests.md
+++ b/docs/Future ideas & requests.md
@@ -1,11 +1,11 @@
 - Track catches for Ragnarok and Scuttler in crimson isle tracker (when in hotspot).
-- Hotspot sharing on keybind
 - Hotspot search
 - Fishing XP tracker
 - Decrease elapsed time in Fishing Profit Tracker (when user forgot to stop tracker being afk)
 - Offer supercrafting or BZ sell when items like raw fish goes to inventory (sacks are full).
 - Track scavenged coins in Fishing Profit Tracker
 - Track Ice Essence drop from mobs in Fishing Profit Tracker
+- Option for Worm profit tracker that calculates the profit with [Gemstone Chamber - the price from Gemstone Mixtures]
 - PogData resets data file on PC crash - consider doing regular backups / research tska library as replacement for PogData
 - Kill time for fishing bosses
 - [Bug] Reset confirmation messages appear for disabled overlays for no reason, for one person.

--- a/docs/Future ideas & requests.md
+++ b/docs/Future ideas & requests.md
@@ -58,6 +58,10 @@
 - Offer supercrafting or BZ sell when items like raw fish goes to inventory (sacks are full).
 - Refactor all existing features so they consume less FPS
 
+## Fishing Hook
+
+- [Bug] Sometimes default Hypixel fishing hook is rendered (when in water)
+
 ## Baits
 
 - Bait changed alert

--- a/features/overlays/crimsonIsleTracker.js
+++ b/features/overlays/crimsonIsleTracker.js
@@ -3,32 +3,50 @@ import * as triggers from '../../constants/triggers';
 import * as seaCreatures from '../../constants/seaCreatures';
 import { persistentData } from "../../data/data";
 import { overlayCoordsData } from "../../data/overlayCoords";
-import { BOLD, GOLD, LIGHT_PURPLE, RED, WHITE, GRAY, DARK_RED, DARK_GRAY, RESET } from "../../constants/formatting";
-import { getLastFishingHookSeenAt, getWorldName, isInSkyblock } from "../../utils/playerState";
-import { formatDate, formatNumberWithSpaces, formatTimeElapsedBetweenDates, isDoubleHook } from "../../utils/common";
-import { CRIMSON_ISLE } from "../../constants/areas";
+import { BOLD, GOLD, LIGHT_PURPLE, RED, WHITE, GRAY, DARK_GRAY, RESET, AQUA } from "../../constants/formatting";
+import { getLastFishingHookInHotspotSeenAt, getLastFishingHookSeenAt, getWorldName, getZoneName, isInSkyblock } from "../../utils/playerState";
+import { formatDate, formatNumberWithSpaces, formatTimeElapsedBetweenDates, getCatchesCounterChatMessage, isDoubleHook } from "../../utils/common";
+import { CRIMSON_ISLE, PLHLEGBLAST_POOL } from "../../constants/areas";
 import { MEME_SOUND_MODE, NORMAL_SOUND_MODE, SAD_TROMBONE_SOUND_SOURCE } from "../../constants/sounds";
 import { createButtonsDisplay, toggleButtonsDisplay } from "../../utils/overlays";
 import { registerIf } from "../../utils/registers";
 
-triggers.REGULAR_CRIMSON_CATCH_TRIGGERS.forEach(entry => {
+const TRACKED_TRIGGERS = [
+    {
+        seaCreatureInfo: triggers.RARE_CATCH_TRIGGERS.find(entry => entry.seaCreature === seaCreatures.FIERY_SCUTTLER),
+        callback: (seaCreatureInfo) => trackFieryScuttlerCatch(seaCreatureInfo),
+    },
+    {
+        seaCreatureInfo: triggers.RARE_CATCH_TRIGGERS.find(entry => entry.seaCreature === seaCreatures.RAGNAROK),
+        callback: (seaCreatureInfo) => trackRagnarokCatch(seaCreatureInfo),
+    },
+    {
+        seaCreatureInfo: triggers.RARE_CATCH_TRIGGERS.find(entry => entry.seaCreature === seaCreatures.PLHLEGBLAST),
+        callback: (seaCreatureInfo) => trackPlhlegblastCatch(seaCreatureInfo),
+    },
+    {
+        seaCreatureInfo: triggers.RARE_CATCH_TRIGGERS.find(entry => entry.seaCreature === seaCreatures.THUNDER),
+        callback: (seaCreatureInfo) => trackThunderCatch(seaCreatureInfo),
+    },
+    {
+        seaCreatureInfo: triggers.RARE_CATCH_TRIGGERS.find(entry => entry.seaCreature === seaCreatures.LORD_JAWBUS),
+        callback: (seaCreatureInfo) => trackLordJawbusCatch(seaCreatureInfo),
+    }
+];
+
+triggers.REGULAR_CRIMSON_CATCH_TRIGGERS.forEach(seaCreatureInfo => {
     registerIf(
-        register("Chat", (event) => trackRegularSeaCreatureCatch()).setCriteria(entry.trigger).setContains(),
+        register("Chat", (event) => trackRegularSeaCreatureCatch()).setCriteria(seaCreatureInfo.trigger).setContains(),
         () => settings.crimsonIsleTrackerOverlay && isInSkyblock() && getWorldName() === CRIMSON_ISLE
     );
 });
 
-const thunderTrigger = triggers.RARE_CATCH_TRIGGERS.find(entry => entry.seaCreature === seaCreatures.THUNDER);
-registerIf(
-    register("Chat", (event) => trackThunderCatch()).setCriteria(thunderTrigger.trigger).setContains(),
-    () => settings.crimsonIsleTrackerOverlay && isInSkyblock() && getWorldName() === CRIMSON_ISLE
-);
-
-const lordJawbusTrigger = triggers.RARE_CATCH_TRIGGERS.find(entry => entry.seaCreature === seaCreatures.LORD_JAWBUS);
-registerIf(
-    register("Chat", (event) => trackLordJawbusCatch()).setCriteria(lordJawbusTrigger.trigger).setContains(),
-    () => settings.crimsonIsleTrackerOverlay && isInSkyblock() && getWorldName() === CRIMSON_ISLE
-);
+TRACKED_TRIGGERS.forEach(entry => {
+    registerIf(
+        register("Chat", (event) => entry.callback(entry.seaCreatureInfo)).setCriteria(entry.seaCreatureInfo.trigger).setContains(),
+        () => settings.crimsonIsleTrackerOverlay && isInSkyblock() && getWorldName() === CRIMSON_ISLE
+    );
+});
 
 const radioactiveVialTrigger = triggers.RARE_DROP_TRIGGERS.find(entry => entry.trigger === triggers.RADIOACTIVE_VIAL_MESSAGE);
 registerIf(
@@ -43,10 +61,16 @@ registerIf(
 
 register("gameUnload", () => {
     if (settings.crimsonIsleTrackerOverlay && settings.resetCrimsonIsleTrackerOnGameClosed && persistentData.crimsonIsle && (
-        persistentData.crimsonIsle.thunder.lastCatchTime ||
-        persistentData.crimsonIsle.lordJawbus.lastCatchTime ||
-        persistentData.crimsonIsle.thunder.catchesSinceLast ||
-        persistentData.crimsonIsle.lordJawbus.catchesSinceLast ||
+        persistentData.crimsonIsle.fieryScuttler?.lastCatchTime ||
+        persistentData.crimsonIsle.fieryScuttler?.catchesSinceLast ||
+        persistentData.crimsonIsle.ragnarok?.lastCatchTime ||
+        persistentData.crimsonIsle.ragnarok?.catchesSinceLast ||
+        persistentData.crimsonIsle.plhlegblast?.lastCatchTime ||
+        persistentData.crimsonIsle.plhlegblast?.catchesSinceLast ||
+        persistentData.crimsonIsle.thunder?.lastCatchTime ||
+        persistentData.crimsonIsle.thunder?.catchesSinceLast ||
+        persistentData.crimsonIsle.lordJawbus?.lastCatchTime ||
+        persistentData.crimsonIsle.lordJawbus?.catchesSinceLast ||
         persistentData.crimsonIsle.radioactiveVials.count
     )) {
         resetCrimsonIsleTracker(true);
@@ -66,11 +90,7 @@ export function resetCrimsonIsleTracker(isConfirmed) {
             return;
         }
     
-        persistentData.crimsonIsle = {
-            thunder: { catchesSinceLast: 0, lastCatchTime: null, catchesHistory: [], averageCatches: 0 },
-            lordJawbus: { catchesSinceLast: 0, lastCatchTime: null, catchesHistory: [], averageCatches: 0 },
-            radioactiveVials: { count: 0, lordJawbusCatchesSinceLast: 0, dropsHistory: [] }
-        };
+        persistentData.crimsonIsle = getDefaultObject();
         persistentData.save();
 
         ChatLib.chat(`${GOLD}[FeeshNotifier] ${WHITE}Crimson Isle tracker was reset.`);    
@@ -124,15 +144,174 @@ export function setRadioactiveVials(count, lastOn) {
     }
 }
 
-function trackThunderCatch() {
+function initMissingPersistentData() { // Init data added later and missing for users with previous version
+    if (!persistentData.crimsonIsle) return;
+    if (!persistentData.crimsonIsle.fieryScuttler) persistentData.crimsonIsle.fieryScuttler = getDefaultSeaCreatureSectionObject();
+    if (!persistentData.crimsonIsle.ragnarok) persistentData.crimsonIsle.ragnarok = getDefaultSeaCreatureSectionObject();
+    if (!persistentData.crimsonIsle.plhlegblast) persistentData.crimsonIsle.plhlegblast = getDefaultSeaCreatureSectionObject();
+}
+
+function getDefaultSeaCreatureSectionObject() {
+    return { catchesSinceLast: 0, lastCatchTime: null, catchesHistory: [], averageCatches: 0 };
+}
+
+function getDefaultObject() {
+    return {
+        fieryScuttler: getDefaultSeaCreatureSectionObject(),
+        ragnarok: getDefaultSeaCreatureSectionObject(),
+        plhlegblast: getDefaultSeaCreatureSectionObject(),
+        thunder: getDefaultSeaCreatureSectionObject(),
+        lordJawbus: getDefaultSeaCreatureSectionObject(),
+        radioactiveVials: { count: 0, lordJawbusCatchesSinceLast: 0, dropsHistory: [] }
+    };
+}
+
+function isFishingInHotspot() {
+    const lastFishingHookInHotspotSeenAt = getLastFishingHookInHotspotSeenAt();
+    return lastFishingHookInHotspotSeenAt && new Date() - lastFishingHookInHotspotSeenAt <= 60 * 1000;
+}
+
+function isInPlhlegblastPool() {
+    const zoneName = getZoneName();
+    return zoneName === PLHLEGBLAST_POOL;
+}
+
+function trackFieryScuttlerCatch(seaCreatureInfo) {
     try {
         if (!isInSkyblock() || getWorldName() !== CRIMSON_ISLE || !settings.crimsonIsleTrackerOverlay) {
             return;
         }
 
-        const catchesSinceLast = persistentData.crimsonIsle.thunder.catchesSinceLast;
-        const lastCatchTime = persistentData.crimsonIsle.thunder.lastCatchTime;
-        const elapsedTime = lastCatchTime ? ` ${GRAY}(${WHITE}${formatTimeElapsedBetweenDates(new Date(lastCatchTime))}${GRAY})` : '';
+        initMissingPersistentData();
+
+        const catchesSinceLast = persistentData.crimsonIsle.fieryScuttler.catchesSinceLast + 1;
+        const lastCatchTime = persistentData.crimsonIsle.fieryScuttler.lastCatchTime;
+
+        let catchesHistory = persistentData.crimsonIsle.fieryScuttler.catchesHistory || [];
+        catchesHistory.unshift(catchesSinceLast); // Most recent counts at the start of array
+        catchesHistory.length = Math.min(catchesHistory.length, 100); // Store last 100
+        persistentData.crimsonIsle.fieryScuttler.catchesHistory = catchesHistory;
+
+        const sumCatches = catchesHistory.reduce(function(a, b) { return a + b; }, 0);
+        persistentData.crimsonIsle.fieryScuttler.averageCatches = catchesHistory.length ? Math.round(sumCatches / catchesHistory.length) : 0;
+
+        persistentData.crimsonIsle.fieryScuttler.catchesSinceLast = 0;
+        persistentData.crimsonIsle.fieryScuttler.lastCatchTime = new Date();
+
+        persistentData.crimsonIsle.thunder.catchesSinceLast += 1;
+        persistentData.crimsonIsle.lordJawbus.catchesSinceLast += 1;
+
+        if (isFishingInHotspot()) {
+            persistentData.crimsonIsle.ragnarok.catchesSinceLast += 1;
+        }
+
+        if (isInPlhlegblastPool()) {
+            persistentData.crimsonIsle.plhlegblast.catchesSinceLast += 1;
+        }
+
+        persistentData.save();
+
+        const message = getCatchesCounterChatMessage(seaCreatureInfo.seaCreature, seaCreatureInfo.rarityColorCode, catchesSinceLast, lastCatchTime);
+        ChatLib.chat(message);
+    } catch (e) {
+		console.error(e);
+		console.log(`[FeeshNotifier] Failed to track Fiery Scuttler catch.`);
+	}
+}
+
+function trackRagnarokCatch(seaCreatureInfo) {
+    try {
+        if (!isInSkyblock() || getWorldName() !== CRIMSON_ISLE || !settings.crimsonIsleTrackerOverlay) {
+            return;
+        }
+
+        initMissingPersistentData();
+
+        const catchesSinceLast = persistentData.crimsonIsle.ragnarok.catchesSinceLast + 1;
+        const lastCatchTime = persistentData.crimsonIsle.ragnarok.lastCatchTime;
+
+        let catchesHistory = persistentData.crimsonIsle.ragnarok.catchesHistory || [];
+        catchesHistory.unshift(catchesSinceLast); // Most recent counts at the start of array
+        catchesHistory.length = Math.min(catchesHistory.length, 100); // Store last 100
+        persistentData.crimsonIsle.ragnarok.catchesHistory = catchesHistory;
+
+        const sumCatches = catchesHistory.reduce(function(a, b) { return a + b; }, 0);
+        persistentData.crimsonIsle.ragnarok.averageCatches = catchesHistory.length ? Math.round(sumCatches / catchesHistory.length) : 0;
+
+        persistentData.crimsonIsle.ragnarok.catchesSinceLast = 0;
+        persistentData.crimsonIsle.ragnarok.lastCatchTime = new Date();
+
+        persistentData.crimsonIsle.thunder.catchesSinceLast += 1;
+        persistentData.crimsonIsle.lordJawbus.catchesSinceLast += 1;
+
+        if (isFishingInHotspot()) {
+            persistentData.crimsonIsle.fieryScuttler.catchesSinceLast += 1;
+        }
+
+        if (isInPlhlegblastPool()) {
+            persistentData.crimsonIsle.plhlegblast.catchesSinceLast += 1;
+        }
+
+        persistentData.save();
+
+        const message = getCatchesCounterChatMessage(seaCreatureInfo.seaCreature, seaCreatureInfo.rarityColorCode, catchesSinceLast, lastCatchTime);
+        ChatLib.chat(message);
+    } catch (e) {
+		console.error(e);
+		console.log(`[FeeshNotifier] Failed to track Ragnarok catch.`);
+	}
+}
+
+function trackPlhlegblastCatch(seaCreatureInfo) {
+    try {
+        if (!isInSkyblock() || getWorldName() !== CRIMSON_ISLE || !settings.crimsonIsleTrackerOverlay) {
+            return;
+        }
+
+        initMissingPersistentData();
+
+        const catchesSinceLast = persistentData.crimsonIsle.plhlegblast.catchesSinceLast + 1;
+        const lastCatchTime = persistentData.crimsonIsle.plhlegblast.lastCatchTime;
+
+        let catchesHistory = persistentData.crimsonIsle.plhlegblast.catchesHistory || [];
+        catchesHistory.unshift(catchesSinceLast); // Most recent counts at the start of array
+        catchesHistory.length = Math.min(catchesHistory.length, 100); // Store last 100
+        persistentData.crimsonIsle.plhlegblast.catchesHistory = catchesHistory;
+
+        const sumCatches = catchesHistory.reduce(function(a, b) { return a + b; }, 0);
+        persistentData.crimsonIsle.plhlegblast.averageCatches = catchesHistory.length ? Math.round(sumCatches / catchesHistory.length) : 0;
+
+        persistentData.crimsonIsle.plhlegblast.catchesSinceLast = 0;
+        persistentData.crimsonIsle.plhlegblast.lastCatchTime = new Date();
+
+        persistentData.crimsonIsle.thunder.catchesSinceLast += 1;
+        persistentData.crimsonIsle.lordJawbus.catchesSinceLast += 1;
+
+        if (isFishingInHotspot()) {
+            persistentData.crimsonIsle.fieryScuttler.catchesSinceLast += 1;
+            persistentData.crimsonIsle.ragnarok.catchesSinceLast += 1;
+        }
+
+        persistentData.save();
+
+        const message = getCatchesCounterChatMessage(seaCreatureInfo.seaCreature, seaCreatureInfo.rarityColorCode, catchesSinceLast, lastCatchTime);
+        ChatLib.chat(message);
+    } catch (e) {
+		console.error(e);
+		console.log(`[FeeshNotifier] Failed to track Plhlegblast catch.`);
+	}
+}
+
+function trackThunderCatch(seaCreatureInfo) {
+    try {
+        if (!isInSkyblock() || getWorldName() !== CRIMSON_ISLE || !settings.crimsonIsleTrackerOverlay) {
+            return;
+        }
+
+        initMissingPersistentData();
+
+        const catchesSinceLast = persistentData.crimsonIsle.thunder.catchesSinceLast + 1;
+        const lastCatchTime = persistentData.crimsonIsle.thunder.lastCatchTime || null;
 
         let catchesHistory = persistentData.crimsonIsle.thunder.catchesHistory || [];
         catchesHistory.unshift(catchesSinceLast); // Most recent counts at the start of array
@@ -147,26 +326,35 @@ function trackThunderCatch() {
 
         persistentData.crimsonIsle.lordJawbus.catchesSinceLast += 1;
 
+        if (isFishingInHotspot()) {
+            persistentData.crimsonIsle.fieryScuttler.catchesSinceLast += 1;
+            persistentData.crimsonIsle.ragnarok.catchesSinceLast += 1;    
+        }
+
+        if (isInPlhlegblastPool()) {
+            persistentData.crimsonIsle.plhlegblast.catchesSinceLast += 1;
+        }
+
         persistentData.save();
 
-        ChatLib.chat(`${GOLD}[FeeshNotifier] ${GRAY}It took ${WHITE}${catchesSinceLast} ${GRAY}${catchesSinceLast === 1 ? 'catch' : 'catches'}${elapsedTime} to get the ${LIGHT_PURPLE}Thunder${GRAY}.`);
+        const message = getCatchesCounterChatMessage(seaCreatureInfo.seaCreature, seaCreatureInfo.rarityColorCode, catchesSinceLast, lastCatchTime);
+        ChatLib.chat(message);
     } catch (e) {
 		console.error(e);
 		console.log(`[FeeshNotifier] Failed to track Thunder catch.`);
 	}
 }
 
-function trackLordJawbusCatch() {
+function trackLordJawbusCatch(seaCreatureInfo) {
     try {
         if (!isInSkyblock() || getWorldName() !== CRIMSON_ISLE || !settings.crimsonIsleTrackerOverlay) {
             return;
         }
 
-        const isDoubleHooked = isDoubleHook();
+        initMissingPersistentData();
 
-        const catchesSinceLast = persistentData.crimsonIsle.lordJawbus.catchesSinceLast;
+        const catchesSinceLast = persistentData.crimsonIsle.lordJawbus.catchesSinceLast + 1;
         const lastCatchTime = persistentData.crimsonIsle.lordJawbus.lastCatchTime;
-        const elapsedTime = lastCatchTime ? ` ${GRAY}(${WHITE}${formatTimeElapsedBetweenDates(new Date(lastCatchTime))}${GRAY})` : '';
 
         let catchesHistory = persistentData.crimsonIsle.lordJawbus.catchesHistory || [];
         catchesHistory.unshift(catchesSinceLast); // Most recent counts at the start of array
@@ -181,6 +369,16 @@ function trackLordJawbusCatch() {
 
         persistentData.crimsonIsle.thunder.catchesSinceLast += 1;
 
+        if (isFishingInHotspot()) {
+            persistentData.crimsonIsle.fieryScuttler.catchesSinceLast += 1;
+            persistentData.crimsonIsle.ragnarok.catchesSinceLast += 1;    
+        }
+
+        if (isInPlhlegblastPool()) {
+            persistentData.crimsonIsle.plhlegblast.catchesSinceLast += 1;
+        }
+
+        const isDoubleHooked = isDoubleHook();
         const valueToAdd = isDoubleHooked ? 2 : 1;
         let lordJawbusCatchesSinceLast = persistentData.crimsonIsle.radioactiveVials.lordJawbusCatchesSinceLast || 0;
         lordJawbusCatchesSinceLast += valueToAdd;
@@ -188,7 +386,8 @@ function trackLordJawbusCatch() {
 
         persistentData.save();
 
-        ChatLib.chat(`${GOLD}[FeeshNotifier] ${GRAY}It took ${WHITE}${catchesSinceLast} ${GRAY}${catchesSinceLast === 1 ? 'catch' : 'catches'}${elapsedTime} to get the ${LIGHT_PURPLE}Lord Jawbus${GRAY}.`);
+        const message = getCatchesCounterChatMessage(seaCreatureInfo.seaCreature, seaCreatureInfo.rarityColorCode, catchesSinceLast, lastCatchTime);
+        ChatLib.chat(message);
     } catch (e) {
 		console.error(e);
 		console.log(`[FeeshNotifier] Failed to track Lord Jawbus catch.`);
@@ -201,12 +400,23 @@ function trackRegularSeaCreatureCatch() {
             return;
         }
 
+        initMissingPersistentData();
+
         persistentData.crimsonIsle.thunder.catchesSinceLast += 1;
         persistentData.crimsonIsle.lordJawbus.catchesSinceLast += 1;
+
+        if (isFishingInHotspot()) {
+            persistentData.crimsonIsle.fieryScuttler.catchesSinceLast += 1;
+            persistentData.crimsonIsle.ragnarok.catchesSinceLast += 1;    
+        }
+
+        if (isInPlhlegblastPool()) {
+            persistentData.crimsonIsle.plhlegblast.catchesSinceLast += 1;
+        }
+
         persistentData.save();
 
-        if (persistentData.crimsonIsle.lordJawbus.catchesSinceLast &&
-            persistentData.crimsonIsle.lordJawbus.catchesSinceLast % 1000 === 0) {
+        if (persistentData.crimsonIsle.lordJawbus.catchesSinceLast && persistentData.crimsonIsle.lordJawbus.catchesSinceLast % 1000 === 0) {
             Client.showTitle('', `${RED}No ${LIGHT_PURPLE}Lord Jawbus ${RED}for ${persistentData.crimsonIsle.lordJawbus.catchesSinceLast} catches`, 1, 45, 1);
             ChatLib.chat(`${GOLD}[FeeshNotifier] ${RED}${BOLD}Yikes! ${RESET}${RED}No ${LIGHT_PURPLE}Lord Jawbus ${RED}for ${persistentData.crimsonIsle.lordJawbus.catchesSinceLast} catches...`);
 
@@ -261,10 +471,16 @@ function renderCrimsonIsleTrackerOverlay() {
     if (!settings.crimsonIsleTrackerOverlay ||
         !persistentData.crimsonIsle ||
         (
-            !persistentData.crimsonIsle.thunder.lastCatchTime &&
-            !persistentData.crimsonIsle.lordJawbus.lastCatchTime &&
-            !persistentData.crimsonIsle.thunder.catchesSinceLast &&
-            !persistentData.crimsonIsle.lordJawbus.catchesSinceLast &&
+            !persistentData.crimsonIsle.fieryScuttler?.lastCatchTime &&
+            !persistentData.crimsonIsle.fieryScuttler?.catchesSinceLast &&
+            !persistentData.crimsonIsle.ragnarok?.lastCatchTime &&
+            !persistentData.crimsonIsle.ragnarok?.catchesSinceLast &&
+            !persistentData.crimsonIsle.plhlegblast?.lastCatchTime &&
+            !persistentData.crimsonIsle.plhlegblast?.catchesSinceLast &&
+            !persistentData.crimsonIsle.thunder?.lastCatchTime &&
+            !persistentData.crimsonIsle.thunder?.catchesSinceLast &&
+            !persistentData.crimsonIsle.lordJawbus?.lastCatchTime &&
+            !persistentData.crimsonIsle.lordJawbus?.catchesSinceLast &&
             !persistentData.crimsonIsle.radioactiveVials.count
         ) ||
         !isInSkyblock() ||
@@ -276,24 +492,18 @@ function renderCrimsonIsleTrackerOverlay() {
         return;
     }
 
-    const lastCatchTimeThunder = persistentData.crimsonIsle.thunder.lastCatchTime
-        ? `${WHITE}${formatTimeElapsedBetweenDates(new Date(persistentData.crimsonIsle.thunder.lastCatchTime))} ${GRAY}(${WHITE}${formatDate(new Date(persistentData.crimsonIsle.thunder.lastCatchTime))}${GRAY})` 
-        : `${WHITE}N/A`;
-    const lastCatchTimeLordJawbus = persistentData.crimsonIsle.lordJawbus.lastCatchTime 
-        ? `${WHITE}${formatTimeElapsedBetweenDates(new Date(persistentData.crimsonIsle.lordJawbus.lastCatchTime))} ${GRAY}(${WHITE}${formatDate(new Date(persistentData.crimsonIsle.lordJawbus.lastCatchTime))}${GRAY})` 
-        : `${WHITE}N/A`;
-    const averageThunder = formatNumberWithSpaces(persistentData.crimsonIsle.thunder.averageCatches) || 'N/A';
-    const averageLordJawbus = formatNumberWithSpaces(persistentData.crimsonIsle.lordJawbus.averageCatches) || 'N/A';
+    let overlayText = `${AQUA}${BOLD}Crimson Isle tracker\n`;
+    overlayText += getFieryScuttlerOverlayText();
+    overlayText += getRagnarokOverlayText();
+    overlayText += getPlhlegblastOverlayText();
+    overlayText += getThunderOverlayText();
+    overlayText += getLordJawbusOverlayText();
+
     const lastTimeVial = persistentData.crimsonIsle.radioactiveVials.dropsHistory.length
         ? `${WHITE}${formatTimeElapsedBetweenDates(new Date(persistentData.crimsonIsle.radioactiveVials.dropsHistory[0].time))} ${GRAY}(${WHITE}${formatDate(new Date(persistentData.crimsonIsle.radioactiveVials.dropsHistory[0].time))}${GRAY})` 
         : `${WHITE}N/A`;
     const lordJawbusCatchesSinceLastVial = persistentData.crimsonIsle.radioactiveVials.lordJawbusCatchesSinceLast || 0;
 
-    let overlayText = `${DARK_RED}${BOLD}Crimson Isle tracker\n`;
-    overlayText += `${LIGHT_PURPLE}Thunder: ${WHITE}${formatNumberWithSpaces(persistentData.crimsonIsle.thunder.catchesSinceLast)} ${GRAY}${persistentData.crimsonIsle.thunder.catchesSinceLast !== 1 ? 'catches' : 'catch'} ago ${DARK_GRAY}(${GRAY}avg: ${WHITE}${averageThunder}${DARK_GRAY})\n`;
-    overlayText += `${GRAY}Last on: ${lastCatchTimeThunder}\n`;
-    overlayText += `${LIGHT_PURPLE}Lord Jawbus: ${WHITE}${formatNumberWithSpaces(persistentData.crimsonIsle.lordJawbus.catchesSinceLast)} ${GRAY}${persistentData.crimsonIsle.lordJawbus.catchesSinceLast !== 1 ? 'catches' : 'catch'} ago ${DARK_GRAY}(${GRAY}avg: ${WHITE}${averageLordJawbus}${DARK_GRAY})\n`;
-    overlayText += `${GRAY}Last on: ${lastCatchTimeLordJawbus}\n`;
     overlayText += `${LIGHT_PURPLE}Radioactive Vials: ${WHITE}${formatNumberWithSpaces(persistentData.crimsonIsle.radioactiveVials.count)}\n`;
     overlayText += `${GRAY}Last on: ${lastTimeVial}\n`;
     overlayText += `${GRAY}Last on: ${WHITE}${formatNumberWithSpaces(lordJawbusCatchesSinceLastVial)} ${GRAY}${lordJawbusCatchesSinceLastVial !== 1 ? 'Jawbuses' : 'Jawbus'} ago`;
@@ -304,4 +514,75 @@ function renderCrimsonIsleTrackerOverlay() {
     overlay.draw();
 
     toggleButtonsDisplay(buttonsDisplay, overlay, overlayCoordsData.crimsonIsleTrackerOverlay);
+
+    function getFieryScuttlerOverlayText() {
+        if (!isFishingInHotspot()) return '';
+
+        let overlayText = '';
+        const obj = persistentData.crimsonIsle.fieryScuttler;
+        overlayText += `${GOLD}Fiery Scuttler: ${getCatchesSinceLastOverlayText(obj)} ${getAverageCatchesOverlayText(obj)}\n`;
+        overlayText += `${getLastCatchTimeOverlayText(obj)}\n`;
+
+        return overlayText;
+    }
+
+    function getRagnarokOverlayText() {
+        if (!isFishingInHotspot()) return '';
+
+        let overlayText = '';
+        const obj = persistentData.crimsonIsle.ragnarok;
+        overlayText += `${LIGHT_PURPLE}Ragnarok: ${getCatchesSinceLastOverlayText(obj)} ${getAverageCatchesOverlayText(obj)}\n`;
+        overlayText += `${getLastCatchTimeOverlayText(obj)}\n`;
+
+        return overlayText;
+    }
+
+    function getPlhlegblastOverlayText() {
+        if (!isInPlhlegblastPool()) return '';
+
+        let overlayText = '';
+        const obj = persistentData.crimsonIsle.plhlegblast;
+        overlayText += `${LIGHT_PURPLE}Plhlegblast: ${getCatchesSinceLastOverlayText(obj)} ${getAverageCatchesOverlayText(obj)}\n`;
+        overlayText += `${getLastCatchTimeOverlayText(obj)}\n`;
+
+        return overlayText;
+    }
+
+    function getThunderOverlayText() {
+        let overlayText = '';
+        const obj = persistentData.crimsonIsle.thunder;
+        overlayText += `${LIGHT_PURPLE}Thunder: ${getCatchesSinceLastOverlayText(obj)} ${getAverageCatchesOverlayText(obj)}\n`;
+        overlayText += `${getLastCatchTimeOverlayText(obj)}\n`;
+
+        return overlayText;
+    }
+
+    function getLordJawbusOverlayText() {
+        let overlayText = '';
+        const obj = persistentData.crimsonIsle.lordJawbus;
+        overlayText += `${LIGHT_PURPLE}Lord Jawbus: ${getCatchesSinceLastOverlayText(obj)} ${getAverageCatchesOverlayText(obj)}\n`;
+        overlayText += `${getLastCatchTimeOverlayText(obj)}\n`;
+
+        return overlayText;
+    }
+
+    function getCatchesSinceLastOverlayText(obj) {
+        const catchesSinceLast = `${WHITE}${formatNumberWithSpaces(obj?.catchesSinceLast || 0)}`;
+        const text = `${catchesSinceLast} ${GRAY}${obj?.catchesSinceLast !== 1 ? 'catches' : 'catch'} ago`;
+        return text;
+    }
+
+    function getAverageCatchesOverlayText(obj) {
+        const average = formatNumberWithSpaces(obj?.averageCatches) || 'N/A';
+        const text = `${DARK_GRAY}(${GRAY}avg: ${WHITE}${average}${DARK_GRAY})`;
+        return text;
+    }
+
+    function getLastCatchTimeOverlayText(obj) {
+        const lastCatchTime = obj?.lastCatchTime
+            ? `${WHITE}${formatTimeElapsedBetweenDates(new Date(obj.lastCatchTime))} ${GRAY}(${WHITE}${formatDate(new Date(obj.lastCatchTime))}${GRAY})` 
+            : `${WHITE}N/A`;
+        const text = `${GRAY}Last on: ${lastCatchTime}`;
+        return text;
+    }
 }

--- a/features/overlays/crimsonIsleTracker.js
+++ b/features/overlays/crimsonIsleTracker.js
@@ -8,7 +8,7 @@ import { getLastFishingHookInHotspotSeenAt, getLastFishingHookSeenAt, getWorldNa
 import { getCatchesCounterChatMessage, getDropCatchesCounterChatMessage } from "../../utils/common";
 import { CRIMSON_ISLE, PLHLEGBLAST_POOL } from "../../constants/areas";
 import { MEME_SOUND_MODE, NORMAL_SOUND_MODE, SAD_TROMBONE_SOUND_SOURCE } from "../../constants/sounds";
-import { createButtonsDisplay, toggleButtonsDisplay, setSeaCreatureStatisticsOnCatch, getSeaCreatureStatisticsOverlayText, getDropStatisticsOverlayText, setDropStatisticsOnCatch, setDropStatisticsOnDrop } from "../../utils/overlays";
+import { createButtonsDisplay, toggleButtonsDisplay, setSeaCreatureStatisticsOnCatch, getSeaCreatureStatisticsOverlayText, getDropStatisticsOverlayText, setDropStatisticsOnCatch, setDropStatisticsOnDrop, initDropCountOnOverlay } from "../../utils/overlays";
 import { registerIf } from "../../utils/registers";
 
 const TRACKED_SEA_CREATURES = [
@@ -102,41 +102,17 @@ export function setRadioactiveVials(count, lastOn) {
             return;
         }
         
-        if (typeof count !== 'number' || count < 0 || !Number.isInteger(count)) {
-            ChatLib.chat(`${GOLD}[FeeshNotifier] ${RED}Please specify correct Radioactive Vials count.`);
+        const errorMessage = initDropCountOnOverlay(persistentData.crimsonIsle.radioactiveVials, count, lastOn);
+        if (errorMessage) {
+            ChatLib.chat(errorMessage);
             return;
-        }
-        persistentData.crimsonIsle.radioactiveVials.count = count;
-
-        if (lastOn) {
-            if (!isIsoDate(lastOn)) {
-                ChatLib.chat(`${GOLD}[FeeshNotifier] ${RED}Please specify correct Last On UTC date in format YYYY-MM-DDThh:mm:ssZ, e.g. 2024-03-18T14:05:00Z`);
-                return;
-            }
-
-            const dropsHistory = (persistentData.crimsonIsle.radioactiveVials.dropsHistory || []);
-            const dateIso = new Date(lastOn);
-            if (dropsHistory.length) {
-                dropsHistory[0].time = dateIso;
-            } else {
-                dropsHistory.unshift({
-                    time: dateIso,
-                });
-            }
         }
 
         persistentData.save();
-
-        ChatLib.chat(`${GOLD}[FeeshNotifier] ${GRAY}Successfully changed Radioactive Vials count to ${count} for the Crimson Isle tracker.`);   
+        ChatLib.chat(`${GOLD}[FeeshNotifier] ${GRAY}Successfully changed Radioactive Vials count to ${count} for the Crimson Isle tracker.`);
     } catch (e) {
         console.error(e);
 		console.log(`[FeeshNotifier] Failed to set Radioactive Vials.`);
-    }
-
-    function isIsoDate(dateString) {
-        if (!/\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z/.test(dateString)) return false;
-        const d = new Date(dateString); 
-        return d instanceof Date && !isNaN(d.getTime());
     }
 }
 

--- a/features/overlays/crimsonIsleTracker.js
+++ b/features/overlays/crimsonIsleTracker.js
@@ -37,7 +37,7 @@ const TRACKED_SEA_CREATURES = [
 const TRACKED_DROPS = [
     {
         dropInfo: triggers.RARE_DROP_TRIGGERS.find(entry => entry.trigger === triggers.RADIOACTIVE_VIAL_MESSAGE),
-        callback: () => trackRadioctiveVialDrop(),
+        callback: (magicFind) => trackRadioctiveVialDrop(magicFind),
     },
 ];
 
@@ -57,7 +57,7 @@ TRACKED_SEA_CREATURES.forEach(entry => {
 
 TRACKED_DROPS.forEach(entry => {
     registerIf(
-        register("Chat", (magicFind, event) => entry.callback()).setCriteria(entry.dropInfo.trigger).setContains(),
+        register("Chat", (magicFind, event) => entry.callback(magicFind)).setCriteria(entry.dropInfo.trigger).setContains(),
         () => settings.crimsonIsleTrackerOverlay && isInSkyblock() && getWorldName() === CRIMSON_ISLE
     );
 });
@@ -387,13 +387,13 @@ function trackRegularSeaCreatureCatch() {
 	}
 }
 
-function trackRadioctiveVialDrop() {
+function trackRadioctiveVialDrop(magicFind) {
     try {
         if (!settings.crimsonIsleTrackerOverlay || !isInSkyblock() || getWorldName() !== CRIMSON_ISLE) {
             return;
         }
 
-        const result = setDropStatisticsOnDrop(persistentData.crimsonIsle.radioactiveVials, 'lordJawbusCatchesSinceLast', 'lordJawbusCatches');
+        const result = setDropStatisticsOnDrop(persistentData.crimsonIsle.radioactiveVials, 'lordJawbusCatchesSinceLast', 'lordJawbusCatches', magicFind);
         persistentData.save();
 
         const dropNumber = persistentData.crimsonIsle.radioactiveVials.count;

--- a/features/overlays/crimsonIsleTracker.js
+++ b/features/overlays/crimsonIsleTracker.js
@@ -3,15 +3,15 @@ import * as triggers from '../../constants/triggers';
 import * as seaCreatures from '../../constants/seaCreatures';
 import { persistentData } from "../../data/data";
 import { overlayCoordsData } from "../../data/overlayCoords";
-import { BOLD, GOLD, LIGHT_PURPLE, RED, WHITE, GRAY, DARK_GRAY, RESET, AQUA } from "../../constants/formatting";
+import { BOLD, GOLD, LIGHT_PURPLE, RED, WHITE, GRAY, RESET, AQUA } from "../../constants/formatting";
 import { getLastFishingHookInHotspotSeenAt, getLastFishingHookSeenAt, getWorldName, getZoneName, isInSkyblock } from "../../utils/playerState";
-import { formatDate, formatNumberWithSpaces, formatTimeElapsedBetweenDates, getCatchesCounterChatMessage, isDoubleHook } from "../../utils/common";
+import { getCatchesCounterChatMessage, getDropCatchesCounterChatMessage } from "../../utils/common";
 import { CRIMSON_ISLE, PLHLEGBLAST_POOL } from "../../constants/areas";
 import { MEME_SOUND_MODE, NORMAL_SOUND_MODE, SAD_TROMBONE_SOUND_SOURCE } from "../../constants/sounds";
-import { createButtonsDisplay, toggleButtonsDisplay } from "../../utils/overlays";
+import { createButtonsDisplay, toggleButtonsDisplay, setSeaCreatureStatisticsOnCatch, getSeaCreatureStatisticsOverlayText, getDropStatisticsOverlayText, setDropStatisticsOnCatch, setDropStatisticsOnDrop } from "../../utils/overlays";
 import { registerIf } from "../../utils/registers";
 
-const TRACKED_TRIGGERS = [
+const TRACKED_SEA_CREATURES = [
     {
         seaCreatureInfo: triggers.RARE_CATCH_TRIGGERS.find(entry => entry.seaCreature === seaCreatures.FIERY_SCUTTLER),
         callback: (seaCreatureInfo) => trackFieryScuttlerCatch(seaCreatureInfo),
@@ -31,7 +31,14 @@ const TRACKED_TRIGGERS = [
     {
         seaCreatureInfo: triggers.RARE_CATCH_TRIGGERS.find(entry => entry.seaCreature === seaCreatures.LORD_JAWBUS),
         callback: (seaCreatureInfo) => trackLordJawbusCatch(seaCreatureInfo),
-    }
+    },
+];
+
+const TRACKED_DROPS = [
+    {
+        dropInfo: triggers.RARE_DROP_TRIGGERS.find(entry => entry.trigger === triggers.RADIOACTIVE_VIAL_MESSAGE),
+        callback: () => trackRadioctiveVialDrop(),
+    },
 ];
 
 triggers.REGULAR_CRIMSON_CATCH_TRIGGERS.forEach(seaCreatureInfo => {
@@ -41,18 +48,19 @@ triggers.REGULAR_CRIMSON_CATCH_TRIGGERS.forEach(seaCreatureInfo => {
     );
 });
 
-TRACKED_TRIGGERS.forEach(entry => {
+TRACKED_SEA_CREATURES.forEach(entry => {
     registerIf(
         register("Chat", (event) => entry.callback(entry.seaCreatureInfo)).setCriteria(entry.seaCreatureInfo.trigger).setContains(),
         () => settings.crimsonIsleTrackerOverlay && isInSkyblock() && getWorldName() === CRIMSON_ISLE
     );
 });
 
-const radioactiveVialTrigger = triggers.RARE_DROP_TRIGGERS.find(entry => entry.trigger === triggers.RADIOACTIVE_VIAL_MESSAGE);
-registerIf(
-    register("Chat", (magicFind, event) => trackRadioctiveVialDrop()).setCriteria(radioactiveVialTrigger.trigger).setContains(),
-    () => settings.crimsonIsleTrackerOverlay && isInSkyblock() && getWorldName() === CRIMSON_ISLE
-);
+TRACKED_DROPS.forEach(entry => {
+    registerIf(
+        register("Chat", (magicFind, event) => entry.callback()).setCriteria(entry.dropInfo.trigger).setContains(),
+        () => settings.crimsonIsleTrackerOverlay && isInSkyblock() && getWorldName() === CRIMSON_ISLE
+    );
+});
 
 registerIf(
     register('renderOverlay', () => renderCrimsonIsleTrackerOverlay()),
@@ -60,19 +68,7 @@ registerIf(
 );
 
 register("gameUnload", () => {
-    if (settings.crimsonIsleTrackerOverlay && settings.resetCrimsonIsleTrackerOnGameClosed && persistentData.crimsonIsle && (
-        persistentData.crimsonIsle.fieryScuttler?.lastCatchTime ||
-        persistentData.crimsonIsle.fieryScuttler?.catchesSinceLast ||
-        persistentData.crimsonIsle.ragnarok?.lastCatchTime ||
-        persistentData.crimsonIsle.ragnarok?.catchesSinceLast ||
-        persistentData.crimsonIsle.plhlegblast?.lastCatchTime ||
-        persistentData.crimsonIsle.plhlegblast?.catchesSinceLast ||
-        persistentData.crimsonIsle.thunder?.lastCatchTime ||
-        persistentData.crimsonIsle.thunder?.catchesSinceLast ||
-        persistentData.crimsonIsle.lordJawbus?.lastCatchTime ||
-        persistentData.crimsonIsle.lordJawbus?.catchesSinceLast ||
-        persistentData.crimsonIsle.radioactiveVials.count
-    )) {
+    if (settings.crimsonIsleTrackerOverlay && settings.resetCrimsonIsleTrackerOnGameClosed && hasAnyData()) {
         resetCrimsonIsleTracker(true);
     }
 });
@@ -166,14 +162,32 @@ function getDefaultObject() {
     };
 }
 
+function hasAnyData() {
+    return persistentData.crimsonIsle && (
+        persistentData.crimsonIsle.fieryScuttler?.lastCatchTime ||
+        persistentData.crimsonIsle.fieryScuttler?.catchesSinceLast ||
+        persistentData.crimsonIsle.ragnarok?.lastCatchTime ||
+        persistentData.crimsonIsle.ragnarok?.catchesSinceLast ||
+        persistentData.crimsonIsle.plhlegblast?.lastCatchTime ||
+        persistentData.crimsonIsle.plhlegblast?.catchesSinceLast ||
+        persistentData.crimsonIsle.thunder?.lastCatchTime ||
+        persistentData.crimsonIsle.thunder?.catchesSinceLast ||
+        persistentData.crimsonIsle.lordJawbus?.lastCatchTime ||
+        persistentData.crimsonIsle.lordJawbus?.catchesSinceLast ||
+        persistentData.crimsonIsle.radioactiveVials?.count
+    );
+}
+
 function isFishingInHotspot() {
+    if (getWorldName() !== CRIMSON_ISLE) return false;
+
     const lastFishingHookInHotspotSeenAt = getLastFishingHookInHotspotSeenAt();
     return lastFishingHookInHotspotSeenAt && new Date() - lastFishingHookInHotspotSeenAt <= 60 * 1000;
 }
 
 function isInPlhlegblastPool() {
-    const zoneName = getZoneName();
-    return zoneName === PLHLEGBLAST_POOL;
+    if (getWorldName() !== CRIMSON_ISLE) return false;
+    return getZoneName() === PLHLEGBLAST_POOL;
 }
 
 function trackFieryScuttlerCatch(seaCreatureInfo) {
@@ -184,19 +198,7 @@ function trackFieryScuttlerCatch(seaCreatureInfo) {
 
         initMissingPersistentData();
 
-        const catchesSinceLast = persistentData.crimsonIsle.fieryScuttler.catchesSinceLast + 1;
-        const lastCatchTime = persistentData.crimsonIsle.fieryScuttler.lastCatchTime;
-
-        let catchesHistory = persistentData.crimsonIsle.fieryScuttler.catchesHistory || [];
-        catchesHistory.unshift(catchesSinceLast); // Most recent counts at the start of array
-        catchesHistory.length = Math.min(catchesHistory.length, 100); // Store last 100
-        persistentData.crimsonIsle.fieryScuttler.catchesHistory = catchesHistory;
-
-        const sumCatches = catchesHistory.reduce(function(a, b) { return a + b; }, 0);
-        persistentData.crimsonIsle.fieryScuttler.averageCatches = catchesHistory.length ? Math.round(sumCatches / catchesHistory.length) : 0;
-
-        persistentData.crimsonIsle.fieryScuttler.catchesSinceLast = 0;
-        persistentData.crimsonIsle.fieryScuttler.lastCatchTime = new Date();
+        const result = setSeaCreatureStatisticsOnCatch(persistentData.crimsonIsle.fieryScuttler);
 
         persistentData.crimsonIsle.thunder.catchesSinceLast += 1;
         persistentData.crimsonIsle.lordJawbus.catchesSinceLast += 1;
@@ -211,7 +213,7 @@ function trackFieryScuttlerCatch(seaCreatureInfo) {
 
         persistentData.save();
 
-        const message = getCatchesCounterChatMessage(seaCreatureInfo.seaCreature, seaCreatureInfo.rarityColorCode, catchesSinceLast, lastCatchTime);
+        const message = getCatchesCounterChatMessage(seaCreatureInfo.seaCreature, seaCreatureInfo.rarityColorCode, result.catchesSinceLast, result.lastCatchTime);
         ChatLib.chat(message);
     } catch (e) {
 		console.error(e);
@@ -227,19 +229,7 @@ function trackRagnarokCatch(seaCreatureInfo) {
 
         initMissingPersistentData();
 
-        const catchesSinceLast = persistentData.crimsonIsle.ragnarok.catchesSinceLast + 1;
-        const lastCatchTime = persistentData.crimsonIsle.ragnarok.lastCatchTime;
-
-        let catchesHistory = persistentData.crimsonIsle.ragnarok.catchesHistory || [];
-        catchesHistory.unshift(catchesSinceLast); // Most recent counts at the start of array
-        catchesHistory.length = Math.min(catchesHistory.length, 100); // Store last 100
-        persistentData.crimsonIsle.ragnarok.catchesHistory = catchesHistory;
-
-        const sumCatches = catchesHistory.reduce(function(a, b) { return a + b; }, 0);
-        persistentData.crimsonIsle.ragnarok.averageCatches = catchesHistory.length ? Math.round(sumCatches / catchesHistory.length) : 0;
-
-        persistentData.crimsonIsle.ragnarok.catchesSinceLast = 0;
-        persistentData.crimsonIsle.ragnarok.lastCatchTime = new Date();
+        const result = setSeaCreatureStatisticsOnCatch(persistentData.crimsonIsle.ragnarok);
 
         persistentData.crimsonIsle.thunder.catchesSinceLast += 1;
         persistentData.crimsonIsle.lordJawbus.catchesSinceLast += 1;
@@ -254,7 +244,7 @@ function trackRagnarokCatch(seaCreatureInfo) {
 
         persistentData.save();
 
-        const message = getCatchesCounterChatMessage(seaCreatureInfo.seaCreature, seaCreatureInfo.rarityColorCode, catchesSinceLast, lastCatchTime);
+        const message = getCatchesCounterChatMessage(seaCreatureInfo.seaCreature, seaCreatureInfo.rarityColorCode, result.catchesSinceLast, result.lastCatchTime);
         ChatLib.chat(message);
     } catch (e) {
 		console.error(e);
@@ -270,19 +260,7 @@ function trackPlhlegblastCatch(seaCreatureInfo) {
 
         initMissingPersistentData();
 
-        const catchesSinceLast = persistentData.crimsonIsle.plhlegblast.catchesSinceLast + 1;
-        const lastCatchTime = persistentData.crimsonIsle.plhlegblast.lastCatchTime;
-
-        let catchesHistory = persistentData.crimsonIsle.plhlegblast.catchesHistory || [];
-        catchesHistory.unshift(catchesSinceLast); // Most recent counts at the start of array
-        catchesHistory.length = Math.min(catchesHistory.length, 100); // Store last 100
-        persistentData.crimsonIsle.plhlegblast.catchesHistory = catchesHistory;
-
-        const sumCatches = catchesHistory.reduce(function(a, b) { return a + b; }, 0);
-        persistentData.crimsonIsle.plhlegblast.averageCatches = catchesHistory.length ? Math.round(sumCatches / catchesHistory.length) : 0;
-
-        persistentData.crimsonIsle.plhlegblast.catchesSinceLast = 0;
-        persistentData.crimsonIsle.plhlegblast.lastCatchTime = new Date();
+        const result = setSeaCreatureStatisticsOnCatch(persistentData.crimsonIsle.plhlegblast);
 
         persistentData.crimsonIsle.thunder.catchesSinceLast += 1;
         persistentData.crimsonIsle.lordJawbus.catchesSinceLast += 1;
@@ -294,7 +272,7 @@ function trackPlhlegblastCatch(seaCreatureInfo) {
 
         persistentData.save();
 
-        const message = getCatchesCounterChatMessage(seaCreatureInfo.seaCreature, seaCreatureInfo.rarityColorCode, catchesSinceLast, lastCatchTime);
+        const message = getCatchesCounterChatMessage(seaCreatureInfo.seaCreature, seaCreatureInfo.rarityColorCode, result.catchesSinceLast, result.lastCatchTime);
         ChatLib.chat(message);
     } catch (e) {
 		console.error(e);
@@ -310,19 +288,7 @@ function trackThunderCatch(seaCreatureInfo) {
 
         initMissingPersistentData();
 
-        const catchesSinceLast = persistentData.crimsonIsle.thunder.catchesSinceLast + 1;
-        const lastCatchTime = persistentData.crimsonIsle.thunder.lastCatchTime || null;
-
-        let catchesHistory = persistentData.crimsonIsle.thunder.catchesHistory || [];
-        catchesHistory.unshift(catchesSinceLast); // Most recent counts at the start of array
-        catchesHistory.length = Math.min(catchesHistory.length, 100); // Store last 100
-        persistentData.crimsonIsle.thunder.catchesHistory = catchesHistory;
-
-        const sumCatches = catchesHistory.reduce(function(a, b) { return a + b; }, 0);
-        persistentData.crimsonIsle.thunder.averageCatches = catchesHistory.length ? Math.round(sumCatches / catchesHistory.length) : 0;
-
-        persistentData.crimsonIsle.thunder.catchesSinceLast = 0;
-        persistentData.crimsonIsle.thunder.lastCatchTime = new Date();
+        const result = setSeaCreatureStatisticsOnCatch(persistentData.crimsonIsle.thunder);
 
         persistentData.crimsonIsle.lordJawbus.catchesSinceLast += 1;
 
@@ -337,7 +303,7 @@ function trackThunderCatch(seaCreatureInfo) {
 
         persistentData.save();
 
-        const message = getCatchesCounterChatMessage(seaCreatureInfo.seaCreature, seaCreatureInfo.rarityColorCode, catchesSinceLast, lastCatchTime);
+        const message = getCatchesCounterChatMessage(seaCreatureInfo.seaCreature, seaCreatureInfo.rarityColorCode, result.catchesSinceLast, result.lastCatchTime);
         ChatLib.chat(message);
     } catch (e) {
 		console.error(e);
@@ -353,19 +319,8 @@ function trackLordJawbusCatch(seaCreatureInfo) {
 
         initMissingPersistentData();
 
-        const catchesSinceLast = persistentData.crimsonIsle.lordJawbus.catchesSinceLast + 1;
-        const lastCatchTime = persistentData.crimsonIsle.lordJawbus.lastCatchTime;
-
-        let catchesHistory = persistentData.crimsonIsle.lordJawbus.catchesHistory || [];
-        catchesHistory.unshift(catchesSinceLast); // Most recent counts at the start of array
-        catchesHistory.length = Math.min(catchesHistory.length, 100); // Store last 100
-        persistentData.crimsonIsle.lordJawbus.catchesHistory = catchesHistory;
-
-        const sumCatches = catchesHistory.reduce(function(a, b) { return a + b; }, 0);
-        persistentData.crimsonIsle.lordJawbus.averageCatches = catchesHistory.length ? Math.round(sumCatches / catchesHistory.length) : 0;
-
-        persistentData.crimsonIsle.lordJawbus.catchesSinceLast = 0;
-        persistentData.crimsonIsle.lordJawbus.lastCatchTime = new Date();
+        const result = setSeaCreatureStatisticsOnCatch(persistentData.crimsonIsle.lordJawbus);
+        setDropStatisticsOnCatch(persistentData.crimsonIsle.radioactiveVials, 'lordJawbusCatchesSinceLast');
 
         persistentData.crimsonIsle.thunder.catchesSinceLast += 1;
 
@@ -378,15 +333,9 @@ function trackLordJawbusCatch(seaCreatureInfo) {
             persistentData.crimsonIsle.plhlegblast.catchesSinceLast += 1;
         }
 
-        const isDoubleHooked = isDoubleHook();
-        const valueToAdd = isDoubleHooked ? 2 : 1;
-        let lordJawbusCatchesSinceLast = persistentData.crimsonIsle.radioactiveVials.lordJawbusCatchesSinceLast || 0;
-        lordJawbusCatchesSinceLast += valueToAdd;
-        persistentData.crimsonIsle.radioactiveVials.lordJawbusCatchesSinceLast = lordJawbusCatchesSinceLast;
-
         persistentData.save();
 
-        const message = getCatchesCounterChatMessage(seaCreatureInfo.seaCreature, seaCreatureInfo.rarityColorCode, catchesSinceLast, lastCatchTime);
+        const message = getCatchesCounterChatMessage(seaCreatureInfo.seaCreature, seaCreatureInfo.rarityColorCode, result.catchesSinceLast, result.lastCatchTime);
         ChatLib.chat(message);
     } catch (e) {
 		console.error(e);
@@ -416,9 +365,10 @@ function trackRegularSeaCreatureCatch() {
 
         persistentData.save();
 
-        if (persistentData.crimsonIsle.lordJawbus.catchesSinceLast && persistentData.crimsonIsle.lordJawbus.catchesSinceLast % 1000 === 0) {
-            Client.showTitle('', `${RED}No ${LIGHT_PURPLE}Lord Jawbus ${RED}for ${persistentData.crimsonIsle.lordJawbus.catchesSinceLast} catches`, 1, 45, 1);
-            ChatLib.chat(`${GOLD}[FeeshNotifier] ${RED}${BOLD}Yikes! ${RESET}${RED}No ${LIGHT_PURPLE}Lord Jawbus ${RED}for ${persistentData.crimsonIsle.lordJawbus.catchesSinceLast} catches...`);
+        const catchesSinceLast = persistentData.crimsonIsle.lordJawbus.catchesSinceLast;
+        if (catchesSinceLast && catchesSinceLast % 1000 === 0) {
+            Client.showTitle('', `${RED}No ${LIGHT_PURPLE}Lord Jawbus ${RED}for ${catchesSinceLast} catches`, 1, 45, 1);
+            ChatLib.chat(`${GOLD}[FeeshNotifier] ${RED}${BOLD}Yikes! ${RESET}${RED}No ${LIGHT_PURPLE}Lord Jawbus ${RED}for ${catchesSinceLast} catches...`);
 
             switch (settings.soundMode) {
                 case MEME_SOUND_MODE:
@@ -443,24 +393,12 @@ function trackRadioctiveVialDrop() {
             return;
         }
 
-        const lordJawbusCatches = persistentData.crimsonIsle.radioactiveVials.lordJawbusCatchesSinceLast || 0;
-
-        persistentData.crimsonIsle.radioactiveVials.count += 1;
-        persistentData.crimsonIsle.radioactiveVials.lordJawbusCatchesSinceLast = 0;
-
-        let vialDropsHistory = persistentData.crimsonIsle.radioactiveVials.dropsHistory || [];
-        const lastDropTime = vialDropsHistory.length && vialDropsHistory[0].time ? vialDropsHistory[0].time : null;
-        const elapsedTime = lastDropTime ? ` ${GRAY}(${WHITE}${formatTimeElapsedBetweenDates(new Date(lastDropTime))}${GRAY})` : '';
-
-        vialDropsHistory.unshift({
-            time: new Date(),
-            lordJawbusCatches: lordJawbusCatches
-        });
-        persistentData.crimsonIsle.radioactiveVials.dropsHistory = vialDropsHistory;
-
+        const result = setDropStatisticsOnDrop(persistentData.crimsonIsle.radioactiveVials, 'lordJawbusCatchesSinceLast', 'lordJawbusCatches');
         persistentData.save();
 
-        ChatLib.chat(`${GOLD}[FeeshNotifier] ${GRAY}It took ${WHITE}${lordJawbusCatches} ${GRAY}${lordJawbusCatches === 1 ? 'Lord Jawbus catch' : 'Lord Jawbus catches'}${elapsedTime} to get the ${LIGHT_PURPLE}Radioactive Vial ${WHITE}#${persistentData.crimsonIsle.radioactiveVials.count}${GRAY}. Congratulations!`);
+        const dropNumber = persistentData.crimsonIsle.radioactiveVials.count;
+        const message = getDropCatchesCounterChatMessage(`${LIGHT_PURPLE}Radioactive Vial`, 'Lord Jawbus', result.lastDropTime, dropNumber, result.catches);
+        ChatLib.chat(message);
     } catch (e) {
 		console.error(e);
 		console.log(`[FeeshNotifier] Failed to track Radioactive Vial drop.`);
@@ -469,20 +407,7 @@ function trackRadioctiveVialDrop() {
 
 function renderCrimsonIsleTrackerOverlay() {
     if (!settings.crimsonIsleTrackerOverlay ||
-        !persistentData.crimsonIsle ||
-        (
-            !persistentData.crimsonIsle.fieryScuttler?.lastCatchTime &&
-            !persistentData.crimsonIsle.fieryScuttler?.catchesSinceLast &&
-            !persistentData.crimsonIsle.ragnarok?.lastCatchTime &&
-            !persistentData.crimsonIsle.ragnarok?.catchesSinceLast &&
-            !persistentData.crimsonIsle.plhlegblast?.lastCatchTime &&
-            !persistentData.crimsonIsle.plhlegblast?.catchesSinceLast &&
-            !persistentData.crimsonIsle.thunder?.lastCatchTime &&
-            !persistentData.crimsonIsle.thunder?.catchesSinceLast &&
-            !persistentData.crimsonIsle.lordJawbus?.lastCatchTime &&
-            !persistentData.crimsonIsle.lordJawbus?.catchesSinceLast &&
-            !persistentData.crimsonIsle.radioactiveVials.count
-        ) ||
+        !hasAnyData() ||
         !isInSkyblock() ||
         getWorldName() !== CRIMSON_ISLE ||
         (new Date() - getLastFishingHookSeenAt() > 10 * 60 * 1000) ||
@@ -492,21 +417,13 @@ function renderCrimsonIsleTrackerOverlay() {
         return;
     }
 
-    let overlayText = `${AQUA}${BOLD}Crimson Isle tracker\n`;
+    let overlayText = `${AQUA}${BOLD}Crimson Isle tracker`;
     overlayText += getFieryScuttlerOverlayText();
     overlayText += getRagnarokOverlayText();
     overlayText += getPlhlegblastOverlayText();
     overlayText += getThunderOverlayText();
     overlayText += getLordJawbusOverlayText();
-
-    const lastTimeVial = persistentData.crimsonIsle.radioactiveVials.dropsHistory.length
-        ? `${WHITE}${formatTimeElapsedBetweenDates(new Date(persistentData.crimsonIsle.radioactiveVials.dropsHistory[0].time))} ${GRAY}(${WHITE}${formatDate(new Date(persistentData.crimsonIsle.radioactiveVials.dropsHistory[0].time))}${GRAY})` 
-        : `${WHITE}N/A`;
-    const lordJawbusCatchesSinceLastVial = persistentData.crimsonIsle.radioactiveVials.lordJawbusCatchesSinceLast || 0;
-
-    overlayText += `${LIGHT_PURPLE}Radioactive Vials: ${WHITE}${formatNumberWithSpaces(persistentData.crimsonIsle.radioactiveVials.count)}\n`;
-    overlayText += `${GRAY}Last on: ${lastTimeVial}\n`;
-    overlayText += `${GRAY}Last on: ${WHITE}${formatNumberWithSpaces(lordJawbusCatchesSinceLastVial)} ${GRAY}${lordJawbusCatchesSinceLastVial !== 1 ? 'Jawbuses' : 'Jawbus'} ago`;
+    overlayText += getRadioactiveVialsOverlayText();
 
     const overlay = new Text(overlayText, overlayCoordsData.crimsonIsleTrackerOverlay.x, overlayCoordsData.crimsonIsleTrackerOverlay.y)
         .setShadow(true)
@@ -518,71 +435,36 @@ function renderCrimsonIsleTrackerOverlay() {
     function getFieryScuttlerOverlayText() {
         if (!isFishingInHotspot()) return '';
 
-        let overlayText = '';
-        const obj = persistentData.crimsonIsle.fieryScuttler;
-        overlayText += `${GOLD}Fiery Scuttler: ${getCatchesSinceLastOverlayText(obj)} ${getAverageCatchesOverlayText(obj)}\n`;
-        overlayText += `${getLastCatchTimeOverlayText(obj)}\n`;
-
-        return overlayText;
+        const overlayText = getSeaCreatureStatisticsOverlayText(`${GOLD}Fiery Scuttler`, persistentData.crimsonIsle.fieryScuttler);
+        return '\n' + overlayText;
     }
 
     function getRagnarokOverlayText() {
         if (!isFishingInHotspot()) return '';
 
-        let overlayText = '';
-        const obj = persistentData.crimsonIsle.ragnarok;
-        overlayText += `${LIGHT_PURPLE}Ragnarok: ${getCatchesSinceLastOverlayText(obj)} ${getAverageCatchesOverlayText(obj)}\n`;
-        overlayText += `${getLastCatchTimeOverlayText(obj)}\n`;
-
-        return overlayText;
+        const overlayText = getSeaCreatureStatisticsOverlayText(`${LIGHT_PURPLE}Ragnarok`, persistentData.crimsonIsle.ragnarok);
+        return '\n' + overlayText;
     }
 
     function getPlhlegblastOverlayText() {
         if (!isInPlhlegblastPool()) return '';
 
-        let overlayText = '';
-        const obj = persistentData.crimsonIsle.plhlegblast;
-        overlayText += `${LIGHT_PURPLE}Plhlegblast: ${getCatchesSinceLastOverlayText(obj)} ${getAverageCatchesOverlayText(obj)}\n`;
-        overlayText += `${getLastCatchTimeOverlayText(obj)}\n`;
-
-        return overlayText;
+        const overlayText = getSeaCreatureStatisticsOverlayText(`${LIGHT_PURPLE}Plhlegblast`, persistentData.crimsonIsle.plhlegblast);
+        return '\n' + overlayText;
     }
 
     function getThunderOverlayText() {
-        let overlayText = '';
-        const obj = persistentData.crimsonIsle.thunder;
-        overlayText += `${LIGHT_PURPLE}Thunder: ${getCatchesSinceLastOverlayText(obj)} ${getAverageCatchesOverlayText(obj)}\n`;
-        overlayText += `${getLastCatchTimeOverlayText(obj)}\n`;
-
-        return overlayText;
+        const overlayText = getSeaCreatureStatisticsOverlayText(`${LIGHT_PURPLE}Thunder`, persistentData.crimsonIsle.thunder);
+        return '\n' + overlayText;
     }
 
     function getLordJawbusOverlayText() {
-        let overlayText = '';
-        const obj = persistentData.crimsonIsle.lordJawbus;
-        overlayText += `${LIGHT_PURPLE}Lord Jawbus: ${getCatchesSinceLastOverlayText(obj)} ${getAverageCatchesOverlayText(obj)}\n`;
-        overlayText += `${getLastCatchTimeOverlayText(obj)}\n`;
-
-        return overlayText;
+        const overlayText = getSeaCreatureStatisticsOverlayText(`${LIGHT_PURPLE}Lord Jawbus`, persistentData.crimsonIsle.lordJawbus);
+        return '\n' + overlayText;
     }
 
-    function getCatchesSinceLastOverlayText(obj) {
-        const catchesSinceLast = `${WHITE}${formatNumberWithSpaces(obj?.catchesSinceLast || 0)}`;
-        const text = `${catchesSinceLast} ${GRAY}${obj?.catchesSinceLast !== 1 ? 'catches' : 'catch'} ago`;
-        return text;
-    }
-
-    function getAverageCatchesOverlayText(obj) {
-        const average = formatNumberWithSpaces(obj?.averageCatches) || 'N/A';
-        const text = `${DARK_GRAY}(${GRAY}avg: ${WHITE}${average}${DARK_GRAY})`;
-        return text;
-    }
-
-    function getLastCatchTimeOverlayText(obj) {
-        const lastCatchTime = obj?.lastCatchTime
-            ? `${WHITE}${formatTimeElapsedBetweenDates(new Date(obj.lastCatchTime))} ${GRAY}(${WHITE}${formatDate(new Date(obj.lastCatchTime))}${GRAY})` 
-            : `${WHITE}N/A`;
-        const text = `${GRAY}Last on: ${lastCatchTime}`;
-        return text;
+    function getRadioactiveVialsOverlayText() {
+        const overlayText = getDropStatisticsOverlayText(`${LIGHT_PURPLE}Radioactive Vial`, 'Jawbus', persistentData.crimsonIsle.radioactiveVials, 'lordJawbusCatchesSinceLast');
+        return '\n' + overlayText;
     }
 }

--- a/features/overlays/jerryWorkshopTracker.js
+++ b/features/overlays/jerryWorkshopTracker.js
@@ -3,15 +3,37 @@ import * as triggers from '../../constants/triggers';
 import * as seaCreatures from '../../constants/seaCreatures';
 import { persistentData } from "../../data/data";
 import { overlayCoordsData } from "../../data/overlayCoords";
-import { BOLD, GOLD, RED, WHITE, DARK_PURPLE, GRAY, AQUA, DARK_GRAY, LIGHT_PURPLE } from "../../constants/formatting";
+import { BOLD, GOLD, RED, WHITE, DARK_PURPLE, GRAY, AQUA, LIGHT_PURPLE } from "../../constants/formatting";
 import { getLastFishingHookSeenAt, getWorldName, isInSkyblock } from "../../utils/playerState";
-import { formatDate, formatNumberWithSpaces, formatTimeElapsedBetweenDates, getCatchesCounterChatMessage } from "../../utils/common";
+import { formatNumberWithSpaces, getCatchesCounterChatMessage } from "../../utils/common";
 import { JERRY_WORKSHOP } from "../../constants/areas";
-import { createButtonsDisplay, toggleButtonsDisplay } from "../../utils/overlays";
+import { createButtonsDisplay, getSeaCreatureStatisticsOverlayText, setSeaCreatureStatisticsOnCatch, toggleButtonsDisplay } from "../../utils/overlays";
 import { registerIf } from "../../utils/registers";
 
 let remainingWorkshopTime = null;
 let sawWorkshopClosingMessage = false;
+
+const TRACKED_SEA_CREATURES = [
+    {
+        seaCreatureInfo: triggers.RARE_CATCH_TRIGGERS.find(entry => entry.seaCreature === seaCreatures.YETI),
+        callback: (seaCreatureInfo) => trackYetiCatch(seaCreatureInfo),
+    },
+    {
+        seaCreatureInfo: triggers.RARE_CATCH_TRIGGERS.find(entry => entry.seaCreature === seaCreatures.REINDRAKE),
+        callback: (seaCreatureInfo) => trackReindrakeCatch(seaCreatureInfo),
+    },
+];
+
+const TRACKED_DROPS = [
+    {
+        dropInfo: triggers.RARE_DROP_TRIGGERS.find(entry => entry.trigger === triggers.BABY_YETI_PET_EPIC_MESSAGE),
+        callback: () => trackEpicBabyYetiPetDrop(),
+    },
+    {
+        dropInfo: triggers.RARE_DROP_TRIGGERS.find(entry => entry.trigger === triggers.BABY_YETI_PET_LEG_MESSAGE),
+        callback: () => trackLegendaryBabyYetiPetDrop(),
+    },
+];
 
 triggers.REGULAR_JERRY_WORKSHOP_CATCH_TRIGGERS.forEach(entry => {
     registerIf(
@@ -20,29 +42,19 @@ triggers.REGULAR_JERRY_WORKSHOP_CATCH_TRIGGERS.forEach(entry => {
     );
 });
 
-const yetiTrigger = triggers.RARE_CATCH_TRIGGERS.find(entry => entry.seaCreature === seaCreatures.YETI);
-registerIf(
-    register("Chat", (event) => trackYetiCatch(yetiTrigger)).setCriteria(yetiTrigger.trigger).setContains(),
-    () => settings.jerryWorkshopTrackerOverlay && isInSkyblock() && getWorldName() === JERRY_WORKSHOP
-);
+TRACKED_SEA_CREATURES.forEach(entry => {
+    registerIf(
+        register("Chat", (event) => entry.callback(entry.seaCreatureInfo)).setCriteria(entry.seaCreatureInfo.trigger).setContains(),
+        () => settings.jerryWorkshopTrackerOverlay && isInSkyblock() && getWorldName() === JERRY_WORKSHOP
+    );
+});
 
-const reindrakeTrigger = triggers.RARE_CATCH_TRIGGERS.find(entry => entry.seaCreature === seaCreatures.REINDRAKE);
-registerIf(
-    register("Chat", (event) => trackReindrakeCatch(reindrakeTrigger)).setCriteria(reindrakeTrigger.trigger).setContains(),
-    () => settings.jerryWorkshopTrackerOverlay && isInSkyblock() && getWorldName() === JERRY_WORKSHOP
-);
-
-const babyYetiPetEpicTrigger = triggers.RARE_DROP_TRIGGERS.find(entry => entry.trigger === triggers.BABY_YETI_PET_EPIC_MESSAGE);
-registerIf(
-    register("Chat", (magicFind, event) => trackEpicBabyYetiPetDrop()).setCriteria(babyYetiPetEpicTrigger.trigger).setContains(),
-    () => settings.jerryWorkshopTrackerOverlay && isInSkyblock() && getWorldName() === JERRY_WORKSHOP
-);
-
-const babyYetiPetLegendaryTrigger = triggers.RARE_DROP_TRIGGERS.find(entry => entry.trigger === triggers.BABY_YETI_PET_LEG_MESSAGE);
-registerIf(
-    register("Chat", (magicFind, event) => trackLegendaryBabyYetiPetDrop()).setCriteria(babyYetiPetLegendaryTrigger.trigger).setContains(),
-    () => settings.jerryWorkshopTrackerOverlay && isInSkyblock() && getWorldName() === JERRY_WORKSHOP
-);
+TRACKED_DROPS.forEach(entry => {
+    registerIf(
+        register("Chat", (magicFind, event) => entry.callback()).setCriteria(entry.dropInfo.trigger).setContains(),
+        () => settings.jerryWorkshopTrackerOverlay && isInSkyblock() && getWorldName() === JERRY_WORKSHOP
+    );
+});
 
 registerIf(
     register("Chat", (event) => { sawWorkshopClosingMessage = true; }).setCriteria(triggers.WORKSHOP_CLOSING_MESSAGE).setContains(),
@@ -66,14 +78,7 @@ register("worldUnload", () => {
 });
 
 register("gameUnload", () => {
-    if (settings.jerryWorkshopTrackerOverlay && settings.resetJerryWorkshopTrackerOnGameClosed && persistentData.jerryWorkshop && (
-        persistentData.jerryWorkshop.yeti.lastCatchTime ||
-        persistentData.jerryWorkshop.reindrake.lastCatchTime ||
-        persistentData.jerryWorkshop.yeti.catchesSinceLast ||
-        persistentData.jerryWorkshop.reindrake.catchesSinceLast ||
-        persistentData.jerryWorkshop.babyYetiPets.epic.count ||
-        persistentData.jerryWorkshop.babyYetiPets.legendary.count
-    )) {
+    if (settings.jerryWorkshopTrackerOverlay && settings.resetJerryWorkshopTrackerOnGameClosed && hasAnyData()) {
         resetJerryWorkshopTracker(true);
     }
 });
@@ -91,11 +96,7 @@ export function resetJerryWorkshopTracker(isConfirmed) {
             return;
         }
     
-        persistentData.jerryWorkshop = {
-            yeti: { catchesSinceLast: 0, lastCatchTime: null, catchesHistory: [], averageCatches: 0 },
-            reindrake: { catchesSinceLast: 0, lastCatchTime: null, catchesHistory: [], averageCatches: 0 },
-            babyYetiPets: { epic: { count: 0 }, legendary: { count: 0 } }
-        };
+        persistentData.jerryWorkshop = getDefaultObject();
         persistentData.save();
 
         ChatLib.chat(`${GOLD}[FeeshNotifier] ${WHITE}Jerry workshop tracker was reset.`);    
@@ -105,31 +106,41 @@ export function resetJerryWorkshopTracker(isConfirmed) {
 	}
 }
 
+function getDefaultSeaCreatureSectionObject() {
+    return { catchesSinceLast: 0, lastCatchTime: null, catchesHistory: [], averageCatches: 0 };
+}
+
+function getDefaultObject() {
+    return {
+        yeti: getDefaultSeaCreatureSectionObject(),
+        reindrake: getDefaultSeaCreatureSectionObject(),
+        babyYetiPets: { epic: { count: 0 }, legendary: { count: 0 } }
+    };
+}
+
+function hasAnyData() {
+    return persistentData.jerryWorkshop && (
+        persistentData.jerryWorkshop.yeti.lastCatchTime ||
+        persistentData.jerryWorkshop.yeti.catchesSinceLast ||
+        persistentData.jerryWorkshop.reindrake.lastCatchTime ||
+        persistentData.jerryWorkshop.reindrake.catchesSinceLast ||
+        persistentData.jerryWorkshop.babyYetiPets.epic.count ||
+        persistentData.jerryWorkshop.babyYetiPets.legendary.count
+    );
+}
+
 function trackYetiCatch(seaCreatureInfo) {
     try {
         if (!settings.jerryWorkshopTrackerOverlay || !isInSkyblock() || getWorldName() !== JERRY_WORKSHOP) {
             return;
         }
 
-        const catchesSinceLast = persistentData.jerryWorkshop.yeti.catchesSinceLast + 1;
-        const lastCatchTime = persistentData.jerryWorkshop.yeti.lastCatchTime;
-
-        let catchesHistory = persistentData.jerryWorkshop.yeti.catchesHistory || [];
-        catchesHistory.unshift(catchesSinceLast); // Most recent counts at the start of array
-        catchesHistory.length = Math.min(catchesHistory.length, 100); // Store last 100
-        persistentData.jerryWorkshop.yeti.catchesHistory = catchesHistory;
-
-        const sumCatches = catchesHistory.reduce(function(a, b) { return a + b; }, 0);
-        persistentData.jerryWorkshop.yeti.averageCatches = catchesHistory.length ? Math.round(sumCatches / catchesHistory.length) : 0;
-
-        persistentData.jerryWorkshop.yeti.catchesSinceLast = 0;
-        persistentData.jerryWorkshop.yeti.lastCatchTime = new Date();
-
+        const result = setSeaCreatureStatisticsOnCatch(persistentData.jerryWorkshop.yeti);
         persistentData.jerryWorkshop.reindrake.catchesSinceLast += 1;
 
         persistentData.save();
 
-        const message = getCatchesCounterChatMessage(seaCreatureInfo.seaCreature, seaCreatureInfo.rarityColorCode, catchesSinceLast, lastCatchTime);
+        const message = getCatchesCounterChatMessage(seaCreatureInfo.seaCreature, seaCreatureInfo.rarityColorCode, result.catchesSinceLast, result.lastCatchTime);
         ChatLib.chat(message);
     } catch (e) {
 		console.error(e);
@@ -143,25 +154,12 @@ function trackReindrakeCatch(seaCreatureInfo) {
             return;
         }
 
-        const catchesSinceLast = persistentData.jerryWorkshop.reindrake.catchesSinceLast + 1;
-        const lastCatchTime = persistentData.jerryWorkshop.reindrake.lastCatchTime;
-
-        let catchesHistory = persistentData.jerryWorkshop.reindrake.catchesHistory || [];
-        catchesHistory.unshift(catchesSinceLast); // Most recent counts at the start of array
-        catchesHistory.length = Math.min(catchesHistory.length, 100); // Store last 100
-        persistentData.jerryWorkshop.reindrake.catchesHistory = catchesHistory;
-
-        const sumCatches = catchesHistory.reduce(function(a, b) { return a + b; }, 0);
-        persistentData.jerryWorkshop.reindrake.averageCatches = catchesHistory.length ? Math.round(sumCatches / catchesHistory.length) : 0;
-
-        persistentData.jerryWorkshop.reindrake.catchesSinceLast = 0;
-        persistentData.jerryWorkshop.reindrake.lastCatchTime = new Date();
-
+        const result = setSeaCreatureStatisticsOnCatch(persistentData.jerryWorkshop.reindrake);
         persistentData.jerryWorkshop.yeti.catchesSinceLast += 1;
 
         persistentData.save();
 
-        const message = getCatchesCounterChatMessage(seaCreatureInfo.seaCreature, seaCreatureInfo.rarityColorCode, catchesSinceLast, lastCatchTime);
+        const message = getCatchesCounterChatMessage(seaCreatureInfo.seaCreature, seaCreatureInfo.rarityColorCode, result.catchesSinceLast, result.lastCatchTime);
         ChatLib.chat(message);
     } catch (e) {
 		console.error(e);
@@ -237,15 +235,7 @@ function trackRemainingWorkshopTime() {
 
 function renderJerryWorkshopOverlay() {
     if (!settings.jerryWorkshopTrackerOverlay ||
-        !persistentData.jerryWorkshop ||
-        (
-            !persistentData.jerryWorkshop.yeti.lastCatchTime &&
-            !persistentData.jerryWorkshop.reindrake.lastCatchTime &&
-            !persistentData.jerryWorkshop.yeti.catchesSinceLast &&
-            !persistentData.jerryWorkshop.reindrake.catchesSinceLast &&
-            !persistentData.jerryWorkshop.babyYetiPets.epic.count &&
-            !persistentData.jerryWorkshop.babyYetiPets.legendary.count
-        ) ||
+        !hasAnyData() ||
         !isInSkyblock() ||
         getWorldName() !== JERRY_WORKSHOP ||
         (new Date() - getLastFishingHookSeenAt() > 10 * 60 * 1000) ||
@@ -255,21 +245,10 @@ function renderJerryWorkshopOverlay() {
         return;
     }
 
-    const lastCatchTimeYeti = persistentData.jerryWorkshop.yeti.lastCatchTime
-        ? `${WHITE}${formatTimeElapsedBetweenDates(new Date(persistentData.jerryWorkshop.yeti.lastCatchTime))} ${GRAY}(${WHITE}${formatDate(new Date(persistentData.jerryWorkshop.yeti.lastCatchTime))}${GRAY})` 
-        : `${WHITE}N/A`;
-    const lastCatchTimeReindrake = persistentData.jerryWorkshop.reindrake.lastCatchTime 
-        ? `${WHITE}${formatTimeElapsedBetweenDates(new Date(persistentData.jerryWorkshop.reindrake.lastCatchTime))} ${GRAY}(${WHITE}${formatDate(new Date(persistentData.jerryWorkshop.reindrake.lastCatchTime))}${GRAY})` 
-        : `${WHITE}N/A`;
-    const averageYeti = formatNumberWithSpaces(persistentData.jerryWorkshop.yeti.averageCatches) || 'N/A';
-    const averageReindrake = formatNumberWithSpaces(persistentData.jerryWorkshop.reindrake.averageCatches) || 'N/A';
-
     let overlayText = `${AQUA}${BOLD}Jerry Workshop tracker`;
-    overlayText += `\n${GOLD}Yeti: ${WHITE}${formatNumberWithSpaces(persistentData.jerryWorkshop.yeti.catchesSinceLast)} ${GRAY}${persistentData.jerryWorkshop.yeti.catchesSinceLast !== 1 ? 'catches' : 'catch'} ago ${DARK_GRAY}(${GRAY}avg: ${WHITE}${averageYeti}${DARK_GRAY})`;
-    overlayText += `\n${GRAY}Last on: ${lastCatchTimeYeti}`;
+    overlayText += getYetiOverlayText();
     overlayText += `\n${GRAY}Baby Yeti pets: ${GOLD}${formatNumberWithSpaces(persistentData.jerryWorkshop.babyYetiPets.legendary.count)} ${DARK_PURPLE}${formatNumberWithSpaces(persistentData.jerryWorkshop.babyYetiPets.epic.count)}`;
-    overlayText += `\n${LIGHT_PURPLE}Reindrake: ${WHITE}${formatNumberWithSpaces(persistentData.jerryWorkshop.reindrake.catchesSinceLast)} ${GRAY}${persistentData.jerryWorkshop.reindrake.catchesSinceLast !== 1 ? 'catches' : 'catch'} ago ${DARK_GRAY}(${GRAY}avg: ${WHITE}${averageReindrake}${DARK_GRAY})`;
-    overlayText += `\n${GRAY}Last on: ${lastCatchTimeReindrake}`;
+    overlayText += getReindrakeOverlayText();
 
     if (remainingWorkshopTime) {
         overlayText += `\n\n${GRAY}Closes in: ${remainingWorkshopTime}`;
@@ -281,4 +260,14 @@ function renderJerryWorkshopOverlay() {
     overlay.draw();
 
     toggleButtonsDisplay(buttonsDisplay, overlay, overlayCoordsData.jerryWorkshopTrackerOverlay);
+
+    function getYetiOverlayText() {
+        const overlayText = getSeaCreatureStatisticsOverlayText(`${GOLD}Yeti`, persistentData.jerryWorkshop.yeti);
+        return '\n' + overlayText;
+    }
+
+    function getReindrakeOverlayText() {
+        const overlayText = getSeaCreatureStatisticsOverlayText(`${LIGHT_PURPLE}Reindrake`, persistentData.jerryWorkshop.reindrake);
+        return '\n' + overlayText;
+    }
 }

--- a/features/overlays/rareCatchesTracker.js
+++ b/features/overlays/rareCatchesTracker.js
@@ -136,7 +136,7 @@ function renderRareCatchTrackerOverlay() {
     entries.forEach((entry) => {
         const trigger = RARE_CATCH_TRIGGERS.find(t => t.seaCreature === entry.seaCreature);
         const rarityColorCode = trigger.rarityColorCode || WHITE;
-        const doubleHookInfo = trigger.seaCreature === seaCreatures.VANQUISHER
+        const doubleHookInfo = trigger.seaCreature === seaCreatures.VANQUISHER || trigger.seaCreature === seaCreatures.REINDRAKE
             ? ''
             : ` ${GRAY}| DH: ${WHITE}${formatNumberWithSpaces(entry.doubleHookAmount)} ${GRAY}(${entry.doubleHookPercent}${GRAY}%)`;
         overlayText += `${GRAY}- ${rarityColorCode}${fromUppercaseToCapitalizedFirstLetters(entry.seaCreature)}${GRAY}: ${WHITE}${formatNumberWithSpaces(entry.amount)}${doubleHookInfo}\n`;

--- a/features/overlays/waterHotspotsAndBayouTracker.js
+++ b/features/overlays/waterHotspotsAndBayouTracker.js
@@ -24,11 +24,11 @@ const TRACKED_SEA_CREATURES = [
 const TRACKED_DROPS = [
     {
         dropInfo: triggers.RARE_DROP_TRIGGERS.find(entry => entry.trigger === triggers.TITANOBOA_SHED_MESSAGE),
-        callback: () => trackTitanoboaShedDrop(),
+        callback: (magicFind) => trackTitanoboaShedDrop(magicFind),
     },
     {
         dropInfo: triggers.RARE_DROP_TRIGGERS.find(entry => entry.trigger === triggers.TIKI_MASK_MESSAGE),
-        callback: () => trackTikiMaskDrop(),
+        callback: (magicFind) => trackTikiMaskDrop(magicFind),
     },
 ];
 
@@ -48,7 +48,7 @@ TRACKED_SEA_CREATURES.forEach(entry => {
 
 TRACKED_DROPS.forEach(entry => {
     registerIf(
-        register("Chat", (magicFind, event) => entry.callback()).setCriteria(entry.dropInfo.trigger).setContains(),
+        register("Chat", (magicFind, event) => entry.callback(magicFind)).setCriteria(entry.dropInfo.trigger).setContains(),
         () => settings.waterHotspotsAndBayouTrackerOverlay && isInSkyblock() && WATER_HOTSPOT_WORLDS.includes(getWorldName())
     );
 });
@@ -185,13 +185,13 @@ function trackRegularSeaCreatureCatch() {
 	}
 }
 
-function trackTitanoboaShedDrop() {
+function trackTitanoboaShedDrop(magicFind) {
     try {
         if (!settings.waterHotspotsAndBayouTrackerOverlay || !isInSkyblock() || getWorldName() !== BACKWATER_BAYOU) {
             return;
         }
 
-        const result = setDropStatisticsOnDrop(persistentData.waterHotspotsAndBayou.titanoboaSheds, 'catchesSinceLast', 'titanoboaCatches');
+        const result = setDropStatisticsOnDrop(persistentData.waterHotspotsAndBayou.titanoboaSheds, 'catchesSinceLast', 'titanoboaCatches', magicFind);
         persistentData.save();
 
         const dropNumber = persistentData.waterHotspotsAndBayou.titanoboaSheds.count;
@@ -203,13 +203,13 @@ function trackTitanoboaShedDrop() {
 	}
 }
 
-function trackTikiMaskDrop() {
+function trackTikiMaskDrop(magicFind) {
     try {
         if (!settings.waterHotspotsAndBayouTrackerOverlay || !isInSkyblock() || !WATER_HOTSPOT_WORLDS.includes(getWorldName())) {
             return;
         }
 
-        const result = setDropStatisticsOnDrop(persistentData.waterHotspotsAndBayou.tikiMasks, 'catchesSinceLast', 'wikiTikiCatches');
+        const result = setDropStatisticsOnDrop(persistentData.waterHotspotsAndBayou.tikiMasks, 'catchesSinceLast', 'wikiTikiCatches', magicFind);
         persistentData.save();
 
         const dropNumber = persistentData.waterHotspotsAndBayou.tikiMasks.count;

--- a/features/overlays/waterHotspotsAndBayouTracker.js
+++ b/features/overlays/waterHotspotsAndBayouTracker.js
@@ -59,14 +59,7 @@ registerIf(
 );
 
 register("gameUnload", () => {
-    if (settings.waterHotspotsAndBayouTrackerOverlay && settings.resetWaterHotspotsAndBayouTrackerOnGameClosed && persistentData.waterHotspotsAndBayou && (
-        persistentData.waterHotspotsAndBayou.titanoboa.lastCatchTime ||
-        persistentData.waterHotspotsAndBayou.titanoboa.catchesSinceLast ||
-        persistentData.waterHotspotsAndBayou.wikiTiki.lastCatchTime ||
-        persistentData.waterHotspotsAndBayou.wikiTiki.catchesSinceLast ||
-        persistentData.waterHotspotsAndBayou.titanoboaSheds.count ||
-        persistentData.waterHotspotsAndBayou.tikiMasks.count
-    )) {
+    if (settings.waterHotspotsAndBayouTrackerOverlay && settings.resetWaterHotspotsAndBayouTrackerOnGameClosed && hasAnyData()) {
         resetWaterHotspotsAndBayouTracker(true);
     }
 });
@@ -105,6 +98,17 @@ function getDefaultObject() {
         wikiTiki: getDefaultSeaCreatureSectionObject(),
         tikiMasks: { count: 0, catchesSinceLast: 0, dropsHistory: [] }
     };
+}
+
+function hasAnyData() {
+    return persistentData.waterHotspotsAndBayou && (
+        persistentData.waterHotspotsAndBayou.titanoboa.lastCatchTime ||
+        persistentData.waterHotspotsAndBayou.titanoboa.catchesSinceLast ||
+        persistentData.waterHotspotsAndBayou.wikiTiki.lastCatchTime ||
+        persistentData.waterHotspotsAndBayou.wikiTiki.catchesSinceLast ||
+        persistentData.waterHotspotsAndBayou.titanoboaSheds.count ||
+        persistentData.waterHotspotsAndBayou.tikiMasks.count
+    );
 }
 
 function isFishingInHotspot() {
@@ -219,15 +223,7 @@ function trackTikiMaskDrop() {
 
 function renderOverlay() {
     if (!settings.waterHotspotsAndBayouTrackerOverlay ||
-        !persistentData.waterHotspotsAndBayou ||
-        (
-            !persistentData.waterHotspotsAndBayou.titanoboa.lastCatchTime &&
-            !persistentData.waterHotspotsAndBayou.titanoboa.catchesSinceLast &&
-            !persistentData.waterHotspotsAndBayou.wikiTiki.lastCatchTime &&
-            !persistentData.waterHotspotsAndBayou.wikiTiki.catchesSinceLast &&
-            !persistentData.waterHotspotsAndBayou.titanoboaSheds.count &&
-            !persistentData.waterHotspotsAndBayou.tikiMasks.count
-        ) ||
+        !hasAnyData() ||
         !isInSkyblock() ||
         !WATER_HOTSPOT_WORLDS.includes(getWorldName()) ||
         !(getWorldName() === BACKWATER_BAYOU || isFishingInHotspot()) ||

--- a/features/overlays/waterHotspotsAndBayouTracker.js
+++ b/features/overlays/waterHotspotsAndBayouTracker.js
@@ -1,0 +1,281 @@
+import settings, { allOverlaysGui } from "../../settings";
+import * as triggers from '../../constants/triggers';
+import * as seaCreatures from '../../constants/seaCreatures';
+import { persistentData } from "../../data/data";
+import { overlayCoordsData } from "../../data/overlayCoords";
+import { BOLD, GOLD, LIGHT_PURPLE, RED, WHITE, GRAY, AQUA } from "../../constants/formatting";
+import { getLastFishingHookInHotspotSeenAt, getLastFishingHookSeenAt, getWorldName, isInSkyblock } from "../../utils/playerState";
+import { getCatchesCounterChatMessage, getDropCatchesCounterChatMessage } from "../../utils/common";
+import { BACKWATER_BAYOU, WATER_HOTSPOT_WORLDS } from "../../constants/areas";
+import { createButtonsDisplay, toggleButtonsDisplay, setSeaCreatureStatisticsOnCatch, setDropStatisticsOnCatch, setDropStatisticsOnDrop, getSeaCreatureStatisticsOverlayText, getDropStatisticsOverlayText } from "../../utils/overlays";
+import { registerIf } from "../../utils/registers";
+
+const TRACKED_SEA_CREATURES = [
+    {
+        seaCreatureInfo: triggers.RARE_CATCH_TRIGGERS.find(entry => entry.seaCreature === seaCreatures.TITANOBOA),
+        callback: (seaCreatureInfo) => trackTitanoboaCatch(seaCreatureInfo),
+    },
+    {
+        seaCreatureInfo: triggers.RARE_CATCH_TRIGGERS.find(entry => entry.seaCreature === seaCreatures.WIKI_TIKI),
+        callback: (seaCreatureInfo) => trackWikiTikiCatch(seaCreatureInfo),
+    },
+];
+
+const TRACKED_DROPS = [
+    {
+        dropInfo: triggers.RARE_DROP_TRIGGERS.find(entry => entry.trigger === triggers.TITANOBOA_SHED_MESSAGE),
+        callback: () => trackTitanoboaShedDrop(),
+    },
+    {
+        dropInfo: triggers.RARE_DROP_TRIGGERS.find(entry => entry.trigger === triggers.TIKI_MASK_MESSAGE),
+        callback: () => trackTikiMaskDrop(),
+    },
+];
+
+triggers.REGULAR_WATER_HOTSPOT_AND_BAYOU_CATCH_TRIGGERS.forEach(seaCreatureInfo => {
+    registerIf(
+        register("Chat", (event) => trackRegularSeaCreatureCatch()).setCriteria(seaCreatureInfo.trigger).setContains(),
+        () => settings.waterHotspotsAndBayouTrackerOverlay && isInSkyblock() && WATER_HOTSPOT_WORLDS.includes(getWorldName())
+    );
+});
+
+TRACKED_SEA_CREATURES.forEach(entry => {
+    registerIf(
+        register("Chat", (event) => entry.callback(entry.seaCreatureInfo)).setCriteria(entry.seaCreatureInfo.trigger).setContains(),
+        () => settings.waterHotspotsAndBayouTrackerOverlay && isInSkyblock() && WATER_HOTSPOT_WORLDS.includes(getWorldName())
+    );
+});
+
+TRACKED_DROPS.forEach(entry => {
+    registerIf(
+        register("Chat", (magicFind, event) => entry.callback()).setCriteria(entry.dropInfo.trigger).setContains(),
+        () => settings.waterHotspotsAndBayouTrackerOverlay && isInSkyblock() && WATER_HOTSPOT_WORLDS.includes(getWorldName())
+    );
+});
+
+registerIf(
+    register('renderOverlay', () => renderOverlay()),
+    () => settings.waterHotspotsAndBayouTrackerOverlay && isInSkyblock() && WATER_HOTSPOT_WORLDS.includes(getWorldName())
+);
+
+register("gameUnload", () => {
+    if (settings.waterHotspotsAndBayouTrackerOverlay && settings.resetWaterHotspotsAndBayouTrackerOnGameClosed && persistentData.waterHotspotsAndBayou && (
+        persistentData.waterHotspotsAndBayou.titanoboa.lastCatchTime ||
+        persistentData.waterHotspotsAndBayou.titanoboa.catchesSinceLast ||
+        persistentData.waterHotspotsAndBayou.wikiTiki.lastCatchTime ||
+        persistentData.waterHotspotsAndBayou.wikiTiki.catchesSinceLast ||
+        persistentData.waterHotspotsAndBayou.titanoboaSheds.count ||
+        persistentData.waterHotspotsAndBayou.tikiMasks.count
+    )) {
+        resetWaterHotspotsAndBayouTracker(true);
+    }
+});
+
+const buttonsDisplay = createButtonsDisplay(true, () => resetWaterHotspotsAndBayouTracker(false), false, null);
+
+export function resetWaterHotspotsAndBayouTracker(isConfirmed) {
+    try {
+        if (!isConfirmed) {
+            new Message(
+                new TextComponent(`${GOLD}[FeeshNotifier] ${WHITE}Do you want to reset Water Hotspots & Bayou tracker? ${RED}${BOLD}[Click to confirm]`)
+                    .setClickAction('run_command')
+                    .setClickValue('/feeshResetWaterHotspotsAndBayou noconfirm')
+            ).chat();
+            return;
+        }
+    
+        persistentData.waterHotspotsAndBayou = getDefaultObject();
+        persistentData.save();
+
+        ChatLib.chat(`${GOLD}[FeeshNotifier] ${WHITE}Water Hotspots & Bayou tracker was reset.`);    
+    } catch (e) {
+		console.error(e);
+		console.log(`[FeeshNotifier] [WaterHotspotsAndBayouTracker] Failed to reset Water Hotspots & Bayou tracker.`);
+	}
+}
+
+function getDefaultSeaCreatureSectionObject() {
+    return { catchesSinceLast: 0, lastCatchTime: null, catchesHistory: [], averageCatches: 0 };
+}
+
+function getDefaultObject() {
+    return {
+        titanoboa: getDefaultSeaCreatureSectionObject(),
+        titanoboaSheds: { count: 0, catchesSinceLast: 0, dropsHistory: [] },
+        wikiTiki: getDefaultSeaCreatureSectionObject(),
+        tikiMasks: { count: 0, catchesSinceLast: 0, dropsHistory: [] }
+    };
+}
+
+function isFishingInHotspot() {
+    if (!WATER_HOTSPOT_WORLDS.includes(getWorldName())) return false;
+
+    const lastFishingHookInHotspotSeenAt = getLastFishingHookInHotspotSeenAt();
+    return lastFishingHookInHotspotSeenAt && new Date() - lastFishingHookInHotspotSeenAt <= 60 * 1000;
+}
+
+function trackTitanoboaCatch(seaCreatureInfo) {
+    try {
+        if (!settings.waterHotspotsAndBayouTrackerOverlay || !isInSkyblock() || getWorldName() !== BACKWATER_BAYOU) {
+            return;
+        }
+
+        const result = setSeaCreatureStatisticsOnCatch(persistentData.waterHotspotsAndBayou.titanoboa);
+        setDropStatisticsOnCatch(persistentData.waterHotspotsAndBayou.titanoboaSheds, 'catchesSinceLast');
+
+        if (isFishingInHotspot()) {
+            persistentData.waterHotspotsAndBayou.wikiTiki.catchesSinceLast += 1;
+        }
+
+        persistentData.save();
+
+        const message = getCatchesCounterChatMessage(seaCreatureInfo.seaCreature, seaCreatureInfo.rarityColorCode, result.catchesSinceLast, result.lastCatchTime);
+        ChatLib.chat(message);
+    } catch (e) {
+		console.error(e);
+		console.log(`[FeeshNotifier] [WaterHotspotsAndBayouTracker] Failed to track Titanoboa catch.`);
+	}
+}
+
+function trackWikiTikiCatch(seaCreatureInfo) {
+    try {
+        if (!settings.waterHotspotsAndBayouTrackerOverlay || !isInSkyblock() || !WATER_HOTSPOT_WORLDS.includes(getWorldName())) {
+            return;
+        }
+
+        const result = setSeaCreatureStatisticsOnCatch(persistentData.waterHotspotsAndBayou.wikiTiki);
+        setDropStatisticsOnCatch(persistentData.waterHotspotsAndBayou.tikiMasks, 'catchesSinceLast');
+
+        if (getWorldName() === BACKWATER_BAYOU) {
+            persistentData.waterHotspotsAndBayou.titanoboa.catchesSinceLast += 1;
+        }
+
+        persistentData.save();
+
+        const message = getCatchesCounterChatMessage(seaCreatureInfo.seaCreature, seaCreatureInfo.rarityColorCode, result.catchesSinceLast, result.lastCatchTime);
+        ChatLib.chat(message);
+    } catch (e) {
+		console.error(e);
+		console.log(`[FeeshNotifier] [WaterHotspotsAndBayouTracker] Failed to track Wiki Tiki catch.`);
+	}
+}
+
+function trackRegularSeaCreatureCatch() {
+    try {
+        if (!settings.waterHotspotsAndBayouTrackerOverlay || !isInSkyblock() || !WATER_HOTSPOT_WORLDS.includes(getWorldName())) {
+            return;
+        }
+
+        if (isFishingInHotspot()) {
+            persistentData.waterHotspotsAndBayou.wikiTiki.catchesSinceLast += 1;
+        }
+
+        if (getWorldName() === BACKWATER_BAYOU) {
+            persistentData.waterHotspotsAndBayou.titanoboa.catchesSinceLast += 1;
+        }
+
+        persistentData.save();
+    } catch (e) {
+		console.error(e);
+		console.log(`[FeeshNotifier] [WaterHotspotsAndBayouTracker] Failed to track regular sea creature catch.`);
+	}
+}
+
+function trackTitanoboaShedDrop() {
+    try {
+        if (!settings.waterHotspotsAndBayouTrackerOverlay || !isInSkyblock() || getWorldName() !== BACKWATER_BAYOU) {
+            return;
+        }
+
+        const result = setDropStatisticsOnDrop(persistentData.waterHotspotsAndBayou.titanoboaSheds, 'catchesSinceLast', 'titanoboaCatches');
+        persistentData.save();
+
+        const dropNumber = persistentData.waterHotspotsAndBayou.titanoboaSheds.count;
+        const message = getDropCatchesCounterChatMessage(`${GOLD}Titanoboa Shed`, 'Titanoboa', result.lastDropTime, dropNumber, result.catches);
+        ChatLib.chat(message);
+    } catch (e) {
+		console.error(e);
+		console.log(`[FeeshNotifier] [WaterHotspotsAndBayouTracker] Failed to track Titanoboa Shed drop.`);
+	}
+}
+
+function trackTikiMaskDrop() {
+    try {
+        if (!settings.waterHotspotsAndBayouTrackerOverlay || !isInSkyblock() || !WATER_HOTSPOT_WORLDS.includes(getWorldName())) {
+            return;
+        }
+
+        const result = setDropStatisticsOnDrop(persistentData.waterHotspotsAndBayou.tikiMasks, 'catchesSinceLast', 'wikiTikiCatches');
+        persistentData.save();
+
+        const dropNumber = persistentData.waterHotspotsAndBayou.tikiMasks.count;
+        const message = getDropCatchesCounterChatMessage(`${GOLD}Tiki Mask`, 'Wiki Tiki', result.lastDropTime, dropNumber, result.catches);
+        ChatLib.chat(message);
+    } catch (e) {
+		console.error(e);
+		console.log(`[FeeshNotifier] [WaterHotspotsAndBayouTracker] Failed to track Tiki Mask drop.`);
+	}
+}
+
+function renderOverlay() {
+    if (!settings.waterHotspotsAndBayouTrackerOverlay ||
+        !persistentData.waterHotspotsAndBayou ||
+        (
+            !persistentData.waterHotspotsAndBayou.titanoboa.lastCatchTime &&
+            !persistentData.waterHotspotsAndBayou.titanoboa.catchesSinceLast &&
+            !persistentData.waterHotspotsAndBayou.wikiTiki.lastCatchTime &&
+            !persistentData.waterHotspotsAndBayou.wikiTiki.catchesSinceLast &&
+            !persistentData.waterHotspotsAndBayou.titanoboaSheds.count &&
+            !persistentData.waterHotspotsAndBayou.tikiMasks.count
+        ) ||
+        !isInSkyblock() ||
+        !WATER_HOTSPOT_WORLDS.includes(getWorldName()) ||
+        !(getWorldName() === BACKWATER_BAYOU || isFishingInHotspot()) ||
+        (new Date() - getLastFishingHookSeenAt() > 10 * 60 * 1000) ||
+        allOverlaysGui.isOpen()
+    ) {
+        buttonsDisplay.hide();
+        return;
+    }
+
+    let overlayText = `${AQUA}${BOLD}Water hotspots & Bayou tracker`;
+    overlayText += getTitanoboaOverlayText();
+    overlayText += getTitanoboaShedsOverlayText();
+    overlayText += getWikiTikiOverlayText();
+    overlayText += getTikiMasksOverlayText();
+
+    const overlay = new Text(overlayText, overlayCoordsData.waterHotspotsAndBayouTrackerOverlay.x, overlayCoordsData.waterHotspotsAndBayouTrackerOverlay.y)
+        .setShadow(true)
+        .setScale(overlayCoordsData.waterHotspotsAndBayouTrackerOverlay.scale);
+    overlay.draw();
+
+    toggleButtonsDisplay(buttonsDisplay, overlay, overlayCoordsData.waterHotspotsAndBayouTrackerOverlay);
+
+    function getTitanoboaOverlayText() {
+        if (getWorldName() !== BACKWATER_BAYOU) return '';
+
+        const overlayText = getSeaCreatureStatisticsOverlayText(`${LIGHT_PURPLE}Titanoboa`, persistentData.waterHotspotsAndBayou.titanoboa);
+        return '\n' + overlayText;
+    }
+
+    function getTitanoboaShedsOverlayText() {
+        if (getWorldName() !== BACKWATER_BAYOU) return '';
+
+        const overlayText = getDropStatisticsOverlayText(`${GOLD}Titanoboa Shed`, 'Titanoboa', persistentData.waterHotspotsAndBayou.titanoboaSheds, 'catchesSinceLast');
+        return '\n' + overlayText;
+    }
+
+    function getWikiTikiOverlayText() {
+        if (!isFishingInHotspot()) return '';
+
+        const overlayText = getSeaCreatureStatisticsOverlayText(`${LIGHT_PURPLE}Wiki Tiki`, persistentData.waterHotspotsAndBayou.wikiTiki);
+        return '\n' + overlayText;
+    }
+
+    function getTikiMasksOverlayText() {
+        if (!isFishingInHotspot()) return '';
+
+        const overlayText = getDropStatisticsOverlayText(`${GOLD}Tiki Mask`, 'Wiki Tiki', persistentData.waterHotspotsAndBayou.tikiMasks, 'catchesSinceLast');
+        return '\n' + overlayText;
+    }
+}

--- a/features/overlays/waterHotspotsAndBayouTracker.js
+++ b/features/overlays/waterHotspotsAndBayouTracker.js
@@ -7,7 +7,7 @@ import { BOLD, GOLD, LIGHT_PURPLE, RED, WHITE, GRAY, AQUA } from "../../constant
 import { getLastFishingHookInHotspotSeenAt, getLastFishingHookSeenAt, getWorldName, isInSkyblock } from "../../utils/playerState";
 import { getCatchesCounterChatMessage, getDropCatchesCounterChatMessage } from "../../utils/common";
 import { BACKWATER_BAYOU, WATER_HOTSPOT_WORLDS } from "../../constants/areas";
-import { createButtonsDisplay, toggleButtonsDisplay, setSeaCreatureStatisticsOnCatch, setDropStatisticsOnCatch, setDropStatisticsOnDrop, getSeaCreatureStatisticsOverlayText, getDropStatisticsOverlayText } from "../../utils/overlays";
+import { createButtonsDisplay, toggleButtonsDisplay, setSeaCreatureStatisticsOnCatch, setDropStatisticsOnCatch, setDropStatisticsOnDrop, getSeaCreatureStatisticsOverlayText, getDropStatisticsOverlayText, initDropCountOnOverlay } from "../../utils/overlays";
 import { registerIf } from "../../utils/registers";
 
 const TRACKED_SEA_CREATURES = [
@@ -85,6 +85,46 @@ export function resetWaterHotspotsAndBayouTracker(isConfirmed) {
 		console.error(e);
 		console.log(`[FeeshNotifier] [WaterHotspotsAndBayouTracker] Failed to reset Water Hotspots & Bayou tracker.`);
 	}
+}
+
+export function setTitanoboaSheds(count, lastOn) {
+    try {
+        if (!isInSkyblock()) {
+            return;
+        }
+        
+        const errorMessage = initDropCountOnOverlay(persistentData.waterHotspotsAndBayou.titanoboaSheds, count, lastOn);
+        if (errorMessage) {
+            ChatLib.chat(errorMessage);
+            return;
+        }
+
+        persistentData.save();
+        ChatLib.chat(`${GOLD}[FeeshNotifier] ${GRAY}Successfully changed Titanoboa Sheds count to ${count} for the Water Hotspots & Bayou tracker.`);   
+    } catch (e) {
+        console.error(e);
+		console.log(`[FeeshNotifier] Failed to set Titanoboa Sheds.`);
+    }
+}
+
+export function setTikiMasks(count, lastOn) {
+    try {
+        if (!isInSkyblock()) {
+            return;
+        }
+        
+        const errorMessage = initDropCountOnOverlay(persistentData.waterHotspotsAndBayou.tikiMasks, count, lastOn);
+        if (errorMessage) {
+            ChatLib.chat(errorMessage);
+            return;
+        }
+
+        persistentData.save();
+        ChatLib.chat(`${GOLD}[FeeshNotifier] ${GRAY}Successfully changed Tiki Masks count to ${count} for the Water Hotspots & Bayou tracker.`);   
+    } catch (e) {
+        console.error(e);
+		console.log(`[FeeshNotifier] Failed to set Tiki Masks.`);
+    }
 }
 
 function getDefaultSeaCreatureSectionObject() {

--- a/index.js
+++ b/index.js
@@ -31,6 +31,7 @@ import "./features/overlays/seaCreaturesPerHourTracker";
 import "./features/overlays/legionAndBobbingTimeTracker";
 import "./features/overlays/crimsonIsleTracker";
 import "./features/overlays/jerryWorkshopTracker";
+import "./features/overlays/waterHotspotsAndBayouTracker";
 import "./features/overlays/wormMembraneProfitTracker";
 import "./features/overlays/magmaCoreProfitTracker";
 import "./features/overlays/abandonedQuarryTracker";

--- a/metadata.json
+++ b/metadata.json
@@ -3,7 +3,7 @@
     "entry": "index.js",
     "author": "MoonTheSadFisher",
     "description": "Hypixel Skyblock fishing utilities for parties.",
-    "version": "1.43.0",
+    "version": "1.44.0",
     "requires": [
         "Amaterasu",
         "PogData",

--- a/moveAllOverlays.js
+++ b/moveAllOverlays.js
@@ -118,6 +118,25 @@ ${GRAY}Last on: ${WHITE}2d 9h 8m ${GRAY}(${WHITE}2024-11-30 08:00:00${GRAY})`,
         height: 0
     },
     {
+        toggleSettingKey: 'waterHotspotsAndBayouTrackerOverlay',
+        guiSettings: overlayCoordsData.waterHotspotsAndBayouTrackerOverlay,
+        sampleText:
+`${AQUA}${BOLD}Water hotspots & Bayou tracker
+${LIGHT_PURPLE}Titanoboa: ${WHITE}417 ${GRAY}catches ago ${DARK_GRAY}(${GRAY}avg: ${WHITE}654${DARK_GRAY})
+${GRAY}Last on: ${WHITE}2d 9h 8m ${GRAY}(${WHITE}2024-11-30 08:00:00${GRAY})
+${GOLD}Titanoboa Sheds: ${WHITE}2
+${GRAY}Last on: ${WHITE}1d 0h 0m ${GRAY}(${WHITE}2024-11-29 12:15:00${GRAY})
+${GRAY}Last on: ${WHITE}10 Titanoboas ago
+${LIGHT_PURPLE}Wiki Tiki: ${WHITE}70 ${GRAY}catches ago ${DARK_GRAY}(${GRAY}avg: ${WHITE}85${DARK_GRAY})
+${GRAY}Last on: ${WHITE}2d 5h 8m ${GRAY}(${WHITE}2024-11-30 12:00:00${GRAY})
+${GOLD}Tiki Masks: ${WHITE}5
+${GRAY}Last on: ${WHITE}1d 0h 0m ${GRAY}(${WHITE}2024-11-29 12:15:00${GRAY})
+${GRAY}Last on: ${WHITE}6 Wiki Tikis ago`,
+        isActive: false,
+        width: 0,
+        height: 0
+    },
+    {
         toggleSettingKey: 'wormProfitTrackerOverlay',
         guiSettings: overlayCoordsData.wormProfitTrackerOverlay,
         sampleText:

--- a/moveAllOverlays.js
+++ b/moveAllOverlays.js
@@ -1,6 +1,6 @@
 import settings, { allOverlaysGui } from "./settings";
 import { overlayCoordsData } from "./data/overlayCoords";
-import { AQUA, BLUE, BOLD, DARK_GRAY, DARK_PURPLE, DARK_RED, GOLD, GRAY, GREEN, LIGHT_PURPLE, RED, RESET, WHITE, YELLOW } from "./constants/formatting";
+import { AQUA, BLUE, BOLD, DARK_GRAY, DARK_PURPLE, GOLD, GRAY, GREEN, LIGHT_PURPLE, RED, RESET, WHITE, YELLOW } from "./constants/formatting";
 import { isInSkyblock } from "./utils/playerState";
 import { decreaseScaleOrSetToMinimal } from "./moveOverlay";
 
@@ -85,7 +85,13 @@ ${AQUA}Elapsed time: ${WHITE}2:00:00
         toggleSettingKey: 'crimsonIsleTrackerOverlay',
         guiSettings: overlayCoordsData.crimsonIsleTrackerOverlay,
         sampleText:
-`${DARK_RED}${BOLD}Crimson Isle tracker
+`${AQUA}${BOLD}Crimson Isle tracker
+${GOLD}Fiery Scuttler: ${WHITE}1 ${GRAY}catch ago ${DARK_GRAY}(${GRAY}avg: ${WHITE}50${DARK_GRAY})
+${GRAY}Last on: ${WHITE}1m ${GRAY}(${WHITE}2024-11-30 11:45:00${GRAY})
+${LIGHT_PURPLE}Ragnarok: ${WHITE}36 ${GRAY}catches ago ${DARK_GRAY}(${GRAY}avg: ${WHITE}350${DARK_GRAY})
+${GRAY}Last on: ${WHITE}15m ${GRAY}(${WHITE}2024-11-30 11:59:00${GRAY})
+${LIGHT_PURPLE}Plhlegblast: ${WHITE}2000 ${GRAY}catches ago ${DARK_GRAY}(${GRAY}avg: ${WHITE}1500${DARK_GRAY})
+${GRAY}Last on: ${WHITE}24h 15m ${GRAY}(${WHITE}2024-11-29 12:00:00${GRAY})
 ${LIGHT_PURPLE}Thunder: ${WHITE}35 ${GRAY}catches ago ${DARK_GRAY}(${GRAY}avg: ${WHITE}70${DARK_GRAY})
 ${GRAY}Last on: ${WHITE}15m ${GRAY}(${WHITE}2024-11-30 12:00:00${GRAY})
 ${LIGHT_PURPLE}Lord Jawbus: ${WHITE}417 ${GRAY}catches ago ${DARK_GRAY}(${GRAY}avg: ${WHITE}454${DARK_GRAY})
@@ -104,9 +110,9 @@ ${GRAY}Last on: ${WHITE}6 Jawbuses ago`,
 `${AQUA}${BOLD}Jerry Workshop tracker
 ${GOLD}Yeti: ${WHITE}70 ${GRAY}catches ago ${DARK_GRAY}(${GRAY}avg: ${WHITE}85${DARK_GRAY})
 ${GRAY}Last on: ${WHITE}2d 5h 8m ${GRAY}(${WHITE}2024-11-30 12:00:00${GRAY})
+${GRAY}Baby Yeti pets: ${GOLD}3 ${DARK_PURPLE}7
 ${LIGHT_PURPLE}Reindrake: ${WHITE}417 ${GRAY}catches ago ${DARK_GRAY}(${GRAY}avg: ${WHITE}654${DARK_GRAY})
-${GRAY}Last on: ${WHITE}2d 9h 8m ${GRAY}(${WHITE}2024-11-30 08:00:00${GRAY})
-${GRAY}Baby Yeti pets: ${GOLD}3 ${DARK_PURPLE}7`,
+${GRAY}Last on: ${WHITE}2d 9h 8m ${GRAY}(${WHITE}2024-11-30 08:00:00${GRAY})`,
         isActive: false,
         width: 0,
         height: 0

--- a/moveOverlay.js
+++ b/moveOverlay.js
@@ -1,4 +1,4 @@
-import { abandonedQuarryTrackerOverlayGui, archfiendDiceProfitTrackerOverlayGui, crimsonIsleTrackerOverlayGui, fishingProfitTrackerOverlayGui, flareRemainingTimeOverlayGui, jerryWorkshopTrackerOverlayGui, legionAndBobbingTimeOverlayGui, magmaCoreProfitTrackerOverlayGui, rareCatchesTrackerOverlayGui, seaCreaturesCountOverlayGui, seaCreaturesHpOverlayGui, seaCreaturesPerHourTrackerOverlayGui, totemRemainingTimeOverlayGui, wormProfitTrackerOverlayGui } from "./settings";
+import { abandonedQuarryTrackerOverlayGui, archfiendDiceProfitTrackerOverlayGui, crimsonIsleTrackerOverlayGui, fishingProfitTrackerOverlayGui, flareRemainingTimeOverlayGui, jerryWorkshopTrackerOverlayGui, legionAndBobbingTimeOverlayGui, magmaCoreProfitTrackerOverlayGui, rareCatchesTrackerOverlayGui, seaCreaturesCountOverlayGui, seaCreaturesHpOverlayGui, seaCreaturesPerHourTrackerOverlayGui, totemRemainingTimeOverlayGui, waterHotspotsAndBayouTrackerOverlayGui, wormProfitTrackerOverlayGui } from "./settings";
 import { overlayCoordsData } from "./data/overlayCoords";
 
 const GUIS = [
@@ -37,6 +37,10 @@ const GUIS = [
     {
         gui: jerryWorkshopTrackerOverlayGui,
         guiSettings: overlayCoordsData.jerryWorkshopTrackerOverlay,
+    },
+    {
+        gui: waterHotspotsAndBayouTrackerOverlayGui,
+        guiSettings: overlayCoordsData.waterHotspotsAndBayouTrackerOverlay,
     },
     {
         gui: wormProfitTrackerOverlayGui,

--- a/settings.js
+++ b/settings.js
@@ -1209,17 +1209,18 @@ Do ${AQUA}/feeshResetCrimsonIsle${GRAY} to reset.`,
     category: "Overlays",
     configName: "getRadioactiveVialsSetupHelp",
     title: "Set Radioactive Vials count",
-    description: "Explains how to setup Radioactive Vials count and last drop date.",
+    description: "Explains in your chat how to setup Radioactive Vials count and last drop date.",
     subcategory: "Crimson Isle tracker",
     onClick() {
         ChatLib.chat(`
 ${LIGHT_PURPLE}${BOLD}Radioactive Vials setup
 
-Do ${AQUA}/feeshSetRadioactiveVials <COUNT> <LAST_ON_UTC_DATE>${RESET} to initialize your vials history:
-  - <COUNT> is a mandatory number of vials.
-  - <LAST_ON_UTC_DATE> is optional and, if provided, should be in YYYY-MM-DDThh:mm:ssZ format (UTC).
+Do ${AQUA}/feeshSetTrackerDrops <ITEM_ID> <COUNT> <LAST_ON_DATE>${RESET} to initialize your drops history:
+  - <ITEM_ID> is a mandatory item ID - RADIOACTIVE_VIAL.
+  - <COUNT> is a mandatory number of times you've dropped it.
+  - <LAST_ON_DATE> is optional and, if provided, should be in YYYY-MM-DD hh:mm:ss format. Can not be in future!
 
-Example: ${AQUA}/feeshSetRadioactiveVials 5 2024-03-18T14:05:00Z`);
+Example: ${AQUA}/feeshSetTrackerDrops RADIOACTIVE_VIAL 5 2025-05-30 23:59:00`);
     }
 })
 .addSwitch({
@@ -1259,6 +1260,25 @@ Shows an overlay with Titanoboa (when fishing in hotspot) and Wiki Tiki (when in
 Do ${AQUA}/feeshResetWaterHotspotsAndBayou${GRAY} to reset.`,
     subcategory: "Water hotspots & Bayou tracker",
     value: true
+})
+.addButton({
+    category: "Overlays",
+    configName: "getTitanoboaShedAndTikiMaskSetupHelp",
+    title: "Set Titanoboa Sheds / Tiki Masks count",
+    description: "Explains in your chat how to setup Titanoboa Sheds / Tiki Masks count and last drop date.",
+    subcategory: "Water hotspots & Bayou tracker",
+    onClick() {
+        ChatLib.chat(`
+${LIGHT_PURPLE}${BOLD}Titanoboa Sheds / Tiki Masks setup
+
+Do ${AQUA}/feeshSetTrackerDrops <ITEM_ID> <COUNT> <LAST_ON_DATE>${RESET} to initialize your drops history:
+  - <ITEM_ID> is a mandatory item ID - TITANOBOA_SHED or TIKI_MASK.
+  - <COUNT> is a mandatory number of times you've dropped it.
+  - <LAST_ON_DATE> is optional and, if provided, should be in YYYY-MM-DD hh:mm:ss format. Can not be in future!
+
+Example 1: ${AQUA}/feeshSetTrackerDrops TITANOBOA_SHED 5 2025-05-30 23:59:00
+Example 2: ${AQUA}/feeshSetTrackerDrops TIKI_MASK 5 2025-05-30 23:59:00`);
+    }
 })
 .addSwitch({
     category: "Overlays",

--- a/settings.js
+++ b/settings.js
@@ -13,6 +13,7 @@ export const seaCreaturesPerHourTrackerOverlayGui = new Gui();
 export const legionAndBobbingTimeOverlayGui = new Gui();
 export const crimsonIsleTrackerOverlayGui = new Gui();
 export const jerryWorkshopTrackerOverlayGui = new Gui();
+export const waterHotspotsAndBayouTrackerOverlayGui = new Gui();
 export const wormProfitTrackerOverlayGui = new Gui();
 export const magmaCoreProfitTrackerOverlayGui = new Gui();
 export const abandonedQuarryTrackerOverlayGui = new Gui();
@@ -1225,7 +1226,7 @@ Example: ${AQUA}/feeshSetRadioactiveVials 5 2024-03-18T14:05:00Z`);
     category: "Overlays",
     configName: "resetCrimsonIsleTrackerOnGameClosed",
     title: "Reset on closing game",
-    description: "Automatically reset the Crimson Isle tracker when you close Minecraft or or reload CT modules.",
+    description: "Automatically reset the Crimson Isle tracker when you close Minecraft or reload CT modules.",
     subcategory: "Crimson Isle tracker"
 })
 .addButton({
@@ -1246,6 +1247,44 @@ Example: ${AQUA}/feeshSetRadioactiveVials 5 2024-03-18T14:05:00Z`);
     subcategory: "Crimson Isle tracker",
     onClick() {
         ChatLib.command("feeshResetCrimsonIsle noconfirm", true);
+    }
+})
+
+.addSwitch({
+    category: "Overlays",
+    configName: "waterHotspotsAndBayouTrackerOverlay",
+    title: "Water hotspots & Bayou tracker",
+    description: `
+Shows an overlay with Titanoboa (when fishing in hotspot) and Wiki Tiki (when in Backwater Bayou) catch statistics. Also has Titanoboa Shed and Tiki Mask drop statistics.
+Do ${AQUA}/feeshResetWaterHotspotsAndBayou${GRAY} to reset.`,
+    subcategory: "Water hotspots & Bayou tracker",
+    value: true
+})
+.addSwitch({
+    category: "Overlays",
+    configName: "resetWaterHotspotsAndBayouTrackerOnGameClosed",
+    title: "Reset on closing game",
+    description: "Automatically reset the Water hotspots & Bayou tracker when you close Minecraft or reload CT modules.",
+    subcategory: "Water hotspots & Bayou tracker"
+})
+.addButton({
+    category: "Overlays",
+    configName: "moveWaterHotspotsAndBayouTrackerOverlay",
+    title: "Move Water hotspots & Bayou tracker",
+    description: "Allows to move and resize the overlay text.",
+    subcategory: "Water hotspots & Bayou tracker",
+    onClick() {
+        moveOverlay(waterHotspotsAndBayouTrackerOverlayGui);
+    }
+})
+.addButton({
+    category: "Overlays",
+    configName: "resetWaterHotspotsAndBayouTracker",
+    title: "Reset Water hotspots & Bayou tracker",
+    description: `Resets tracking for Water hotspots & Bayou tracker. Executes ${AQUA}/feeshResetWaterHotspotsAndBayou`,
+    subcategory: "Water hotspots & Bayou tracker",
+    onClick() {
+        ChatLib.command("feeshResetWaterHotspotsAndBayou noconfirm", true);
     }
 })
 

--- a/settings.js
+++ b/settings.js
@@ -1199,7 +1199,7 @@ const config = new DefaultConfig("FeeshNotifier", "config/settings.json")
     configName: "crimsonIsleTrackerOverlay",
     title: "Crimson Isle tracker",
     description: `
-Shows an overlay with Thunder / Lord Jawbus catch statistics and Radioactive Vial drop statistics while in the Crimson Isle.
+Shows an overlay with Fiery Scuttler & Ragnarok (when fishing in hotspot), Plhlegblast (when in Plhlegblast Pool), Thunder & Lord Jawbus catch statistics. Also has Radioactive Vial drop statistics. Shown only when in the Crimson Isle!
 Do ${AQUA}/feeshResetCrimsonIsle${GRAY} to reset.`,
     subcategory: "Crimson Isle tracker",
     value: true

--- a/utils/common.js
+++ b/utils/common.js
@@ -1,5 +1,5 @@
 import { NO_FISHING_WORLDS } from '../constants/areas';
-import { RED, DARK_GRAY, BLUE, WHITE, BOLD, RESET } from '../constants/formatting';
+import { RED, DARK_GRAY, BLUE, WHITE, BOLD, RESET, GOLD, GRAY } from '../constants/formatting';
 import { NBTTagString } from '../constants/javaTypes';
 import { EntityFishHook, NBTTagString } from '../constants/javaTypes';
 import { DOUBLE_HOOK_MESSAGES, HURRICANE_BOTTLE_CHARGED_MESSAGE, STORM_BOTTLE_CHARGED_MESSAGE, THUNDER_BOTTLE_CHARGED_MESSAGE } from '../constants/triggers';
@@ -93,6 +93,14 @@ export function getPartyChatMessage(baseMessage) {
 	return `${RESET}${BLUE}` + "${*}" + ` ${DARK_GRAY}> ` + "${rankAndPlayer}" + `${WHITE}: ${RESET}${baseMessage}${RESET}`;
 	// To test using Co-op chat:
 	// return `${RESET}${AQUA}Co-op > ` + "${rankAndPlayer}" + `${WHITE}: ${RESET}${baseMessage}${RESET}`;
+}
+
+export function getCatchesCounterChatMessage(seaCreatureName, seaCreatureRarity, catchesSinceLast, lastCatchTime) {
+	const elapsedTimeText = lastCatchTime ? ` ${GRAY}(${WHITE}${formatTimeElapsedBetweenDates(new Date(lastCatchTime))}${GRAY})` : '';
+	const b2bText = catchesSinceLast === 1 ? `${RED}B2B! ` : '';
+	const catchesText = `${WHITE}${catchesSinceLast} ${GRAY}${catchesSinceLast === 1 ? 'catch' : 'catches'}`;
+	const seaCreatureDisplayName = `${seaCreatureRarity}${fromUppercaseToCapitalizedFirstLetters(seaCreatureName)}`;
+	return `${GOLD}[FeeshNotifier] ${b2bText}${GRAY}It took ${catchesText}${elapsedTimeText} to get the ${seaCreatureDisplayName}${GRAY}.`;
 }
 
 // Transforms UPPERCASE TEXT to a Regular Text With Capitalized First Letters.

--- a/utils/common.js
+++ b/utils/common.js
@@ -103,6 +103,12 @@ export function getCatchesCounterChatMessage(seaCreatureName, seaCreatureRarity,
 	return `${GOLD}[FeeshNotifier] ${b2bText}${GRAY}It took ${catchesText}${elapsedTimeText} to get the ${seaCreatureDisplayName}${GRAY}.`;
 }
 
+export function getDropCatchesCounterChatMessage(dropDisplayName, seaCreatureName, lastDropTime, dropNumber, catches) {
+	const elapsedTimeText = lastDropTime ? ` ${GRAY}(${WHITE}${formatTimeElapsedBetweenDates(new Date(lastDropTime))}${GRAY})` : '';
+	const catchesText = catches === 1 ? `${WHITE}${catches} ${GRAY}${fromUppercaseToCapitalizedFirstLetters(seaCreatureName)} catch` : `${WHITE}${catches} ${GRAY}${fromUppercaseToCapitalizedFirstLetters(seaCreatureName)} catches`;
+    return `${GOLD}[FeeshNotifier] ${GRAY}It took ${catchesText}${elapsedTimeText} to get the ${dropDisplayName} ${WHITE}#${dropNumber}${GRAY}. Congratulations!`;   
+}
+
 // Transforms UPPERCASE TEXT to a Regular Text With Capitalized First Letters.
 export function fromUppercaseToCapitalizedFirstLetters(str) {
 	if (!str) {

--- a/utils/overlays.js
+++ b/utils/overlays.js
@@ -132,8 +132,9 @@ export function setDropStatisticsOnCatch(dropObj, catchesSinceLastPropName) {
  * @param {object} dropObj Drop object reference from persistent data
  * @param {string} catchesSinceLastPropName Property name for 'Catches since last drop'
  * @param {string} dropsHistoryCatchesPropName Property name for 'Catches' inside of drops history objects
+ * @param {number} magicFind Drop's magic find
  */
-export function setDropStatisticsOnDrop(dropObj, catchesSinceLastPropName, dropsHistoryCatchesPropName) {
+export function setDropStatisticsOnDrop(dropObj, catchesSinceLastPropName, dropsHistoryCatchesPropName, magicFind) {
     const catches = dropObj[catchesSinceLastPropName] || 0;
 
     dropObj.count += 1;
@@ -144,6 +145,7 @@ export function setDropStatisticsOnDrop(dropObj, catchesSinceLastPropName, drops
 
     dropsHistory.unshift({
         time: new Date(),
+        magicFind: +magicFind || null,
         [dropsHistoryCatchesPropName]: catches
     });
     dropObj.dropsHistory = dropsHistory;

--- a/utils/overlays.js
+++ b/utils/overlays.js
@@ -1,6 +1,6 @@
 import settings from "../settings";
-import { GREEN, RED, YELLOW } from "../constants/formatting";
-import { isInChatOrInventoryGui } from "./common";
+import { DARK_GRAY, GRAY, GREEN, RED, WHITE, YELLOW } from "../constants/formatting";
+import { formatDate, formatNumberWithSpaces, formatTimeElapsedBetweenDates, isDoubleHook, isInChatOrInventoryGui, pluralize } from "./common";
 
 /**
  * Create Display with specified buttons and actions on button click.
@@ -88,4 +88,123 @@ export function getButtonsDisplayRenderY(buttonsDisplay, overlay, overlayCoords)
 		const height = buttonsDisplay.getHeight();
 		return overlayCoords.y - height - 2;
 	}
+}
+
+/**
+ * Set 'Catches history', 'Catches since last', 'Last catch time', and 'Average catches' for sea creature object reference from persistent data. Does not save the result!
+ * @param {object} seaCreatureObj Sea creature object reference from persistent data
+ */
+export function setSeaCreatureStatisticsOnCatch(seaCreatureObj) {
+    const catchesSinceLast = seaCreatureObj.catchesSinceLast + 1;
+    const lastCatchTime = seaCreatureObj.lastCatchTime;
+
+    let catchesHistory = seaCreatureObj.catchesHistory || [];
+    catchesHistory.unshift(catchesSinceLast); // Most recent counts at the start of array
+    catchesHistory.length = Math.min(catchesHistory.length, 100); // Store last 100
+    seaCreatureObj.catchesHistory = catchesHistory;
+
+    const sumCatches = catchesHistory.reduce(function(a, b) { return a + b; }, 0);
+    seaCreatureObj.averageCatches = catchesHistory.length ? Math.round(sumCatches / catchesHistory.length) : 0;
+    seaCreatureObj.catchesSinceLast = 0;
+    seaCreatureObj.lastCatchTime = new Date();
+
+    return {
+        catchesSinceLast: catchesSinceLast,
+        lastCatchTime: lastCatchTime
+    };
+}
+
+/**
+ * Set 'Catches since last drop' for drop object reference from persistent data. Does not save the result!
+ * @param {object} dropObj Drop object reference from persistent data
+ * @param {string} catchesSinceLastPropName Property name for 'Catches since last drop'
+ */
+export function setDropStatisticsOnCatch(dropObj, catchesSinceLastPropName) {
+    const isDoubleHooked = isDoubleHook();
+    const valueToAdd = isDoubleHooked ? 2 : 1;
+    let catchesSinceLastDrop = dropObj[catchesSinceLastPropName] || 0;
+    catchesSinceLastDrop += valueToAdd;
+    dropObj[catchesSinceLastPropName] = catchesSinceLastDrop;
+}
+
+/**
+ * Set 'Catches since last drop' for drop object reference from persistent data. Does not save the result!
+ * @param {object} dropObj Drop object reference from persistent data
+ * @param {string} catchesSinceLastPropName Property name for 'Catches since last drop'
+ * @param {string} dropsHistoryCatchesPropName Property name for 'Catches' inside of drops history objects
+ */
+export function setDropStatisticsOnDrop(dropObj, catchesSinceLastPropName, dropsHistoryCatchesPropName) {
+    const catches = dropObj[catchesSinceLastPropName] || 0;
+
+    dropObj.count += 1;
+    dropObj[catchesSinceLastPropName] = 0;
+
+    let dropsHistory = dropObj.dropsHistory || [];
+    const lastDropTime = dropsHistory.length && dropsHistory[0].time ? dropsHistory[0].time : null;
+
+    dropsHistory.unshift({
+        time: new Date(),
+        [dropsHistoryCatchesPropName]: catches
+    });
+    dropObj.dropsHistory = dropsHistory;
+
+    return {
+        lastDropTime: lastDropTime,
+        catches: catches
+    };
+}
+
+/**
+ * Get overlay text for sea creature statistics, such as 'Catches since last', 'Last catch time', and 'Average catches'.
+ * @param {object} dropObj Drop object reference from persistent data
+ * @param {string} seaCreatureDisplayName Sea creature name with color/formatting
+ * @param {object} seaCreatureObj Sea creature object reference from persistent data
+ */
+export function getSeaCreatureStatisticsOverlayText(seaCreatureDisplayName, seaCreatureObj) {
+    let overlayText = '';
+    overlayText += `${seaCreatureDisplayName}: ${getCatchesSinceLastOverlayText(seaCreatureObj)} ${getAverageCatchesOverlayText(seaCreatureObj)}`;
+    overlayText += `\n${getLastCatchTimeOverlayText(seaCreatureObj)}`;
+
+    return overlayText;
+
+    function getCatchesSinceLastOverlayText(obj) {
+        const catchesSinceLast = `${WHITE}${formatNumberWithSpaces(obj?.catchesSinceLast || 0)}`;
+        const text = `${catchesSinceLast} ${GRAY}${obj?.catchesSinceLast !== 1 ? 'catches' : 'catch'} ago`;
+        return text;
+    }
+
+    function getAverageCatchesOverlayText(obj) {
+        const average = formatNumberWithSpaces(obj?.averageCatches) || 'N/A';
+        const text = `${DARK_GRAY}(${GRAY}avg: ${WHITE}${average}${DARK_GRAY})`;
+        return text;
+    }
+
+    function getLastCatchTimeOverlayText(obj) {
+        const lastCatchTime = obj?.lastCatchTime
+            ? `${WHITE}${formatTimeElapsedBetweenDates(new Date(obj.lastCatchTime))} ${GRAY}(${WHITE}${formatDate(new Date(obj.lastCatchTime))}${GRAY})` 
+            : `${WHITE}N/A`;
+        const text = `${GRAY}Last on: ${lastCatchTime}`;
+        return text;
+    }
+}
+
+/**
+ * Get overlay text for drop statistics, such as 'Count', 'Last drop time', and 'Catches since last drop'.
+ * @param {string} dropDisplayName Drop name with color/formatting
+ * @param {string} seaCreatureName Sea creature name without color/formatting
+ * @param {object} dropObj Drop object reference from persistent data
+ * @param {string} catchesSinceLastPropName Property name for 'Catches since last drop'
+ */
+export function getDropStatisticsOverlayText(dropDisplayName, seaCreatureName, dropObj, catchesSinceLastPropName) {
+    const lastDropTime = dropObj.dropsHistory.length
+        ? `${WHITE}${formatTimeElapsedBetweenDates(new Date(dropObj.dropsHistory[0].time))} ${GRAY}(${WHITE}${formatDate(new Date(dropObj.dropsHistory[0].time))}${GRAY})` 
+        : `${WHITE}N/A`;
+    const catchesSinceLastDrop = dropObj[catchesSinceLastPropName] || 0;
+
+    let overlayText = '';
+    overlayText += `${pluralize(dropDisplayName)}: ${WHITE}${formatNumberWithSpaces(dropObj.count)}`;
+    overlayText += `\n${GRAY}Last on: ${lastDropTime}`;
+    overlayText += `\n${GRAY}Last on: ${WHITE}${formatNumberWithSpaces(catchesSinceLastDrop)} ${GRAY}${catchesSinceLastDrop !== 1 ? pluralize(seaCreatureName) : seaCreatureName} ago`;
+
+    return overlayText;
 }


### PR DESCRIPTION
## Features:
- Added Water hotspots & Bayou tracker. It shows an overlay with Titanoboa (when fishing in hotspot) and Wiki Tiki (when in Backwater Bayou) catch statistics. Also has Titanoboa Shed and Tiki Mask drop statistics.
- Added Fiery Scuttler & Ragnarok (when fishing in hotspot), Plhlegblast (when in Plhlegblast Pool) tracking to Crimson Isle tracker.
- Changed command to initialize Radioactive Vials in the Crimson Isle Tracker, to have the same pattern everywhere.
- Reused code across Water hotspots & Bayou, Crimson Isle, and Jerry's Workshop tracker.

## Bugfixes:
- Do not display DH for Reindrakes in Rare Catches tracker.