### PR TITLE
Release 1.47.0

### DIFF
--- a/constants/areas.js
+++ b/constants/areas.js
@@ -16,6 +16,7 @@ export const DUNGEON_HUB = 'Dungeon Hub';
 export const THE_END = 'The End';
 export const GLACITE_MINESHAFTS = 'Glacite Mineshafts';
 export const RIFT = 'Rift Dimension';
+export const GALATEA = 'Galatea';
 export const PLHLEGBLAST_POOL = 'Plhlegblast Pool';
 
 export const WATER_HOTSPOT_WORLDS = [
@@ -49,5 +50,6 @@ export const WATER_FISHING_WORLDS = [
     DWARVEN_MINES,
     JERRY_WORKSHOP,
     PARK,
-    FARMING_ISLANDS
+    FARMING_ISLANDS,
+    GALATEA
 ];

--- a/constants/fishingProfitItems.js
+++ b/constants/fishingProfitItems.js
@@ -716,6 +716,12 @@ export const FISHING_PROFIT_ITEMS = [
         itemDisplayName: `${LEGENDARY}Lord Jawbus`,
         npcPrice: 0,
     },
+    {
+        itemId: 'SHARD_SHINYFISH',
+        itemName: 'Shinyfish',
+        itemDisplayName: `${LEGENDARY}Shinyfish`,
+        npcPrice: 0,
+    },
 
     // Water
 

--- a/constants/fishingProfitItems.js
+++ b/constants/fishingProfitItems.js
@@ -1327,7 +1327,7 @@ export const FISHING_PROFIT_ITEMS = [
         itemId: 'FRIED_FEATHER',
         itemName: 'Fried Feather',
         itemDisplayName: `${UNCOMMON}Fried Feather`,
-        npcPrice: 10000,
+        npcPrice: 1000,
     },
     {
         itemId: 'SINGED_POWDER',

--- a/constants/triggers.js
+++ b/constants/triggers.js
@@ -162,6 +162,9 @@ export const GOOD_CATCH_ICE_ESSENCE_MESSAGE = `${RESET}${DARK_PURPLE}⛃ ${RESET
 export const GREAT_CATCH_ICE_ESSENCE_MESSAGE = `${RESET}${GOLD}⛃ ${RESET}${GOLD}${BOLD}GREAT CATCH! ${RESET}${WHITE}You caught ${RESET}${AQUA}Ice Essence ${RESET}${DARK_GRAY}x` + "${count}" + `${RESET}${WHITE}!${RESET}`;
 export const OUTSTANDING_CATCH_ICE_ESSENCE_MESSAGE = `${RESET}${LIGHT_PURPLE}⛃ ${RESET}${LIGHT_PURPLE}${BOLD}OUTSTANDING CATCH! ${RESET}${WHITE}You caught ${RESET}${AQUA}Ice Essence ${RESET}${DARK_GRAY}x` + "${count}" + `${RESET}${WHITE}!${RESET}`;
 
+export const GOOD_CATCH_SHARD_MESSAGE_1 = `${RESET}${DARK_PURPLE}⛃ ${RESET}${DARK_PURPLE}${BOLD}GOOD CATCH! ${RESET}${WHITE}You caught a ` + "${shard}" + ` Shard${RESET}${WHITE}!${RESET}`;
+export const GOOD_CATCH_SHARD_MESSAGE_2 = `${RESET}${DARK_PURPLE}⛃ ${RESET}${DARK_PURPLE}${BOLD}GOOD CATCH! ${RESET}${WHITE}You caught an ` + "${shard}" + ` Shard${RESET}${WHITE}!${RESET}`; // &r&5&lGOOD CATCH! &r&fYou caught an Abyssal Lanternfish Shard&r&f!&r
+
 export const USE_BAITS_FROM_FISHING_BAG_DISABLED = `${RESET}${RED}Use Baits From Bag is now disabled!${RESET}`;
 export const USE_BAITS_FROM_FISHING_BAG_ENABLED = `${RESET}${GREEN}Use Baits From Bag is now enabled!${RESET}`;
 
@@ -1242,6 +1245,17 @@ export const ICE_ESSENCE_FISHED_TRIGGERS = [
         trigger: OUTSTANDING_CATCH_ICE_ESSENCE_MESSAGE
     }
 ];
+
+// Messages when the shards itself is not dropped as an item to the inventory.
+export const SHARD_FISHED_TRIGGERS = [
+    {
+        trigger: GOOD_CATCH_SHARD_MESSAGE_1
+    },
+    {
+        trigger: GOOD_CATCH_SHARD_MESSAGE_2
+    },
+];
+
 
 export const SHARK_CATCH_TRIGGERS = [
     {

--- a/constants/triggers.js
+++ b/constants/triggers.js
@@ -162,8 +162,8 @@ export const GOOD_CATCH_ICE_ESSENCE_MESSAGE = `${RESET}${DARK_PURPLE}⛃ ${RESET
 export const GREAT_CATCH_ICE_ESSENCE_MESSAGE = `${RESET}${GOLD}⛃ ${RESET}${GOLD}${BOLD}GREAT CATCH! ${RESET}${WHITE}You caught ${RESET}${AQUA}Ice Essence ${RESET}${DARK_GRAY}x` + "${count}" + `${RESET}${WHITE}!${RESET}`;
 export const OUTSTANDING_CATCH_ICE_ESSENCE_MESSAGE = `${RESET}${LIGHT_PURPLE}⛃ ${RESET}${LIGHT_PURPLE}${BOLD}OUTSTANDING CATCH! ${RESET}${WHITE}You caught ${RESET}${AQUA}Ice Essence ${RESET}${DARK_GRAY}x` + "${count}" + `${RESET}${WHITE}!${RESET}`;
 
-export const GOOD_CATCH_SHARD_MESSAGE_1 = `${RESET}${DARK_PURPLE}⛃ ${RESET}${DARK_PURPLE}${BOLD}GOOD CATCH! ${RESET}${WHITE}You caught a ` + "${shard}" + ` Shard${RESET}${WHITE}!${RESET}`;
-export const GOOD_CATCH_SHARD_MESSAGE_2 = `${RESET}${DARK_PURPLE}⛃ ${RESET}${DARK_PURPLE}${BOLD}GOOD CATCH! ${RESET}${WHITE}You caught an ` + "${shard}" + ` Shard${RESET}${WHITE}!${RESET}`; // &r&5&lGOOD CATCH! &r&fYou caught an Abyssal Lanternfish Shard&r&f!&r
+export const GOOD_CATCH_SHARD_MESSAGE = `${RESET}${DARK_PURPLE}⛃ ${RESET}${DARK_PURPLE}${BOLD}GOOD CATCH! ${RESET}${WHITE}You caught ` + "${shardText}" + ` Shard${RESET}${WHITE}!${RESET}`; // &r&5&lGOOD CATCH! &r&fYou caught an Abyssal Lanternfish Shard&r&f!&r
+export const BLACK_HOLE_SHARD_MESSAGE = `${GREEN}You caught ` + "${shardsText}" + ` ${GREEN}Shard`; // &aYou caught a &fSea Archer &aShard!&r   // &aYou caught &7x4 &fSea Archer &aShards&a!&r
 
 export const USE_BAITS_FROM_FISHING_BAG_DISABLED = `${RESET}${RED}Use Baits From Bag is now disabled!${RESET}`;
 export const USE_BAITS_FROM_FISHING_BAG_ENABLED = `${RESET}${GREEN}Use Baits From Bag is now enabled!${RESET}`;
@@ -1245,17 +1245,6 @@ export const ICE_ESSENCE_FISHED_TRIGGERS = [
         trigger: OUTSTANDING_CATCH_ICE_ESSENCE_MESSAGE
     }
 ];
-
-// Messages when the shards itself is not dropped as an item to the inventory.
-export const SHARD_FISHED_TRIGGERS = [
-    {
-        trigger: GOOD_CATCH_SHARD_MESSAGE_1
-    },
-    {
-        trigger: GOOD_CATCH_SHARD_MESSAGE_2
-    },
-];
-
 
 export const SHARK_CATCH_TRIGGERS = [
     {

--- a/constants/triggers.js
+++ b/constants/triggers.js
@@ -94,7 +94,7 @@ export const BANSHEE_MESSAGE = `${RESET}${GREEN}The desolate wail of a Banshee b
 export const SNAPPING_TURTLE_MESSAGE = `${RESET}${GREEN}A Snapping Turtle is coming your way, and it's ANGRY!${RESET}`;
 export const BAYOU_SLUDGE_MESSAGE = `${RESET}${GREEN}A swampy mass of slime emerges, the Bayou Sludge!${RESET}`;
 export const ALLIGATOR_MESSAGE = `${RESET}${GREEN}A long snout breaks the surface of the water. It's an Alligator!${RESET}`;
-export const TITANOBOA_MESSAGE = `${RESET}${GREEN}${RESET}${RED}${BOLD}A massive Titanoboa surfaces. It's body stretches as far as the eye can see.${RESET}`; // &r&a&r&c&lA massive Titanoboa surfaces. It's body stretches as far as the eye can see.&r
+export const TITANOBOA_MESSAGE = `${RESET}${GREEN}${RESET}${RED}${BOLD}A massive Titanoboa surfaces. Its body stretches as far as the eye can see.${RESET}`; // &r&a&r&c&lA massive Titanoboa surfaces. Its body stretches as far as the eye can see.&r
 export const BLUE_RINGED_OCTOPUS_MESSAGE = `${RESET}${GREEN}A garish set of tentacles arise. It's a Blue Ringed Octopus!${RESET}`;
 export const WIKI_TIKI_MESSAGE = `${RESET}${RED}${RESET}${RED}${BOLD}The water bubbles and froths. A massive form emerges- you have disturbed the Wiki Tiki! You shall pay the price.${RESET}`; // &r&c&r&c&lThe water bubbles and froths. A massive form emerges- you have disturbed the Wiki Tiki! You shall pay the price.&r
 
@@ -123,13 +123,13 @@ export const TIKI_MASK_MESSAGE = `RARE DROP! ${RESET}${GOLD}Tiki Mask ${MAGIC_FI
 export const TITANOBOA_SHED_MESSAGE = `RARE DROP! ${RESET}${GOLD}Titanoboa Shed ${MAGIC_FIND_MESSAGE_PATTERN}`; // RARE DROP! &r&6Titanoboa Shed &r&b(+&r&b236% &r&b✯ Magic Find&r&b)
 export const SCUTTLER_SHELL_MESSAGE = `RARE DROP! ${RESET}${GOLD}Scuttler Shell ${MAGIC_FIND_MESSAGE_PATTERN}`; // RARE DROP! &r&6Scuttler Shell &r&b(+&r&b236% &r&b✯ Magic Find&r&b)
 
-export const AQUAMARINE_DYE_MESSAGE = `${RESET}${LIGHT_PURPLE}${BOLD}WOW! ` + '${playerNameAndRank}' + ` ${RESET}${GOLD}found ${RESET}${AQUA}Aquamarine Dye`; // &r&d&lWOW! &r&b[MVP&r&c+&r&b] &bMoonTheSadFisher&r&r&f &r&6found &r&bAquamarine Dye &r&8#95&r&6!&r
-export const ICEBERG_DYE_MESSAGE = `${RESET}${LIGHT_PURPLE}${BOLD}WOW! ` + '${playerNameAndRank}' + ` ${RESET}${GOLD}found ${RESET}${DARK_AQUA}Iceberg Dye`; // &r&d&lWOW! &r&b[MVP&r&c+&r&b] &bMoonTheSadFisher&r&r&f &r&6found &r&3Iceberg Dye&r
-export const CARMINE_DYE_MESSAGE = `${RESET}${LIGHT_PURPLE}${BOLD}WOW! ` + '${playerNameAndRank}' + ` ${RESET}${GOLD}found ${RESET}${DARK_RED}Carmine Dye`; // &r&d&lWOW! &r&b[MVP&r&c+&r&b] &bMoonTheSadFisher&r&r&f &r&6found &r&4Carmine Dye&r
-export const MIDNIGHT_DYE_MESSAGE = `${RESET}${LIGHT_PURPLE}${BOLD}WOW! ` + '${playerNameAndRank}' + ` ${RESET}${GOLD}found ${RESET}${DARK_PURPLE}Midnight Dye`; // &r&d&lWOW! &r&b[MVP&r&c+&r&b] &bMoonTheSadFisher&r&r&f &r&6found &r&5Midnight Dye&r
-export const TREASURE_DYE_MESSAGE = `${RESET}${LIGHT_PURPLE}${BOLD}WOW! ` + '${playerNameAndRank}' + ` ${RESET}${GOLD}found ${RESET}${GOLD}Treasure Dye`; // &r&d&lWOW! &r&b[MVP&r&c+&r&b] &bMoonTheSadFisher&r&r&f &r&6found &r&6Treasure Dye&r
-export const PERIWINKLE_DYE_MESSAGE = `${RESET}${LIGHT_PURPLE}${BOLD}WOW! ` + '${playerNameAndRank}' + ` ${RESET}${GOLD}found ${RESET}${DARK_AQUA}Periwinkle Dye`; // &r&d&lWOW! &r&b[MVP&r&c+&r&b] &bMoonTheSadFisher&r&r&f &r&6found &r&3Periwinkle Dye&r
-export const BONE_DYE_MESSAGE = `${RESET}${LIGHT_PURPLE}${BOLD}WOW! ` + '${playerNameAndRank}' + ` ${RESET}${GOLD}found ${RESET}${WHITE}Bone Dye`; // &r&d&lWOW! &r&b[MVP&r&c+&r&b] &bMoonTheSadFisher&r&r&f &r&6found &r&fBone Dye&r
+export const AQUAMARINE_DYE_MESSAGE = `${RESET}${LIGHT_PURPLE}${BOLD}WOW! ` + '${playerNameAndRank}' + ` ${RESET}${GOLD}found an ${RESET}${AQUA}Aquamarine Dye`; // &r&d&lWOW! &r&b[MVP&r&c+&r&b] &bMoonTheSadFisher&r&r&f &r&6found an &r&bAquamarine Dye &r&8#95&r&6!&r
+export const ICEBERG_DYE_MESSAGE = `${RESET}${LIGHT_PURPLE}${BOLD}WOW! ` + '${playerNameAndRank}' + ` ${RESET}${GOLD}found an ${RESET}${DARK_AQUA}Iceberg Dye`; // &r&d&lWOW! &r&b[MVP&r&c+&r&b] &bMoonTheSadFisher&r&r&f &r&6found an &r&3Iceberg Dye&r
+export const CARMINE_DYE_MESSAGE = `${RESET}${LIGHT_PURPLE}${BOLD}WOW! ` + '${playerNameAndRank}' + ` ${RESET}${GOLD}found a ${RESET}${DARK_RED}Carmine Dye`; // &r&d&lWOW! &r&b[MVP&r&c+&r&b] &bMoonTheSadFisher&r&r&f &r&6found a &r&4Carmine Dye&r
+export const MIDNIGHT_DYE_MESSAGE = `${RESET}${LIGHT_PURPLE}${BOLD}WOW! ` + '${playerNameAndRank}' + ` ${RESET}${GOLD}found a ${RESET}${DARK_PURPLE}Midnight Dye`; // &r&d&lWOW! &r&b[MVP&r&c+&r&b] &bMoonTheSadFisher&r&r&f &r&6found a &r&5Midnight Dye&r
+export const TREASURE_DYE_MESSAGE = `${RESET}${LIGHT_PURPLE}${BOLD}WOW! ` + '${playerNameAndRank}' + ` ${RESET}${GOLD}found a ${RESET}${GOLD}Treasure Dye`; // &r&d&lWOW! &r&b[MVP&r&c+&r&b] &bMoonTheSadFisher&r&r&f &r&6found a &r&6Treasure Dye&r
+export const PERIWINKLE_DYE_MESSAGE = `${RESET}${LIGHT_PURPLE}${BOLD}WOW! ` + '${playerNameAndRank}' + ` ${RESET}${GOLD}found a ${RESET}${DARK_AQUA}Periwinkle Dye`; // &r&d&lWOW! &r&b[MVP&r&c+&r&b] &bMoonTheSadFisher&r&r&f &r&6found a&r&3Periwinkle Dye&r
+export const BONE_DYE_MESSAGE = `${RESET}${LIGHT_PURPLE}${BOLD}WOW! ` + '${playerNameAndRank}' + ` ${RESET}${GOLD}found a ${RESET}${WHITE}Bone Dye`; // &r&d&lWOW! &r&b[MVP&r&c+&r&b] &bMoonTheSadFisher&r&r&f &r&6found a &r&fBone Dye&r
 
 export const SQUID_PET_LEG_MESSAGE = `${RESET}${LIGHT_PURPLE}⛃ ${RESET}${LIGHT_PURPLE}${BOLD}OUTSTANDING CATCH! ${RESET}${WHITE}You caught a ${RESET}${GRAY}[Lvl 1] ${RESET}${GOLD}Squid${RESET}${WHITE}!${RESET}`;
 export const SQUID_PET_EPIC_MESSAGE = `${RESET}${LIGHT_PURPLE}⛃ ${RESET}${LIGHT_PURPLE}${BOLD}OUTSTANDING CATCH! ${RESET}${WHITE}You caught a ${RESET}${GRAY}[Lvl 1] ${RESET}${DARK_PURPLE}Squid${RESET}${WHITE}!${RESET}`;

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -9,7 +9,7 @@ Features:
 Use Ctrl+Middle Click instead to delete.
 
 Bugfixes:
--
+- Removed The Loch Emperor from other water worlds than Galatea. 
 
 Other:
 - Rewrite Fishing Profit Tracker using custom clickable overlay (instead of DisplayLine). This enables more often updates without ConcurrentModificationException, and more straightforward code.

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -6,6 +6,7 @@ Released: ???
 
 Features:
 - Count Shards caught while Treasure fishing in Fishing Profit Tracker. 
+- Count Shards caught using Black Hole in Fishing Profit Tracker. 
 - Prevent removing a line from Fishing Profit Tracker when using Ctrl+Left Click on a line with 1x item. So you can't accidentally remove a line entirely.
 Use Ctrl+Middle Click instead to delete.
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -13,6 +13,7 @@ Use Ctrl+Middle Click instead to delete.
 Bugfixes:
 - Added Shinyfish to count in Fishing Profit Tracker.
 - Removed The Loch Emperor from other water worlds than Galatea.
+- Fixed Titanoboa and Dyes trigger messages after latest SB update.
 
 Other:
 - Rewrite Fishing Profit Tracker using custom clickable overlay (instead of DisplayLine). This enables more often updates without ConcurrentModificationException, and more straightforward code.

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -9,7 +9,8 @@ Features:
 Use Ctrl+Middle Click instead to delete.
 
 Bugfixes:
-- Removed The Loch Emperor from other water worlds than Galatea. 
+- Added Shinyfish to count in Fishing Profit Tracker.
+- Removed The Loch Emperor from other water worlds than Galatea.
 
 Other:
 - Rewrite Fishing Profit Tracker using custom clickable overlay (instead of DisplayLine). This enables more often updates without ConcurrentModificationException, and more straightforward code.

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -5,13 +5,14 @@
 Released: ???
 
 Features:
--
+- Prevent removing a line from Fishing Profit Tracker when using Ctrl+Left Click on a line with 1x item. So you can't accidentally remove a line entirely.
+Use Ctrl+Middle Click instead to delete.
 
 Bugfixes:
 -
 
 Other:
--
+- Rewrite Fishing Profit Tracker using custom clickable overlay (instead of DisplayLine). This enables more often updates without ConcurrentModificationException, and more straightforward code.
 
 ## v1.46.0
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,8 +1,21 @@
 # Releases
 
-## v1.46.0
+## v1.47.0
 
 Released: ???
+
+Features:
+-
+
+Bugfixes:
+-
+
+Other:
+-
+
+## v1.46.0
+
+Released: 2025-06-30
 
 Features:
 - Added more Galatea fishing drops for potential future update to CT 3.0.

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -5,6 +5,7 @@
 Released: ???
 
 Features:
+- Count Shards caught while Treasure fishing in Fishing Profit Tracker. 
 - Prevent removing a line from Fishing Profit Tracker when using Ctrl+Left Click on a line with 1x item. So you can't accidentally remove a line entirely.
 Use Ctrl+Middle Click instead to delete.
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -16,7 +16,9 @@ Bugfixes:
 - Fixed Titanoboa and Dyes trigger messages after latest SB update.
 
 Other:
-- Rewrite Fishing Profit Tracker using custom clickable overlay (instead of DisplayLine). This enables more often updates without ConcurrentModificationException, and more straightforward code.
+- Fishing Profit Tracker refactorings:
+    - Rewrite using custom clickable overlay (instead of DisplayLine). This enables more often updates without ConcurrentModificationException, and more straightforward code.
+    - Reused / simplified some code.
 
 ## v1.46.0
 

--- a/docs/Future ideas & requests.md
+++ b/docs/Future ideas & requests.md
@@ -2,8 +2,6 @@
 
 ## Galatea
 
-- Alpha: Fixed a grammatical error in the drop message for Dyes (???)
-- Alpha: Fixed a grammatical error in the Titanoboa spawn message (???)
 - 1.21 support with CT 3.0
   - Depends on migration of CT itself, and other modules from "requires" section
 - Attribute rendering rework on old items and on shards

--- a/docs/Future ideas & requests.md
+++ b/docs/Future ideas & requests.md
@@ -5,16 +5,8 @@
 - Alpha: Fixed a grammatical error in the drop message for Dyes (???)
 - Alpha: Fixed a grammatical error in the Titanoboa spawn message (???)
 - 1.21 support with CT 3.0
-  - Depends on migration of other modules from "requires" section
+  - Depends on migration of CT itself, and other modules from "requires" section
 - Attribute rendering rework on old items and on shards
-- Update Fishing loot table
-  - Add new items (mob drops, treasures, shards)
-    - Water shards (Bazaar ID unknown):
-      - (C) Mist, Cod, Night Squid, Verdant, Sea Archer, Birries, Tadgang, Coralot, Newt
-      - (U) Tide, Salmon, Ent, Magma Slug, Stridersurfer
-      - (R) Cascade, Toad, Lizard King, Piranha, Abyssal Lanternfish, Silentdepth, Snowfin, Carrot King, Limisquid, Bullfrog, ...
-      - (E) ...
-      - (L) Shinyfish, ...
 
 ## Fishing profit tracker
 

--- a/docs/Future ideas & requests.md
+++ b/docs/Future ideas & requests.md
@@ -5,7 +5,6 @@
 - 1.21 support with CT 3.0
   - Depends on migration of other modules from "requires" section
 - Attribute rendering rework on old items and on shards
-- Remove old attribute shards from Fishing Profit Tracker
 - Update Fishing loot table
   - Add new items (mob drops, treasures, shards)
     - Water shards (Bazaar ID unknown):
@@ -29,8 +28,6 @@
 - Profit tracker causes lags after a while (memory consumption grows)
 - [Bug] Some items are tracked by Fishing Profit Tracker when dropped, but drop was prevented by SB settings (basically it drops and picks up again).
 - [Bug] Trading with other players adds items to the profit trackers.
-- [Bug] Fishing Profit Tracker recalculates profits/h too often when in "display buttons" mode.
-- [Bug] Fishing Profit Tracker does not recalculate profits/h while fishing and not gaining any loot (e.g. dirt fishing).
 
 ## Deployables
 
@@ -81,7 +78,6 @@
 - Bait changed alert
 - No bait used alert
 - Track baits cost in Fishing profit tracker
-- [Bug] Bait alert false triggered when opening /fb with fishing rod casted.
 
 ## Fishing bosses
 
@@ -144,14 +140,15 @@ Sort by: rarity, locked/unlocked
 - Water
   - Get 2 lucky clover cores in 10 seconds
   - Full oasis bestiary (It was so much fun... Sigh / Useless grind)
+- Bayou
+- Galatea?
 - Marina
   - Get 400+ sharks per festival
 - Trophy
   - Gold hunter
   - DIamond hunter
 - Treasure
-  - Catch legendary squid / guardian
-  - The same as above, but 2x (blessing)
+  - Catch legendary squid?
 - Dye
   - Obtain aquamarine / iceberg / etc dye
 - Giant rod

--- a/docs/Future ideas & requests.md
+++ b/docs/Future ideas & requests.md
@@ -2,6 +2,8 @@
 
 ## Galatea
 
+- Alpha: Fixed a grammatical error in the drop message for Dyes (???)
+- Alpha: Fixed a grammatical error in the Titanoboa spawn message (???)
 - 1.21 support with CT 3.0
   - Depends on migration of other modules from "requires" section
 - Attribute rendering rework on old items and on shards

--- a/features/overlays/fishingProfitTracker.js
+++ b/features/overlays/fishingProfitTracker.js
@@ -164,14 +164,10 @@ function isTrackerVisible() {
 
 function changeItemAmount(itemId, isDelete, difference) {
     try {
-        if (!isTrackerVisible()) {
-            return;
-        }
+        if (!isTrackerVisible()) return;
 
         const item = persistentData.fishingProfit.profitTrackerItems[itemId];
-        if (!item) {
-            return;
-        }
+        if (!item) return;
 
         if (isDelete) {
             delete persistentData.fishingProfit.profitTrackerItems[itemId];
@@ -198,9 +194,7 @@ function changeItemAmount(itemId, isDelete, difference) {
 
 function activateSessionOnPlayersFishingHook() {
     try {
-        if (!settings.fishingProfitTrackerOverlay || !isWorldLoaded || !isInSkyblock() || !isInFishingWorld(getWorldName())) {
-            return;
-        }
+        if (!settings.fishingProfitTrackerOverlay || !isWorldLoaded || !isInSkyblock() || !isInFishingWorld(getWorldName())) return;
     
         const isHookActive = isFishingHookActive();
         if (isHookActive) {
@@ -224,9 +218,7 @@ function activateSessionOnPlayersFishingHook() {
 
 function refreshElapsedTime() {
     try {
-        if (!isTrackerVisible() || !isSessionActive) {
-            return;
-        }
+        if (!isTrackerVisible() || !isSessionActive) return;
 
         const maxSecondsElapsedSinceLastAction = 60 * 6; // Time to kill any mob before despawn, e.g. Jawbus
         const lastHookSeenAt = getLastFishingHookSeenAt();
@@ -245,16 +237,11 @@ function refreshElapsedTime() {
 
 function refreshPrices() {
     try {
-        if (!isTrackerVisible()) {
-            return;
-        }
+        if (!isTrackerVisible()) return;
     
         Object.entries(persistentData.fishingProfit.profitTrackerItems).forEach(([key, value]) => {
             const item = FISHING_PROFIT_ITEMS.find(i => i.itemId === key);
-            if (!item) {
-                return;
-            }
-
+            if (!item) return;
             const itemPrice = getItemPrice(item);
             value.totalItemProfit = value.amount * itemPrice;  
         });
@@ -268,9 +255,7 @@ function refreshPrices() {
 	}
 
     function getItemPrice(item) {
-        if (!item) {
-            return 0;
-        }
+        if (!item) return 0;
     
         if (item.amountOfMagmaFish) { // Trophy Fish
             const magmaFishBazaarPrices = getBazaarItemPrices('MAGMA_FISH');
@@ -305,18 +290,11 @@ function refreshPrices() {
 
 function onAddedToSacks(event) {
     try {
-        if (!isTrackerVisible() || !event || !isSessionActive) {
-            return;
-        }
+        if (!isTrackerVisible() || !event || !isSessionActive) return;
     
         const lastGuisClosed = getLastGuisClosed();
-        if (isInSacksGui() || new Date() - lastGuisClosed.lastSacksGuiClosedAt < 15 * 1000) { // Sacks closed < 15 seconds ago
-            return;
-        }
-
-        if (isInSupercraftGui() || new Date() - lastGuisClosed.lastSupercraftGuiClosedAt < 15 * 1000) { // Supercraft closed < 15 seconds ago
-            return;
-        }
+        if (isInSacksGui() || new Date() - lastGuisClosed.lastSacksGuiClosedAt < 15 * 1000) return; // Sacks closed < 15 seconds ago
+        if (isInSupercraftGui() || new Date() - lastGuisClosed.lastSupercraftGuiClosedAt < 15 * 1000) return; // Supercraft closed < 15 seconds ago
 
         const itemsAddedToSacks = getItemsAddedToSacks(EventLib.getMessage(event));
         let isUpdated = false;
@@ -324,18 +302,14 @@ function onAddedToSacks(event) {
         for (let itemAddedToSack of itemsAddedToSacks) {
             const itemName = getCleanItemName(itemAddedToSack.itemName);
 
-            if (!itemAddedToSack.difference || !itemName) {
-                continue;
-            }
+            if (!itemAddedToSack.difference || !itemName) continue;
 
             const item = getFishingProfitItemByName(itemName);
             const itemId = item?.itemId;
-            if (!item || !itemId) {
-                continue;
-            }
+            if (!item || !itemId) continue;
     
-            if (itemId?.startsWith('MAGMA_FISH') && lastGuisClosed.lastOdgerGuiClosedAt && new Date() - lastGuisClosed.lastOdgerGuiClosedAt < 15 * 1000) { // User probably just filleted trophy fish
-                continue;
+            if (itemId?.startsWith('MAGMA_FISH') && lastGuisClosed.lastOdgerGuiClosedAt && new Date() - lastGuisClosed.lastOdgerGuiClosedAt < 15 * 1000) {
+                continue; // User probably just filleted trophy fish
             }
 
             const currentAmount = persistentData.fishingProfit.profitTrackerItems[itemId] ? persistentData.fishingProfit.profitTrackerItems[itemId].amount : 0;
@@ -363,9 +337,7 @@ function onAddedToSacks(event) {
 
 function onCoinsFished(coins) {
     try {
-        if (!isTrackerVisible() || !coins || !isSessionActive) {
-            return;
-        }
+        if (!isTrackerVisible() || !coins || !isSessionActive) return;
     
         const itemId = 'FISHED_COINS';
         const coinsWithoutSeparator = +(coins.replace(/,/g, ''));
@@ -393,67 +365,41 @@ function onCoinsFished(coins) {
 
 function onIceEssenceFished(count) {
     try {
-        if (!isTrackerVisible() || !count || !isSessionActive || getWorldName() !== JERRY_WORKSHOP) {
-            return;
-        }
-
-        const fishingProfitItem = FISHING_PROFIT_ITEMS.find(i => i.itemId === 'ESSENCE_ICE');
-        const itemId = fishingProfitItem?.itemId;
-        if (!fishingProfitItem || !itemId) {
-            return;
-        }
+        if (!isTrackerVisible() || !count || !isSessionActive || getWorldName() !== JERRY_WORKSHOP) return;
 
         const essenceCountWithoutSeparator = +(count.replace(/,/g, ''));
-        const item = persistentData.fishingProfit.profitTrackerItems[itemId];
-        const currentAmount = item?.amount || 0;
-
-        persistentData.fishingProfit.profitTrackerItems[itemId] = {
-            itemName: fishingProfitItem.itemName,
-            itemDisplayName: fishingProfitItem.itemDisplayName,
-            itemId: itemId,
-            amount: currentAmount + essenceCountWithoutSeparator,
-        };
-        persistentData.save();
-
+        refreshItemData(i => i.itemId === 'ESSENCE_ICE', essenceCountWithoutSeparator);
         refreshPrices();
-        refreshOverlay();  
+        refreshOverlay();
     } catch (e) {
 		console.error(e);
 		console.log(`[FeeshNotifier] [ProfitTracker] Failed to track fished ice essence.`);
 	}
 }
 
-// shardText sample: "an Abyssal Lanternfish", "a Cod", "a Shinyfish"
+/**
+ * 
+ * @param {*} shardText "an Abyssal Lanternfish", "a Cod", "a Shinyfish"
+ */
 function onShardFished(shardText) {
     try {
         if (!isTrackerVisible() || !shardText || !isSessionActive) return;
 
         const [article, ...shardNameParts] = shardText.removeFormatting().split(' ');
         const shardName = shardNameParts.join(' ');
-        const fishingProfitItem = FISHING_PROFIT_ITEMS.find(i => i.itemName === shardName.removeFormatting());
-        const itemId = fishingProfitItem?.itemId;
-        if (!fishingProfitItem || !itemId) return;
-
-        const item = persistentData.fishingProfit.profitTrackerItems[itemId];
-        const currentAmount = item?.amount || 0;
-
-        persistentData.fishingProfit.profitTrackerItems[itemId] = {
-            itemName: fishingProfitItem.itemName,
-            itemDisplayName: fishingProfitItem.itemDisplayName,
-            itemId: itemId,
-            amount: currentAmount + 1,
-        };
-        persistentData.save();
-
+        refreshItemData(i => i.itemName === shardName.removeFormatting(), 1);
         refreshPrices();
-        refreshOverlay();  
+        refreshOverlay();
     } catch (e) {
 		console.error(e);
-		console.log(`[FeeshNotifier] [ProfitTracker] Failed to track fished shard.`);
+		console.log(`[FeeshNotifier] [ProfitTracker] Failed to track fished Shard.`);
 	}
 }
 
-// shardsText sample: "a Sea Archer", "an Ent", "x4 Sea Emperor"
+/**
+ * 
+ * @param {*} shardsText "a Sea Archer", "an Ent", "x4 Sea Emperor"
+ */
 function onShardCaughtInBlackHole(shardsText) {
     try {
         if (!isTrackerVisible() || !shardsText || !isSessionActive) return;
@@ -462,38 +408,19 @@ function onShardCaughtInBlackHole(shardsText) {
         const count = countText === 'a' || countText === 'an' ? 1 : +(countText.replace('x', ''));
         const shardName = shardNameParts.join(' ');
 
-        const fishingProfitItem = FISHING_PROFIT_ITEMS.find(i => i.itemName === shardName);
-        const itemId = fishingProfitItem?.itemId;
-        if (!fishingProfitItem || !itemId) return;
-
-        const item = persistentData.fishingProfit.profitTrackerItems[itemId];
-        const currentAmount = item?.amount || 0;
-
-        persistentData.fishingProfit.profitTrackerItems[itemId] = {
-            itemName: fishingProfitItem.itemName,
-            itemDisplayName: fishingProfitItem.itemDisplayName,
-            itemId: itemId,
-            amount: currentAmount + count,
-        };
-        persistentData.save();
-
+        refreshItemData(i => i.itemName === shardName, count);
         refreshPrices();
-        refreshOverlay();  
+        refreshOverlay();
     } catch (e) {
 		console.error(e);
-		console.log(`[FeeshNotifier] [ProfitTracker] Failed to track shard caught in black hole.`);
+		console.log(`[FeeshNotifier] [ProfitTracker] Failed to track Shard caught in Black Hole.`);
 	}
 }
 
 function onPetReachedMaxLevel(level, petDisplayName) {
     try {
-        if (level !== 100 && level !== 200) {
-            return;
-        }
-
-        if (!isTrackerVisible() || !petDisplayName || !isSessionActive || getWorldName() !== CRIMSON_ISLE) {
-            return;
-        }
+        if (level !== 100 && level !== 200) return;
+        if (!isTrackerVisible() || !petDisplayName || !isSessionActive || getWorldName() !== CRIMSON_ISLE) return;
     
         const petName = petDisplayName.removeFormatting();
         const rarityColorCode = petDisplayName.substring(0, 2);
@@ -524,6 +451,23 @@ function onPetReachedMaxLevel(level, petDisplayName) {
 	}
 }
 
+function refreshItemData(findItemFunc, amountToAdd) {
+    const fishingProfitItem = FISHING_PROFIT_ITEMS.find(i => findItemFunc(i));
+    const itemId = fishingProfitItem?.itemId;
+    if (!fishingProfitItem || !itemId) return;
+
+    const item = persistentData.fishingProfit.profitTrackerItems[itemId] || null;
+    const currentAmount = item?.amount || 0;
+
+    persistentData.fishingProfit.profitTrackerItems[itemId] = {
+        itemName: fishingProfitItem.itemName,
+        itemDisplayName: fishingProfitItem.itemDisplayName,
+        itemId: itemId,
+        amount: currentAmount + amountToAdd,
+    };
+    persistentData.save();
+}
+
 function detectInventoryChanges() {
     try {
         if (!isTrackerVisible() || !isWorldLoaded || !isSessionActive) {
@@ -539,15 +483,11 @@ function detectInventoryChanges() {
         const heldItem = Player.getPlayer()?.field_71071_by?.func_70445_o();
         if (heldItem) {
             var item = new Item(heldItem);
-            if (item) {
-                return; // Do not recalculate inventory while a player is moving an item
-            }
+            if (item) return; // Do not recalculate inventory while a player is moving an item
         }
 
         const hasBarrier = (Player?.getInventory()?.getItems() || []).find(i => i?.getName() === 'Barrier'); // NEU slot binding replaces inventory items with Barriers
-        if (hasBarrier) {
-            return;
-        }
+        if (hasBarrier) return;
         
         const currentInventory = getFishingProfitItemsInCurrentInventory();
 
@@ -630,13 +570,9 @@ function detectInventoryChanges() {
 
     function onItemAddedToInventory(itemId, previousCount, newCount) {
         const item = FISHING_PROFIT_ITEMS.find(i => i.itemId === itemId);
-        if (!item) {
-            return;
-        }
+        if (!item) return;
 
-        if (isInventoryPotentiallyDirty(itemId, item)) {
-            return;
-        }
+        if (isInventoryPotentiallyDirty(itemId, item)) return;
 
         const difference = newCount - previousCount;
         if (difference > 0) {

--- a/features/overlays/seaCreaturesHpTracker.js
+++ b/features/overlays/seaCreaturesHpTracker.js
@@ -2,7 +2,7 @@ import settings, { allOverlaysGui, seaCreaturesHpOverlayGui } from "../../settin
 import { AQUA, BOLD, RED } from "../../constants/formatting";
 import { overlayCoordsData } from "../../data/overlayCoords";
 import { getWorldName, isInSkyblock } from "../../utils/playerState";
-import { BACKWATER_BAYOU, CRIMSON_ISLE, CRYSTAL_HOLLOWS, JERRY_WORKSHOP, WATER_FISHING_WORLDS, WATER_HOTSPOT_WORLDS } from "../../constants/areas";
+import { BACKWATER_BAYOU, CRIMSON_ISLE, CRYSTAL_HOLLOWS, GALATEA, JERRY_WORKSHOP, WATER_FISHING_WORLDS, WATER_HOTSPOT_WORLDS } from "../../constants/areas";
 import { OFF_SOUND_MODE } from "../../constants/sounds";
 import { registerIf } from "../../utils/registers";
 import { getSeaCreaturesInRange } from "../../utils/entityDetection";
@@ -81,7 +81,7 @@ const TRACKED_MOBS = [
         hasImmunity: true,
     },
     {
-        worlds: WATER_FISHING_WORLDS,
+        worlds: [GALATEA],
         baseMobName: 'The Loch Emperor',
         hasImmunity: true,
     },

--- a/keybinds.js
+++ b/keybinds.js
@@ -9,7 +9,7 @@ import { pauseWormMembraneProfitTracker } from "./features/overlays/wormMembrane
 
 const pauseKeyBind = new Keybind("Pause active overlays", Keyboard.KEY_PAUSE, "FeeshNotifier");
 pauseKeyBind.registerKeyRelease(() => {
-    pauseFishingProfitTracker(true);
+    pauseFishingProfitTracker();
     pauseSeaCreaturesPerHourTracker();
     pauseAbandonedQuarryTracker();
     pauseMagmaCoreProfitTracker();

--- a/metadata.json
+++ b/metadata.json
@@ -3,7 +3,7 @@
     "entry": "index.js",
     "author": "MoonTheSadFisher",
     "description": "Hypixel Skyblock fishing utilities for parties.",
-    "version": "1.46.0",
+    "version": "1.47.0",
     "requires": [
         "Amaterasu",
         "PogData",

--- a/utils/overlays.js
+++ b/utils/overlays.js
@@ -1,6 +1,341 @@
 import settings from "../settings";
 import { DARK_GRAY, GOLD, GRAY, GREEN, RED, WHITE, YELLOW } from "../constants/formatting";
 import { formatDate, formatNumberWithSpaces, formatTimeElapsedBetweenDates, isDoubleHook, isInChatOrInventoryGui, pluralize } from "./common";
+import { allOverlaysGui } from "../settings";
+import { isInChatOrInventoryGui } from "./common";
+import { registerIf } from "./registers";
+
+export const LEFT_CLICK_TYPE = 'LEFT';
+export const CTRL_LEFT_CLICK_TYPE = 'CTRL+LEFT';
+export const CTRL_MIDDLE_CLICK_TYPE = 'CTRL+MID';
+export const CTRL_RIGHT_CLICK_TYPE = 'CTRL+RIGHT';
+
+const SMALLER_LINE_SCALE_ADJUSTMENT = -0.2;
+
+/**
+ * Overlay representing a text widget rendered on screen.
+ */
+export class Overlay {
+    /**
+    * Create Overlay object.
+    * @param {func} registerIfFunc Callback function to check whether the overlay should be rendered
+    */
+    constructor(registerIfFunc) {
+        this.textLines = [];
+        this.buttonLines = [];
+        this.positionData = null; // config object with x, y, scale
+        this.isClickable = false;
+        this.shouldSeparateButtonLines = true;
+        this.registerIfFunc = registerIfFunc;
+
+        registerIf(
+            register('renderOverlay', (event) => {
+                if (!this.registerIfFunc()) {
+                    this.clear();
+                    return;
+                }
+
+                if (this.isClickable && Client?.currentGui?.getClassName() === 'GuiInventory') {
+                    return;
+                }
+
+                if (allOverlaysGui.isOpen()) {
+                    return;
+                }
+
+                this._draw();
+            }),
+            this.registerIfFunc
+        );
+
+        registerIf(
+            register('guiRender', () => { // To render overlay on top of dark background in Inventory GUI
+                if (allOverlaysGui.isOpen()) {
+                    this.clear();
+                    return;
+                }
+
+                if (!this.registerIfFunc()) {
+                    this.clear();
+                    return;
+                }
+
+                if (!this.isClickable || Client?.currentGui?.getClassName() !== 'GuiInventory') {
+                    return;
+                }
+
+                this._draw();
+            }),
+            this.registerIfFunc
+        );
+
+        registerIf(
+            register('guiMouseRelease', (x, y, mouseButton, gui, event) => {
+                if (!this.registerIfFunc()) {
+                    return;
+                }
+
+                if (!isInChatOrInventoryGui() || (!this.textLines.length && !this.buttonLines.length)) {
+                    return;
+                }
+
+                const clickedLine = this.buttonLines.find(l => l._isHovered(x, y)) || this.textLines.find(l => l._isHovered(x, y));
+                if (!clickedLine) return;
+
+                const isCtrlPressed = Keyboard.isKeyDown(29) || Keyboard.isKeyDown(157); // 29 and 157 is LCTRL/RCTRL https://minecraft.fandom.com/wiki/Key_codes
+
+                switch (true) {
+                    case mouseButton === 0 && isCtrlPressed: {
+                        clickedLine._onCtrlLeftClick();
+                        break;
+                    }
+                    case mouseButton === 0: {
+                        clickedLine._onLeftClick();
+                        break;
+                    }
+                    case mouseButton === 2 && isCtrlPressed: {
+                        clickedLine._onCtrlMiddleClick();
+                        break;
+                    }
+                    case mouseButton === 1 && isCtrlPressed: {
+                        clickedLine._onCtrlRightClick();
+                        break;
+                    }
+                }
+            }),
+            this.registerIfFunc
+        );
+    }
+
+    /**
+    * Set object containing x, y and scale for the Overlay.
+    * Dynamically changes when values are changed while moving/scaling overlays.
+    * @param {object} positionData Object from overlayCoordsData - { x, y, scale }
+    */
+    setPositionData(positionData) 
+    {
+        this.positionData = positionData;
+        return this;
+    }
+
+    /**
+    * Define whether the Overlay will be clickable.
+    * If clickable, the overlay will render on the foreground of the Inventory GUI (not behind darker background).
+    * @param {boolean} isClickable
+    */
+    setIsClickable(isClickable) {
+        this.isClickable = isClickable;
+        return this;
+    }
+
+    /**
+    * Define whether the button lines should be separated from the Overlay with extra empty line.
+    * @param {boolean} shouldSeparateButtonLines
+    */
+    setShouldSeparateButtonLines(shouldSeparateButtonLines) {
+        this.shouldSeparateButtonLines = shouldSeparateButtonLines;
+        return this;
+    }
+
+    /**
+    * Clear Overlay's text lines and button lines.
+    */
+    clear() {
+        if (this.textLines.length) this.textLines = [];
+        if (this.buttonLines.length) this.buttonLines = [];
+        return this;
+    }
+
+    /**
+    * Add a new text line to the Overlay.
+    * @param {OverlayTextLine} textLine
+    */
+    addTextLine(textLine) {
+        this.textLines.push(textLine);
+        return this;
+    }
+
+    /**
+    * Replace the Overlay's text lines with the new ones.
+    * @param {OverlayTextLine[]} textLines
+    */
+    setTextLines(textLines) {
+        this.textLines = textLines;
+        return this;
+    }
+
+    /**
+    * Add a new button line to the Overlay.
+    * @param {OverlayButtonLine} textLine
+    */
+    addButtonLine(buttonLine) {
+        this.buttonLines.push(buttonLine);
+        return this;
+    }
+
+    /**
+    * Replace the Overlay's button lines with the new ones.
+    * @param {OverlayButtonLine[]} buttonLines
+    */
+    setButtonLines(buttonLines) {
+        this.buttonLines = buttonLines;
+        return this;
+    }
+
+    _draw() {
+        if (!this.textLines.length && !this.buttonLines.length) {
+            return;
+        }
+
+        let x = this.positionData.x;
+        let y = this.positionData.y;
+        let lastLineHeight = 0;
+
+        this.textLines.forEach((line) => {
+            y += lastLineHeight;
+            line._setX(x)._setY(y)._setScale(this.positionData.scale)._draw();
+            lastLineHeight = line.height;
+        });
+
+        if (!isInChatOrInventoryGui() || !this.buttonLines.length) return;
+
+        const emptyLine = this.shouldSeparateButtonLines
+            ? new Text(' ').setScale(getAdjustedScale(this.positionData.scale, SMALLER_LINE_SCALE_ADJUSTMENT)).setAlign('LEFT').setShadow(true)
+            : null;
+        const emptyLineHeight = emptyLine ? emptyLine.getHeight() : 0;
+
+        if (settings.buttonsPosition === 0) { // At the bottom of Overlay
+            y += lastLineHeight;
+            emptyLine?.setX(x)?.setY(y)?.draw();
+            lastLineHeight = emptyLineHeight;
+
+            this.buttonLines.forEach((line) => {
+                y += lastLineHeight;
+                line._setX(x)._setY(y)._setScale(this.positionData.scale)._draw();
+                lastLineHeight = line.height;
+            });
+        }
+  
+        if (settings.buttonsPosition === 1) { // At the top of Overlay
+            y = this.positionData.y;
+            lastLineHeight = emptyLineHeight;
+            y -= lastLineHeight;
+            emptyLine?.setX(x)?.setY(y)?.draw();
+
+            [...this.buttonLines].reverse().forEach((line) => {
+                line._setScale(this.positionData.scale);
+                lastLineHeight = line.text.getHeight();
+                y -= lastLineHeight;
+                line._setX(x)._setY(y);
+                line._draw();
+            });         
+        }
+    }
+}
+
+/**
+ * Overlay text lines containing overlay data - e.g. title, payload. Text lines can be clickable while no GUI opened / in chat / in inventory.
+ */
+export class OverlayTextLine {
+    constructor() {
+        this.text = new Text('');
+        this.width = 0;
+        this.height = 0;
+        this.isSmallerScale = false;
+        this.onLeftClickFunc = null;
+        this.onClickFuncs = [];
+    }
+
+    /**
+    * Set line text with formatting.
+    * @param {string} text
+    */
+    setText(text) {
+        this.text.setString(text);
+        return this;
+    }
+
+    /**
+    * Set if the line should be rendered smaller than the base scale value defined for the Overlay.
+    * @param {boolean} isSmallerScale
+    */
+    setIsSmallerScale(isSmallerScale) {
+        this.isSmallerScale = isSmallerScale;
+        return this;
+    }
+
+    /**
+    * Set callback to execute on line click.
+    * @param {string} type Click type - e.g. left click or Ctrl + Right click
+    * @param {func} func Callback function
+    */
+    setOnClick(type, func) {
+        if (this.onClickFuncs.find(f => f.type === type)) return;
+
+        this.onClickFuncs.push({ type: type, func: func });
+        return this;
+    }
+
+    _setX(x) {
+        this.text.x = x;
+        return this;
+    }
+
+    _setY(y) {
+        this.text.y = y;
+        return this;
+    }
+
+    _setScale(overlayScale) {
+        const adjustedScale = this.isSmallerScale ? getAdjustedScale(overlayScale, SMALLER_LINE_SCALE_ADJUSTMENT) : overlayScale;
+        this.text.setScale(adjustedScale);
+        return this;
+    }
+
+    _draw() {
+        this.text.setAlign('LEFT').setShadow(true).draw();
+        this.width = this.text.getWidth();
+        this.height = this.text.getHeight();
+    }
+
+    _isHovered(x, y) {
+        return (
+            (x >= this.text.x && x <= this.text.x + this.width) &&
+            (y >= this.text.y && y < this.text.y + this.height * 0.85) // Fix for case when I click top of a line, it thinks that previous line is hovered
+        );
+    }
+
+    _onLeftClick() {
+        const func = this.onClickFuncs.find(f => f.type === LEFT_CLICK_TYPE);
+        if (func) func.func();
+    }
+
+    _onCtrlLeftClick() {
+        const func = this.onClickFuncs.find(f => f.type === CTRL_LEFT_CLICK_TYPE);
+        if (func) func.func();
+    }
+
+    _onCtrlMiddleClick() {
+        const func = this.onClickFuncs.find(f => f.type === CTRL_MIDDLE_CLICK_TYPE);
+        if (func) func.func();
+    }
+
+    _onCtrlRightClick() {
+        const func = this.onClickFuncs.find(f => f.type === CTRL_RIGHT_CLICK_TYPE);
+        if (func) func.func();
+    }
+}
+
+/**
+ * Overlay buttons placed on top / on bottom of the overlay. E.g. Pause or Reset button.
+ * Their position (on top or on bottom) is controlled via settings.
+ */
+export class OverlayButtonLine extends OverlayTextLine {
+    constructor() {
+        super();
+    }
+}
+
 
 /**
  * Create Display with specified buttons and actions on button click.
@@ -253,4 +588,9 @@ export function initDropCountOnOverlay(dropObj, count, lastOn) {
         const localDate = new Date(year, month - 1, day, hour, minute, second);
         return localDate;
     }
+}
+
+function getAdjustedScale(baseScale, scaleAdjustment) {
+    const adjustedScale = baseScale + scaleAdjustment;
+    return adjustedScale > 0 ? adjustedScale : 0.1;
 }


### PR DESCRIPTION
## Features
- Count Shards caught while Treasure fishing in Fishing Profit Tracker. 
- Count Shards caught using Black Hole in Fishing Profit Tracker. 
- Prevent removing a line from Fishing Profit Tracker when using Ctrl+Left Click on a line with 1x item. So you can't accidentally remove a line entirely.
Use Ctrl+Middle Click instead to delete.

## Bugfixes
- Added Shinyfish to count in Fishing Profit Tracker.
- Removed The Loch Emperor from other water worlds than Galatea.
- Fixed Titanoboa and Dyes trigger messages after latest SB update.

## Other
- Fishing Profit Tracker refactorings:
    - Rewrite using custom clickable overlay (instead of DisplayLine). This enables more often updates without ConcurrentModificationException, and more straightforward code.
    - Reused / simplified some code.