### PR TITLE
feat: Added Dev config section with Show Skyblock item ID feature

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -11,6 +11,9 @@ Features:
 Bugfixes:
 - Fixed Custom Fishing Hook not being applied sometimes.
 
+Other:
+- Added Dev config section with Show Skyblock item ID feature [disabled by default].
+
 ## v1.44.0
 
 Released: 2025-06-04

--- a/features/inventory/showItemId.js
+++ b/features/inventory/showItemId.js
@@ -1,0 +1,22 @@
+import settings from "../../settings";
+import { addLineToLore } from "../../utils/common";
+import { isInSkyblock } from "../../utils/playerState";
+import { registerIf } from "../../utils/registers";
+
+registerIf(
+    register('itemTooltip', (lore, item) => showItemId(item)),
+    () => settings.showItemId && isInSkyblock()
+);
+
+function showItemId(item) {
+    if (!item || !isInSkyblock() || !settings.showItemId) {
+        return;
+    }
+
+    const itemId = item.getNBT()?.getCompoundTag('tag')?.getCompoundTag('ExtraAttributes')?.getString('id');
+    if (!itemId) {
+        return;
+    }
+
+    addLineToLore(item, `§r§6Skyblock ID: `, `§r§7${itemId}`);
+}

--- a/index.js
+++ b/index.js
@@ -49,6 +49,7 @@ import "./features/inventory/showExpertiseKills";
 import "./features/inventory/showCaughtTrophyFishRaritiesInOdger";
 import "./features/inventory/showExpBoostPercentage";
 import "./features/inventory/showMobyDuckProgress";
+import "./features/inventory/showItemId";
 
 import "./features/chat/messageOnCatch";
 import "./features/chat/announceMobSpawnToAllChat";


### PR DESCRIPTION
 Added Dev config section with Show Skyblock item ID feature [disabled by default].