### PR TITLE
fix: Fixed Custom Fishing Hook not being applied sometimes

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -8,7 +8,7 @@ Features:
 - Worm Profit tracker - in Gemstone chambers mode, the price of a Gemstone Mixture is subtracted from the price of a Gemstone Chamber, for more accurate profits. You can configure buy method for mixtures in the settings.
 
 Bugfixes:
--
+- Fixed Custom Fishing Hook not being applied sometimes.
 
 ## v1.44.0
 

--- a/utils/common.js
+++ b/utils/common.js
@@ -334,7 +334,11 @@ export function isFishingRod(item) {
  * @returns {EntityFishHook}
  */
 export function getPlayerFishingHook() {
-	return World.getAllEntitiesOfType(EntityFishHook).find(e => Player.getPlayer().field_71104_cf == e.getEntity()); // field_71104_cf = fishEntity
+	return World.getAllEntitiesOfType(EntityFishHook)
+		.find(e =>
+			Player.getPlayer().field_71104_cf == e.getEntity() || // field_71104_cf = fishEntity
+			e.getEntity()?.field_146042_b?.getDisplayNameString() === Player.getName() // field_146042_b = angler
+		);
 }
 
 /**


### PR DESCRIPTION
Fixed detection of player's fishing hook - `Player.getPlayer().field_71104_cf == e.getEntity()` condition does not work randomly for some catches.