### PR TITLE
fix: Fixed alert on Fishing Bag to be triggered twice

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -10,6 +10,7 @@ Features:
 
 Bugfixes:
 - Fixed Custom Fishing Hook not being applied sometimes.
+- Fixed alert on Fishing Bag to be triggered twice after opening /fb with active bobber.
 
 Other:
 - Added Dev config section with Show Skyblock item ID feature [disabled by default].

--- a/features/alerts/alertOnFishingBagDisabled.js
+++ b/features/alerts/alertOnFishingBagDisabled.js
@@ -43,6 +43,11 @@ function alertOnFishingBagDisabled() {
         ) {
             return;
         }
+    
+        const currentGui = Player.getContainer()?.getName();
+        if (currentGui?.includes('Fishing Bag')) { // When player opens disabled fishing bag, they receive alert again while it's disabled
+            return;
+        }
 
         let isHookActive = isFishingHookActive();
         if (!isHookActive) {


### PR DESCRIPTION
Fixed alert on Fishing Bag to be triggered twice after opening /fb with active bobber.